### PR TITLE
Update SDK to use VPC API version 2021-11-23 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ script:
 - npm run lint
 - npm run check-packages
 
-after_success:
-- npm run report-coverage
-
 deploy:
 - provider: script
   skip_cleanup: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/node": "^12.0.8",
         "extend": "^3.0.2",
-        "ibm-cloud-sdk-core": "^2.14.4"
+        "ibm-cloud-sdk-core": "^2.17.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^3.0.4",
@@ -40,11 +40,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dependencies": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@babel/core": {
@@ -228,10 +228,12 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
-      "dev": true
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helpers": {
       "version": "7.9.2",
@@ -245,13 +247,16 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -331,19 +336,18 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -352,27 +356,34 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -391,16 +402,42 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "node_modules/@jest/console": {
       "version": "24.9.0",
@@ -1232,19 +1269,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@semantic-release/github/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1795,10 +1819,13 @@
       }
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/acorn-walk": {
       "version": "6.2.0",
@@ -2655,20 +2682,6 @@
         "wrap-ansi": "^5.1.0"
       }
     },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -2692,16 +2705,17 @@
       }
     },
     "node_modules/codecov": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.6.5.tgz",
-      "integrity": "sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.3.tgz",
+      "integrity": "sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==",
+      "deprecated": "https://about.codecov.io/blog/codecov-uploader-deprecation-plan/",
       "dev": true,
       "dependencies": {
         "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.13.1",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
+        "ignore-walk": "3.0.4",
+        "js-yaml": "3.14.1",
+        "teeny-request": "7.1.1",
+        "urlgrey": "1.0.0"
       },
       "bin": {
         "codecov": "bin/codecov"
@@ -3490,29 +3504,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^1.3.0",
-        "espree": "^7.3.0",
-        "esquery": "^1.2.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -3520,7 +3537,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -3529,7 +3546,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^5.2.3",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -3538,6 +3555,9 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-google": {
@@ -3629,18 +3649,18 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/eslint/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3690,6 +3710,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -3702,7 +3734,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
@@ -3711,16 +3743,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint/node_modules/globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/has-flag": {
@@ -3847,22 +3891,25 @@
       }
     },
     "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/espree": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
-      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "dependencies": {
         "acorn": "^7.4.0",
-        "acorn-jsx": "^5.2.0",
+        "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^1.3.0"
       },
       "engines": {
@@ -3870,24 +3917,15 @@
       }
     },
     "node_modules/espree/node_modules/acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esprima": {
@@ -3904,9 +3942,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3916,9 +3954,9 @@
       }
     },
     "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -3958,6 +3996,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4193,9 +4232,9 @@
       ]
     },
     "node_modules/fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "node_modules/fast-diff": {
@@ -4232,6 +4271,21 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
@@ -4263,15 +4317,15 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "dependencies": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       },
       "engines": {
-        "node": ">=4"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/file-type": {
@@ -4328,23 +4382,37 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "dependencies": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=4"
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
     "node_modules/follow-redirects": {
@@ -5334,9 +5402,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5535,10 +5603,12 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "9.18.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+      "version": "9.18.5",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
+      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
       "dev": true,
+      "hasInstallScript": true,
       "engines": {
         "node": "*"
       }
@@ -5603,25 +5673,16 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "dev": true,
       "dependencies": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -5634,9 +5695,9 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "2.14.4",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.14.4.tgz",
-      "integrity": "sha512-NfHQb/L9EOoZSqGD0PdQMD9pdK9LzoaiYcBljU0jlfTgVs7fWGRw4frZDkS449yGFLEsus2dqrJeqyM52xo9rw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.17.0.tgz",
+      "integrity": "sha512-p1GPdwVuXja5AIDQu0PS8bokjZOkFvC1rX2qHot6KdrRRahEcBUtyxrTTejKlB6khLHS3uj9m+mkyDwp1hhwsA==",
       "dependencies": {
         "@types/file-type": "~5.2.1",
         "@types/isstream": "^0.1.0",
@@ -5702,9 +5763,9 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -5930,9 +5991,9 @@
       }
     },
     "node_modules/ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
       "dev": true,
       "dependencies": {
         "minimatch": "^3.0.4"
@@ -6690,6 +6751,33 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+      "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "import-local": "^2.0.0",
+        "is-ci": "^2.0.0",
+        "jest-config": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "prompts": "^2.0.1",
+        "realpath-native": "^1.1.0",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jest-config": {
@@ -7582,33 +7670,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jest/node_modules/jest-cli": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-      "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/core": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "import-local": "^2.0.0",
-        "is-ci": "^2.0.0",
-        "jest-config": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "prompts": "^2.0.1",
-        "realpath-native": "^1.1.0",
-        "yargs": "^13.3.0"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/jquery": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
@@ -7621,9 +7682,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7710,9 +7771,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -7802,18 +7863,18 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/jwa": {
@@ -7974,6 +8035,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -7989,6 +8056,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "node_modules/lodash.uniqby": {
@@ -8669,9 +8742,9 @@
       }
     },
     "node_modules/node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
       "dev": true,
       "dependencies": {
         "growly": "^1.3.0",
@@ -8736,9 +8809,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.0.tgz",
-      "integrity": "sha512-3nv3dKMucKPEXhx/FEtJQR26ksYdyVlLEP9/dYvYwCbLbP6H8ya94IRf+mB93ec+fndv/Ye8SylWfD7jmN6kSA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -8748,25 +8821,28 @@
       }
     },
     "node_modules/npm": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.12.1.tgz",
-      "integrity": "sha512-vjIniB3kqujcDTgH+k90J2i5PPqYZyf1gi5Ni5fARK4WQr5FuVnTQlTXloyk15+qWUxwWHcy6U8YCWwh/TLzmA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
+      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
       "bundleDependencies": [
+        "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/ci-detect",
         "@npmcli/config",
+        "@npmcli/map-workspaces",
+        "@npmcli/package-json",
         "@npmcli/run-script",
         "abbrev",
         "ansicolors",
         "ansistyles",
         "archy",
-        "byte-size",
         "cacache",
         "chalk",
         "chownr",
         "cli-columns",
         "cli-table3",
         "columnify",
+        "fastest-levenshtein",
         "glob",
         "graceful-fs",
         "hosted-git-info",
@@ -8774,7 +8850,6 @@
         "init-package-json",
         "is-cidr",
         "json-parse-even-better-errors",
-        "leven",
         "libnpmaccess",
         "libnpmdiff",
         "libnpmexec",
@@ -8795,6 +8870,7 @@
         "node-gyp",
         "nopt",
         "npm-audit-report",
+        "npm-install-checks",
         "npm-package-arg",
         "npm-pick-manifest",
         "npm-profile",
@@ -8818,252 +8894,80 @@
         "treeverse",
         "validate-npm-package-name",
         "which",
-        "write-file-atomic",
-        "@npmcli/disparity-colors",
-        "@npmcli/git",
-        "@npmcli/installed-package-contents",
-        "@npmcli/map-workspaces",
-        "@npmcli/metavuln-calculator",
-        "@npmcli/move-file",
-        "@npmcli/name-from-folder",
-        "@npmcli/node-gyp",
-        "@npmcli/promise-spawn",
-        "@tootallnate/once",
-        "agent-base",
-        "agentkeepalive",
-        "aggregate-error",
-        "ajv",
-        "ansi-regex",
-        "ansi-styles",
-        "aproba",
-        "are-we-there-yet",
-        "asap",
-        "asn1",
-        "assert-plus",
-        "asynckit",
-        "aws-sign2",
-        "aws4",
-        "balanced-match",
-        "bcrypt-pbkdf",
-        "bin-links",
-        "binary-extensions",
-        "brace-expansion",
-        "builtins",
-        "caseless",
-        "cidr-regex",
-        "clean-stack",
-        "clone",
-        "cmd-shim",
-        "code-point-at",
-        "color-convert",
-        "color-name",
-        "colors",
-        "combined-stream",
-        "common-ancestor-path",
-        "concat-map",
-        "console-control-strings",
-        "core-util-is",
-        "dashdash",
-        "debug",
-        "debuglog",
-        "defaults",
-        "delayed-stream",
-        "delegates",
-        "depd",
-        "dezalgo",
-        "diff",
-        "ecc-jsbn",
-        "emoji-regex",
-        "encoding",
-        "env-paths",
-        "err-code",
-        "extend",
-        "extsprintf",
-        "fast-deep-equal",
-        "fast-json-stable-stringify",
-        "forever-agent",
-        "form-data",
-        "fs-minipass",
-        "fs.realpath",
-        "function-bind",
-        "gauge",
-        "getpass",
-        "har-schema",
-        "har-validator",
-        "has",
-        "has-flag",
-        "has-unicode",
-        "http-cache-semantics",
-        "http-proxy-agent",
-        "http-signature",
-        "https-proxy-agent",
-        "humanize-ms",
-        "iconv-lite",
-        "ignore-walk",
-        "imurmurhash",
-        "indent-string",
-        "infer-owner",
-        "inflight",
-        "inherits",
-        "ip",
-        "ip-regex",
-        "is-core-module",
-        "is-fullwidth-code-point",
-        "is-lambda",
-        "is-typedarray",
-        "isarray",
-        "isexe",
-        "isstream",
-        "jsbn",
-        "json-schema",
-        "json-schema-traverse",
-        "json-stringify-nice",
-        "json-stringify-safe",
-        "jsonparse",
-        "jsprim",
-        "just-diff",
-        "just-diff-apply",
-        "lru-cache",
-        "mime-db",
-        "mime-types",
-        "minimatch",
-        "minipass-collect",
-        "minipass-fetch",
-        "minipass-flush",
-        "minipass-json-stream",
-        "minipass-sized",
-        "minizlib",
-        "mute-stream",
-        "normalize-package-data",
-        "npm-bundled",
-        "npm-install-checks",
-        "npm-normalize-package-bin",
-        "npm-packlist",
-        "number-is-nan",
-        "oauth-sign",
-        "object-assign",
-        "once",
-        "p-map",
-        "path-is-absolute",
-        "path-parse",
-        "performance-now",
-        "proc-log",
-        "process-nextick-args",
-        "promise-all-reject-late",
-        "promise-call-limit",
-        "promise-inflight",
-        "promise-retry",
-        "promzard",
-        "psl",
-        "punycode",
-        "qs",
-        "read-cmd-shim",
-        "readable-stream",
-        "request",
-        "resolve",
-        "retry",
-        "safe-buffer",
-        "safer-buffer",
-        "set-blocking",
-        "signal-exit",
-        "smart-buffer",
-        "socks",
-        "socks-proxy-agent",
-        "spdx-correct",
-        "spdx-exceptions",
-        "spdx-expression-parse",
-        "spdx-license-ids",
-        "sshpk",
-        "string_decoder",
-        "string-width",
-        "stringify-package",
-        "strip-ansi",
-        "supports-color",
-        "tunnel-agent",
-        "tweetnacl",
-        "typedarray-to-buffer",
-        "unique-filename",
-        "unique-slug",
-        "uri-js",
-        "util-deprecate",
-        "uuid",
-        "validate-npm-package-license",
-        "verror",
-        "walk-up-path",
-        "wcwidth",
-        "wide-align",
-        "wrappy",
-        "yallist"
+        "write-file-atomic"
       ],
       "dev": true,
       "dependencies": {
-        "@npmcli/arborist": "^2.4.4",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
-        "@npmcli/run-script": "^1.8.5",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.0.6",
-        "chalk": "^4.1.0",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^1.1.1",
-        "libnpmfund": "^1.0.2",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.0",
-        "make-fetch-happen": "^8.0.14",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.4",
-        "npm-package-arg": "^8.1.2",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^10.1.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.3",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@isaacs/string-locale-compare": "*",
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-install-checks": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -9091,42 +8995,62 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.4.4",
+      "version": "2.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@isaacs/string-locale-compare": "^1.0.1",
         "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/map-workspaces": "^1.0.2",
         "@npmcli/metavuln-calculator": "^1.1.0",
         "@npmcli/move-file": "^1.1.0",
         "@npmcli/name-from-folder": "^1.0.1",
         "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/package-json": "^1.0.1",
         "@npmcli/run-script": "^1.8.2",
         "bin-links": "^2.2.1",
         "cacache": "^15.0.3",
         "common-ancestor-path": "^1.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
+        "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
-        "npm-registry-fetch": "^10.0.0",
-        "pacote": "^11.2.6",
+        "npm-registry-fetch": "^11.0.0",
+        "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
+        "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^1.0.1",
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
         "semver": "^7.3.5",
-        "tar": "^6.1.0",
+        "ssri": "^8.0.1",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
       "bin": {
         "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
@@ -9136,7 +9060,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9163,8 +9087,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "2.0.9",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9196,7 +9130,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9246,6 +9180,15 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
       "dev": true,
@@ -9256,14 +9199,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
         "read-package-json-fast": "^2.0.1"
       }
@@ -9387,13 +9329,16 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/asap": {
@@ -9498,21 +9443,13 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/byte-size": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "15.0.6",
+      "version": "15.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -9542,7 +9479,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9708,6 +9645,15 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/color-support": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/npm/node_modules/colors": {
       "version": "1.4.0",
       "dev": true,
@@ -9777,7 +9723,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.1",
+      "version": "4.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9928,6 +9874,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
       "dev": true,
@@ -9940,7 +9892,6 @@
     "node_modules/npm/node_modules/form-data": {
       "version": "2.3.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9976,51 +9927,23 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "2.7.4",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^1.0.3",
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
+        "string-width": "^1.0.1 || ^2.0.0",
+        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "wide-align": "^1.1.2"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/getpass": {
@@ -10033,7 +9956,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "7.1.7",
+      "version": "7.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10053,7 +9976,7 @@
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.6",
+      "version": "4.2.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -10177,7 +10100,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10248,16 +10171,15 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "2.0.3",
+      "version": "2.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.1",
-        "npm-package-arg": "^8.1.2",
+        "npm-package-arg": "^8.1.5",
         "promzard": "^0.3.0",
         "read": "~1.0.1",
-        "read-package-json": "^3.0.1",
+        "read-package-json": "^4.1.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^3.0.0"
@@ -10294,7 +10216,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.2.0",
+      "version": "2.7.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10329,7 +10251,6 @@
     "node_modules/npm/node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
@@ -10418,17 +10339,8 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/leven": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "4.0.2",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10436,7 +10348,7 @@
         "aproba": "^2.0.0",
         "minipass": "^3.1.1",
         "npm-package-arg": "^8.1.2",
-        "npm-registry-fetch": "^10.0.0"
+        "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -10453,8 +10365,8 @@
         "binary-extensions": "^2.2.0",
         "diff": "^5.0.0",
         "minimatch": "^3.0.4",
-        "npm-package-arg": "^8.1.1",
-        "pacote": "^11.3.0",
+        "npm-package-arg": "^8.1.4",
+        "pacote": "^11.3.4",
         "tar": "^6.1.0"
       },
       "engines": {
@@ -10462,7 +10374,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "1.1.1",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10484,35 +10396,35 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^2.0.0"
+        "@npmcli/arborist": "^2.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^10.0.0"
+        "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^10.0.0"
+        "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -10533,14 +10445,14 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "normalize-package-data": "^3.0.2",
         "npm-package-arg": "^8.1.2",
-        "npm-registry-fetch": "^10.0.0",
+        "npm-registry-fetch": "^11.0.0",
         "semver": "^7.1.3",
         "ssri": "^8.0.1"
       },
@@ -10549,32 +10461,32 @@
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^10.0.0"
+        "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^10.0.0"
+        "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10599,13 +10511,13 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "8.0.14",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.1.3",
-        "cacache": "^15.0.5",
+        "cacache": "^15.2.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -10616,8 +10528,9 @@
         "minipass-fetch": "^1.3.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^5.0.0",
+        "socks-proxy-agent": "^6.0.0",
         "ssri": "^8.0.0"
       },
       "engines": {
@@ -10625,7 +10538,7 @@
       }
     },
     "node_modules/npm/node_modules/mime-db": {
-      "version": "1.47.0",
+      "version": "1.49.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10634,12 +10547,12 @@
       }
     },
     "node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.30",
+      "version": "2.1.32",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.47.0"
+        "mime-db": "1.49.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -10658,7 +10571,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.3",
+      "version": "3.1.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10682,7 +10595,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "1.3.3",
+      "version": "1.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10795,6 +10708,15 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/negotiator": {
+      "version": "0.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "7.1.2",
       "dev": true,
@@ -10819,6 +10741,66 @@
         "node": ">= 10.12.0"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
+      "version": "2.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
@@ -10835,13 +10817,13 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
-        "resolve": "^1.20.0",
+        "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       },
@@ -10850,7 +10832,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10889,7 +10871,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "8.1.2",
+      "version": "8.1.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10933,25 +10915,24 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^10.0.0"
+        "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "10.1.1",
+      "version": "11.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^6.0.0",
-        "make-fetch-happen": "^8.0.9",
+        "make-fetch-happen": "^9.0.1",
         "minipass": "^3.1.3",
         "minipass-fetch": "^1.3.0",
         "minipass-json-stream": "^1.0.1",
@@ -10969,15 +10950,28 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "4.1.2",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/number-is-nan": {
@@ -11041,12 +11035,12 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^2.0.1",
+        "@npmcli/git": "^2.1.0",
         "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
         "@npmcli/run-script": "^1.8.2",
@@ -11059,7 +11053,7 @@
         "npm-package-arg": "^8.0.1",
         "npm-packlist": "^2.1.4",
         "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^10.0.0",
+        "npm-registry-fetch": "^11.0.0",
         "promise-retry": "^2.0.1",
         "read-package-json-fast": "^2.0.1",
         "rimraf": "^3.0.2",
@@ -11096,7 +11090,6 @@
     "node_modules/npm/node_modules/path-parse": {
       "version": "1.0.6",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/performance-now": {
@@ -11114,7 +11107,6 @@
     "node_modules/npm/node_modules/process-nextick-args": {
       "version": "2.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -11214,7 +11206,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "3.0.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11229,7 +11221,7 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11242,18 +11234,17 @@
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "2.3.7",
+      "version": "3.6.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
@@ -11299,6 +11290,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/npm/node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
       "version": "2.5.0",
       "dev": true,
@@ -11315,7 +11320,6 @@
     "node_modules/npm/node_modules/resolve": {
       "version": "1.20.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.2.0",
@@ -11350,8 +11354,22 @@
       }
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -11389,7 +11407,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11413,17 +11431,17 @@
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
@@ -11453,7 +11471,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.7",
+      "version": "3.0.10",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
@@ -11474,6 +11492,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11491,12 +11514,12 @@
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.1.1",
+      "version": "1.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
@@ -11564,7 +11587,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.0",
+      "version": "6.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12123,9 +12146,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -12710,6 +12733,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -13186,9 +13218,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -13556,9 +13588,9 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -13688,17 +13720,71 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slide": {
@@ -14319,31 +14405,116 @@
       "dev": true
     },
     "node_modules/table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
       "dev": true,
       "dependencies": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.1.tgz",
+      "integrity": "sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/temp-dir": {
@@ -14452,9 +14623,9 @@
       }
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -14551,18 +14722,18 @@
       "dev": true
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14970,10 +15141,13 @@
       "dev": true
     },
     "node_modules/urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-1.0.0.tgz",
+      "integrity": "sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==",
+      "dev": true,
+      "dependencies": {
+        "fast-url-parser": "^1.1.3"
+      }
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -15147,20 +15321,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -15179,18 +15339,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "node_modules/write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/write-file-atomic": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
@@ -15203,9 +15351,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dev": true,
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -15274,32 +15422,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
@@ -15313,11 +15435,11 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
@@ -15487,10 +15609,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
-      "dev": true
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
     },
     "@babel/helpers": {
       "version": "7.9.2",
@@ -15504,12 +15625,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -15578,27 +15699,26 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -15608,12 +15728,12 @@
           }
         },
         "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "ignore": {
@@ -15629,12 +15749,29 @@
           "dev": true
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -16341,16 +16478,6 @@
             "slash": "^3.0.0"
           }
         },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "dev": true,
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
         "jsonfile": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -16805,10 +16932,11 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -17518,17 +17646,6 @@
         "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -17547,16 +17664,16 @@
       "dev": true
     },
     "codecov": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.6.5.tgz",
-      "integrity": "sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.3.tgz",
+      "integrity": "sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.13.1",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
+        "ignore-walk": "3.0.4",
+        "js-yaml": "3.14.1",
+        "teeny-request": "7.1.1",
+        "urlgrey": "1.0.0"
       }
     },
     "collection-visit": {
@@ -18192,29 +18309,32 @@
       }
     },
     "eslint": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^1.3.0",
-        "espree": "^7.3.0",
-        "esquery": "^1.2.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -18222,7 +18342,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -18231,15 +18351,15 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^5.2.3",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -18277,6 +18397,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
         "eslint-utils": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -18284,21 +18410,29 @@
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+              "dev": true
+            }
           }
         },
         "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         },
         "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
@@ -18389,9 +18523,9 @@
           }
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
@@ -18464,32 +18598,26 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
-      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
         "acorn": "^7.4.0",
-        "acorn-jsx": "^5.2.0",
+        "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^1.3.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-          "dev": true
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         }
       }
@@ -18501,18 +18629,18 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -18543,7 +18671,8 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -18732,9 +18861,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-diff": {
@@ -18768,6 +18897,23 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
     "fastq": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
@@ -18796,12 +18942,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "file-type": {
@@ -18843,20 +18989,30 @@
       }
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
     "follow-redirects": {
@@ -19577,9 +19733,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -19732,9 +19888,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.18.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+      "version": "9.18.5",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
+      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
       "dev": true
     },
     "hook-std": {
@@ -19787,21 +19943,13 @@
       }
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "dev": true,
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        }
       }
     },
     "human-signals": {
@@ -19811,9 +19959,9 @@
       "dev": true
     },
     "ibm-cloud-sdk-core": {
-      "version": "2.14.4",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.14.4.tgz",
-      "integrity": "sha512-NfHQb/L9EOoZSqGD0PdQMD9pdK9LzoaiYcBljU0jlfTgVs7fWGRw4frZDkS449yGFLEsus2dqrJeqyM52xo9rw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.17.0.tgz",
+      "integrity": "sha512-p1GPdwVuXja5AIDQu0PS8bokjZOkFvC1rX2qHot6KdrRRahEcBUtyxrTTejKlB6khLHS3uj9m+mkyDwp1hhwsA==",
       "requires": {
         "@types/file-type": "~5.2.1",
         "@types/isstream": "^0.1.0",
@@ -19873,9 +20021,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
           "version": "4.2.1",
@@ -20043,9 +20191,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -20518,29 +20666,6 @@
       "requires": {
         "import-local": "^2.0.0",
         "jest-cli": "^24.9.0"
-      },
-      "dependencies": {
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-          "dev": true,
-          "requires": {
-            "@jest/core": "^24.9.0",
-            "@jest/test-result": "^24.9.0",
-            "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "import-local": "^2.0.0",
-            "is-ci": "^2.0.0",
-            "jest-config": "^24.9.0",
-            "jest-util": "^24.9.0",
-            "jest-validate": "^24.9.0",
-            "prompts": "^2.0.1",
-            "realpath-native": "^1.1.0",
-            "yargs": "^13.3.0"
-          }
-        }
       }
     },
     "jest-changed-files": {
@@ -20648,6 +20773,27 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "jest-cli": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+      "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "import-local": "^2.0.0",
+        "is-ci": "^2.0.0",
+        "jest-config": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "prompts": "^2.0.1",
+        "realpath-native": "^1.1.0",
+        "yargs": "^13.3.0"
       }
     },
     "jest-config": {
@@ -21409,9 +21555,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -21485,9 +21631,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -21563,14 +21709,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -21714,6 +21860,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -21729,6 +21881,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.uniqby": {
@@ -22248,9 +22406,9 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",
@@ -22307,116 +22465,134 @@
       }
     },
     "normalize-url": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.0.0.tgz",
-      "integrity": "sha512-3nv3dKMucKPEXhx/FEtJQR26ksYdyVlLEP9/dYvYwCbLbP6H8ya94IRf+mB93ec+fndv/Ye8SylWfD7jmN6kSA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true
     },
     "npm": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.12.1.tgz",
-      "integrity": "sha512-vjIniB3kqujcDTgH+k90J2i5PPqYZyf1gi5Ni5fARK4WQr5FuVnTQlTXloyk15+qWUxwWHcy6U8YCWwh/TLzmA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
+      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
       "dev": true,
       "requires": {
-        "@npmcli/arborist": "^2.4.4",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
-        "@npmcli/run-script": "^1.8.5",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.0.6",
-        "chalk": "^4.1.0",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^1.1.1",
-        "libnpmfund": "^1.0.2",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.0",
-        "make-fetch-happen": "^8.0.14",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.4",
-        "npm-package-arg": "^8.1.2",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^10.1.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.3",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@isaacs/string-locale-compare": "*",
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-install-checks": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "dependencies": {
+        "@gar/promisify": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@isaacs/string-locale-compare": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/arborist": {
-          "version": "2.4.4",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@isaacs/string-locale-compare": "^1.0.1",
             "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/map-workspaces": "^1.0.2",
             "@npmcli/metavuln-calculator": "^1.1.0",
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
             "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/package-json": "^1.0.1",
             "@npmcli/run-script": "^1.8.2",
             "bin-links": "^2.2.1",
             "cacache": "^15.0.3",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
+            "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.0",
+            "npm-package-arg": "^8.1.5",
             "npm-pick-manifest": "^6.1.0",
-            "npm-registry-fetch": "^10.0.0",
-            "pacote": "^11.2.6",
+            "npm-registry-fetch": "^11.0.0",
+            "pacote": "^11.3.5",
             "parse-conflict-json": "^1.1.1",
+            "proc-log": "^1.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
             "semver": "^7.3.5",
-            "tar": "^6.1.0",
+            "ssri": "^8.0.1",
             "treeverse": "^1.0.4",
             "walk-up-path": "^1.0.0"
           }
@@ -22427,7 +22603,7 @@
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22446,8 +22622,17 @@
             "ansi-styles": "^4.3.0"
           }
         },
+        "@npmcli/fs": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.0.1",
+            "semver": "^7.3.5"
+          }
+        },
         "@npmcli/git": {
-          "version": "2.0.9",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22471,7 +22656,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22510,6 +22695,14 @@
           "bundled": true,
           "dev": true
         },
+        "@npmcli/package-json": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.1"
+          }
+        },
         "@npmcli/promise-spawn": {
           "version": "1.3.2",
           "bundled": true,
@@ -22519,13 +22712,12 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.5",
+          "version": "1.8.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
-            "infer-owner": "^1.0.4",
             "node-gyp": "^7.1.0",
             "read-package-json-fast": "^2.0.1"
           }
@@ -22612,12 +22804,12 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
+          "version": "1.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "readable-stream": "^3.6.0"
           }
         },
         "asap": {
@@ -22698,16 +22890,12 @@
           "bundled": true,
           "dev": true
         },
-        "byte-size": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "cacache": {
-          "version": "15.0.6",
+          "version": "15.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/fs": "^1.0.0",
             "@npmcli/move-file": "^1.0.1",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -22733,7 +22921,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22839,6 +23027,11 @@
           "bundled": true,
           "dev": true
         },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "colors": {
           "version": "1.4.0",
           "bundled": true,
@@ -22891,7 +23084,7 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23000,6 +23193,11 @@
           "bundled": true,
           "dev": true
         },
+        "fastest-levenshtein": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
@@ -23007,7 +23205,6 @@
         },
         "form-data": {
           "version": "2.3.3",
-          "bundled": true,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -23034,43 +23231,19 @@
           "dev": true
         },
         "gauge": {
-          "version": "2.7.4",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
+            "string-width": "^1.0.1 || ^2.0.0",
+            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "wide-align": "^1.1.2"
           }
         },
         "getpass": {
@@ -23082,7 +23255,7 @@
           }
         },
         "glob": {
-          "version": "7.1.7",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23095,7 +23268,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.6",
+          "version": "4.2.8",
           "bundled": true,
           "dev": true
         },
@@ -23182,7 +23355,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.6.2",
+          "version": "0.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -23233,15 +23406,14 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.3",
+          "version": "2.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^8.1.2",
+            "npm-package-arg": "^8.1.5",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "^3.0.1",
+            "read-package-json": "^4.1.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
@@ -23266,7 +23438,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.2.0",
+          "version": "2.7.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23290,7 +23462,6 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
           "dev": true
         },
         "isexe": {
@@ -23359,20 +23530,15 @@
           "bundled": true,
           "dev": true
         },
-        "leven": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "libnpmaccess": {
-          "version": "4.0.2",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
             "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^10.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmdiff": {
@@ -23385,13 +23551,13 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.1",
-            "pacote": "^11.3.0",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23409,29 +23575,29 @@
           }
         },
         "libnpmfund": {
-          "version": "1.0.2",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.0.0"
+            "@npmcli/arborist": "^2.5.0"
           }
         },
         "libnpmhook": {
-          "version": "6.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^10.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmorg": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^10.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmpack": {
@@ -23445,36 +23611,36 @@
           }
         },
         "libnpmpublish": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "normalize-package-data": "^3.0.2",
             "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^10.0.0",
+            "npm-registry-fetch": "^11.0.0",
             "semver": "^7.1.3",
             "ssri": "^8.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^10.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmteam": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^10.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "libnpmversion": {
-          "version": "1.2.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23494,12 +23660,12 @@
           }
         },
         "make-fetch-happen": {
-          "version": "8.0.14",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.1.3",
-            "cacache": "^15.0.5",
+            "cacache": "^15.2.0",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^4.0.1",
             "https-proxy-agent": "^5.0.0",
@@ -23510,22 +23676,23 @@
             "minipass-fetch": "^1.3.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.2",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^5.0.0",
+            "socks-proxy-agent": "^6.0.0",
             "ssri": "^8.0.0"
           }
         },
         "mime-db": {
-          "version": "1.47.0",
+          "version": "1.49.0",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.30",
+          "version": "2.1.32",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.47.0"
+            "mime-db": "1.49.0"
           }
         },
         "minimatch": {
@@ -23537,7 +23704,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.3",
+          "version": "3.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23553,7 +23720,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.3.3",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23630,6 +23797,11 @@
           "bundled": true,
           "dev": true
         },
+        "negotiator": {
+          "version": "0.6.2",
+          "bundled": true,
+          "dev": true
+        },
         "node-gyp": {
           "version": "7.1.2",
           "bundled": true,
@@ -23645,6 +23817,57 @@
             "semver": "^7.3.2",
             "tar": "^6.0.2",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
           }
         },
         "nopt": {
@@ -23656,18 +23879,18 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
         },
         "npm-audit-report": {
-          "version": "2.1.4",
+          "version": "2.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23696,7 +23919,7 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.1.2",
+          "version": "8.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23728,20 +23951,19 @@
           }
         },
         "npm-profile": {
-          "version": "5.0.3",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^10.0.0"
+            "npm-registry-fetch": "^11.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "10.1.1",
+          "version": "11.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0",
-            "make-fetch-happen": "^8.0.9",
+            "make-fetch-happen": "^9.0.1",
             "minipass": "^3.1.3",
             "minipass-fetch": "^1.3.0",
             "minipass-json-stream": "^1.0.1",
@@ -23755,14 +23977,25 @@
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
           }
         },
         "number-is-nan": {
@@ -23802,11 +24035,11 @@
           }
         },
         "pacote": {
-          "version": "11.3.3",
+          "version": "11.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.0.1",
+            "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
             "@npmcli/promise-spawn": "^1.2.0",
             "@npmcli/run-script": "^1.8.2",
@@ -23819,7 +24052,7 @@
             "npm-package-arg": "^8.0.1",
             "npm-packlist": "^2.1.4",
             "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^10.0.0",
+            "npm-registry-fetch": "^11.0.0",
             "promise-retry": "^2.0.1",
             "read-package-json-fast": "^2.0.1",
             "rimraf": "^3.0.2",
@@ -23844,7 +24077,6 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
           "dev": true
         },
         "performance-now": {
@@ -23859,7 +24091,6 @@
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
           "dev": true
         },
         "promise-all-reject-late": {
@@ -23928,7 +24159,7 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "3.0.1",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23939,7 +24170,7 @@
           }
         },
         "read-package-json-fast": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23948,17 +24179,13 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
+          "version": "3.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -23999,6 +24226,16 @@
             "uuid": "^3.3.2"
           },
           "dependencies": {
+            "form-data": {
+              "version": "2.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+              }
+            },
             "tough-cookie": {
               "version": "2.5.0",
               "bundled": true,
@@ -24012,7 +24249,6 @@
         },
         "resolve": {
           "version": "1.20.0",
-          "bundled": true,
           "dev": true,
           "requires": {
             "is-core-module": "^2.2.0",
@@ -24033,7 +24269,7 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true
         },
@@ -24061,7 +24297,7 @@
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true
         },
@@ -24075,13 +24311,13 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "5.0.0",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4",
-            "socks": "^2.3.3"
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.1",
+            "socks": "^2.6.1"
           }
         },
         "spdx-correct": {
@@ -24108,7 +24344,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.7",
+          "version": "3.0.10",
           "bundled": true,
           "dev": true
         },
@@ -24137,11 +24373,11 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
+          "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         },
         "string-width": {
@@ -24190,7 +24426,7 @@
           }
         },
         "tar": {
-          "version": "6.1.0",
+          "version": "6.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24640,9 +24876,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -25113,6 +25349,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -25494,9 +25736,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -25766,9 +26008,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true
     },
     "set-blocking": {
@@ -25867,14 +26109,52 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        }
       }
     },
     "slide": {
@@ -26394,28 +26674,95 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.1.tgz",
+      "integrity": "sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "temp-dir": {
@@ -26504,9 +26851,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -26587,15 +26934,15 @@
       "dev": true
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true
     },
     "tsc-publish": {
@@ -26920,10 +27267,13 @@
       "dev": true
     },
     "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-1.0.0.tgz",
+      "integrity": "sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==",
+      "dev": true,
+      "requires": {
+        "fast-url-parser": "^1.1.3"
+      }
     },
     "use": {
       "version": "3.1.1",
@@ -27076,17 +27426,6 @@
         "strip-ansi": "^5.0.0"
       },
       "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -27104,15 +27443,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
-    },
     "write-file-atomic": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
@@ -27125,9 +27455,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
@@ -27181,26 +27511,6 @@
         "yargs-parser": "^13.1.2"
       },
       "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
         "yargs-parser": {
           "version": "13.1.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@semantic-release/changelog": "^3.0.4",
         "@semantic-release/git": "^7.0.12",
         "axios": "^0.21.1",
-        "codecov": "^3.5.0",
         "dotenv": "^8.2.0",
         "eslint": "^7.9.0",
         "eslint-config-google": "^0.12.0",
@@ -2072,15 +2071,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.10"
-      }
-    },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -2702,26 +2692,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/codecov": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.3.tgz",
-      "integrity": "sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==",
-      "deprecated": "https://about.codecov.io/blog/codecov-uploader-deprecation-plan/",
-      "dev": true,
-      "dependencies": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.4",
-        "js-yaml": "3.14.1",
-        "teeny-request": "7.1.1",
-        "urlgrey": "1.0.0"
-      },
-      "bin": {
-        "codecov": "bin/codecov"
-      },
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/collection-visit": {
@@ -4269,21 +4239,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "node_modules/fast-url-parser/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "node_modules/fastq": {
@@ -9889,19 +9844,6 @@
         "node": "*"
       }
     },
-    "node_modules/npm/node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
       "dev": true,
@@ -10246,11 +10188,6 @@
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
@@ -11087,11 +11024,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/path-parse": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
       "dev": true,
@@ -11103,11 +11035,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
@@ -11315,18 +11242,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/resolve": {
-      "version": "1.20.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/npm/node_modules/retry": {
@@ -14167,15 +14082,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "node_modules/stream-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "dev": true,
-      "dependencies": {
-        "stubs": "^3.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -14347,12 +14253,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stubs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-      "dev": true
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -14490,31 +14390,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/teeny-request": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.1.tgz",
-      "integrity": "sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "stream-events": "^1.0.5",
-        "uuid": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/temp-dir": {
@@ -15139,15 +15014,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
-    },
-    "node_modules/urlgrey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-1.0.0.tgz",
-      "integrity": "sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==",
-      "dev": true,
-      "dependencies": {
-        "fast-url-parser": "^1.1.3"
-      }
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -17143,12 +17009,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "dev": true
-    },
     "argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -17662,19 +17522,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codecov": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.3.tgz",
-      "integrity": "sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.4",
-        "js-yaml": "3.14.1",
-        "teeny-request": "7.1.1",
-        "urlgrey": "1.0.0"
-      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -18896,23 +18743,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
     },
     "fastq": {
       "version": "1.6.0",
@@ -23203,15 +23033,6 @@
           "bundled": true,
           "dev": true
         },
-        "form-data": {
-          "version": "2.3.3",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
         "fs-minipass": {
           "version": "2.1.0",
           "bundled": true,
@@ -23458,10 +23279,6 @@
         "is-typedarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
           "dev": true
         },
         "isexe": {
@@ -24075,10 +23892,6 @@
           "bundled": true,
           "dev": true
         },
-        "path-parse": {
-          "version": "1.0.6",
-          "dev": true
-        },
         "performance-now": {
           "version": "2.1.0",
           "bundled": true,
@@ -24087,10 +23900,6 @@
         "proc-log": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
           "dev": true
         },
         "promise-all-reject-late": {
@@ -24245,14 +24054,6 @@
                 "punycode": "^2.1.1"
               }
             }
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
           }
         },
         "retry": {
@@ -26476,15 +26277,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "stream-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "dev": true,
-      "requires": {
-        "stubs": "^3.0.0"
-      }
-    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -26626,12 +26418,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "stubs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-      "dev": true
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -26741,27 +26527,6 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
-        }
-      }
-    },
-    "teeny-request": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.1.tgz",
-      "integrity": "sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "stream-events": "^1.0.5",
-        "uuid": "^8.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
         }
       }
     },
@@ -27265,15 +27030,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
-    },
-    "urlgrey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-1.0.0.tgz",
-      "integrity": "sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==",
-      "dev": true,
-      "requires": {
-        "fast-url-parser": "^1.1.3"
-      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test-travis": "jest --runInBand --testNamePattern='^((?!@slow).)*$' test/",
     "test-unit-travis": "jest --runInBand test/unit/",
     "test-integration-travis": "jest --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log",
-    "report-coverage": "codecov",
     "check-packages": "installed-check -e -d -v"
   },
   "license": "Apache-2.0",
@@ -43,7 +42,6 @@
     "@semantic-release/changelog": "^3.0.4",
     "@semantic-release/git": "^7.0.12",
     "axios": "^0.21.1",
-    "codecov": "^3.5.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.9.0",
     "eslint-config-google": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@types/node": "^12.0.8",
     "extend": "^3.0.2",
-    "ibm-cloud-sdk-core": "^2.14.4"
+    "ibm-cloud-sdk-core": "^2.17.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.4",

--- a/test/unit/vpc.v1.test.js
+++ b/test/unit/vpc.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+
 // need to import the whole package to mock getAuthenticatorFromEnvironment
 const core = require('ibm-cloud-sdk-core');
 
@@ -342,7 +342,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpc({});
@@ -351,17 +351,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpcPromise = vpcService.deleteVpc();
-        expectToBePromise(deleteVpcPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpc();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpcPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -427,7 +427,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpc({});
@@ -436,17 +436,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcPromise = vpcService.getVpc();
-        expectToBePromise(getVpcPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpc();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -515,7 +515,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpc({});
@@ -524,17 +524,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpcPromise = vpcService.updateVpc();
-        expectToBePromise(updateVpcPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpc();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpcPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -600,7 +600,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcDefaultNetworkAcl({});
@@ -609,17 +609,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcDefaultNetworkAclPromise = vpcService.getVpcDefaultNetworkAcl();
-        expectToBePromise(getVpcDefaultNetworkAclPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcDefaultNetworkAcl();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcDefaultNetworkAclPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -685,7 +685,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcDefaultRoutingTable({});
@@ -694,17 +694,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcDefaultRoutingTablePromise = vpcService.getVpcDefaultRoutingTable();
-        expectToBePromise(getVpcDefaultRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcDefaultRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcDefaultRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -770,7 +770,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcDefaultSecurityGroup({});
@@ -779,17 +779,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcDefaultSecurityGroupPromise = vpcService.getVpcDefaultSecurityGroup();
-        expectToBePromise(getVpcDefaultSecurityGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcDefaultSecurityGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcDefaultSecurityGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -861,7 +861,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpcAddressPrefixes({});
@@ -870,17 +870,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpcAddressPrefixesPromise = vpcService.listVpcAddressPrefixes();
-        expectToBePromise(listVpcAddressPrefixesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpcAddressPrefixes();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpcAddressPrefixesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -969,7 +969,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVpcAddressPrefix({});
@@ -978,17 +978,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVpcAddressPrefixPromise = vpcService.createVpcAddressPrefix();
-        expectToBePromise(createVpcAddressPrefixPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVpcAddressPrefix();
+        } catch (e) {
+          err = e;
+        }
 
-        createVpcAddressPrefixPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1059,7 +1059,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpcAddressPrefix({});
@@ -1068,17 +1068,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpcAddressPrefixPromise = vpcService.deleteVpcAddressPrefix();
-        expectToBePromise(deleteVpcAddressPrefixPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpcAddressPrefix();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpcAddressPrefixPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1149,7 +1149,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcAddressPrefix({});
@@ -1158,17 +1158,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcAddressPrefixPromise = vpcService.getVpcAddressPrefix();
-        expectToBePromise(getVpcAddressPrefixPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcAddressPrefix();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcAddressPrefixPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1245,7 +1245,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpcAddressPrefix({});
@@ -1254,17 +1254,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpcAddressPrefixPromise = vpcService.updateVpcAddressPrefix();
-        expectToBePromise(updateVpcAddressPrefixPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpcAddressPrefix();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpcAddressPrefixPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1339,7 +1339,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpcRoutes({});
@@ -1348,17 +1348,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpcRoutesPromise = vpcService.listVpcRoutes();
-        expectToBePromise(listVpcRoutesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpcRoutes();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpcRoutesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1455,7 +1455,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVpcRoute({});
@@ -1464,17 +1464,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVpcRoutePromise = vpcService.createVpcRoute();
-        expectToBePromise(createVpcRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVpcRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        createVpcRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1545,7 +1545,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpcRoute({});
@@ -1554,17 +1554,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpcRoutePromise = vpcService.deleteVpcRoute();
-        expectToBePromise(deleteVpcRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpcRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpcRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1635,7 +1635,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcRoute({});
@@ -1644,17 +1644,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcRoutePromise = vpcService.getVpcRoute();
-        expectToBePromise(getVpcRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1728,7 +1728,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpcRoute({});
@@ -1737,17 +1737,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpcRoutePromise = vpcService.updateVpcRoute();
-        expectToBePromise(updateVpcRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpcRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpcRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1822,7 +1822,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpcRoutingTables({});
@@ -1831,17 +1831,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpcRoutingTablesPromise = vpcService.listVpcRoutingTables();
-        expectToBePromise(listVpcRoutingTablesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpcRoutingTables();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpcRoutingTablesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -1945,7 +1945,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVpcRoutingTable({});
@@ -1954,17 +1954,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVpcRoutingTablePromise = vpcService.createVpcRoutingTable();
-        expectToBePromise(createVpcRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVpcRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        createVpcRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2035,7 +2035,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpcRoutingTable({});
@@ -2044,17 +2044,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpcRoutingTablePromise = vpcService.deleteVpcRoutingTable();
-        expectToBePromise(deleteVpcRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpcRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpcRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2125,7 +2125,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcRoutingTable({});
@@ -2134,17 +2134,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcRoutingTablePromise = vpcService.getVpcRoutingTable();
-        expectToBePromise(getVpcRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2229,7 +2229,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpcRoutingTable({});
@@ -2238,17 +2238,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpcRoutingTablePromise = vpcService.updateVpcRoutingTable();
-        expectToBePromise(updateVpcRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpcRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpcRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2329,7 +2329,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpcRoutingTableRoutes({});
@@ -2338,17 +2338,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpcRoutingTableRoutesPromise = vpcService.listVpcRoutingTableRoutes();
-        expectToBePromise(listVpcRoutingTableRoutesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpcRoutingTableRoutes();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpcRoutingTableRoutesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2454,7 +2454,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVpcRoutingTableRoute({});
@@ -2463,17 +2463,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVpcRoutingTableRoutePromise = vpcService.createVpcRoutingTableRoute();
-        expectToBePromise(createVpcRoutingTableRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVpcRoutingTableRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        createVpcRoutingTableRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2553,7 +2553,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpcRoutingTableRoute({});
@@ -2562,17 +2562,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpcRoutingTableRoutePromise = vpcService.deleteVpcRoutingTableRoute();
-        expectToBePromise(deleteVpcRoutingTableRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpcRoutingTableRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpcRoutingTableRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2652,7 +2652,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpcRoutingTableRoute({});
@@ -2661,17 +2661,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpcRoutingTableRoutePromise = vpcService.getVpcRoutingTableRoute();
-        expectToBePromise(getVpcRoutingTableRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpcRoutingTableRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpcRoutingTableRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2754,7 +2754,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpcRoutingTableRoute({});
@@ -2763,17 +2763,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpcRoutingTableRoutePromise = vpcService.updateVpcRoutingTableRoute();
-        expectToBePromise(updateVpcRoutingTableRoutePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpcRoutingTableRoute();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpcRoutingTableRoutePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -2961,7 +2961,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createSubnet({});
@@ -2970,17 +2970,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createSubnetPromise = vpcService.createSubnet();
-        expectToBePromise(createSubnetPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createSubnet();
+        } catch (e) {
+          err = e;
+        }
 
-        createSubnetPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3046,7 +3046,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSubnet({});
@@ -3055,17 +3055,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSubnetPromise = vpcService.deleteSubnet();
-        expectToBePromise(deleteSubnetPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSubnet();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSubnetPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3131,7 +3131,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSubnet({});
@@ -3140,17 +3140,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSubnetPromise = vpcService.getSubnet();
-        expectToBePromise(getSubnetPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSubnet();
+        } catch (e) {
+          err = e;
+        }
 
-        getSubnetPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3245,7 +3245,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateSubnet({});
@@ -3254,17 +3254,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateSubnetPromise = vpcService.updateSubnet();
-        expectToBePromise(updateSubnetPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateSubnet();
+        } catch (e) {
+          err = e;
+        }
 
-        updateSubnetPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3330,7 +3330,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSubnetNetworkAcl({});
@@ -3339,17 +3339,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSubnetNetworkAclPromise = vpcService.getSubnetNetworkAcl();
-        expectToBePromise(getSubnetNetworkAclPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSubnetNetworkAcl();
+        } catch (e) {
+          err = e;
+        }
 
-        getSubnetNetworkAclPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3427,7 +3427,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.replaceSubnetNetworkAcl({});
@@ -3436,17 +3436,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const replaceSubnetNetworkAclPromise = vpcService.replaceSubnetNetworkAcl();
-        expectToBePromise(replaceSubnetNetworkAclPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.replaceSubnetNetworkAcl();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceSubnetNetworkAclPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3512,7 +3512,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.unsetSubnetPublicGateway({});
@@ -3521,17 +3521,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const unsetSubnetPublicGatewayPromise = vpcService.unsetSubnetPublicGateway();
-        expectToBePromise(unsetSubnetPublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.unsetSubnetPublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        unsetSubnetPublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3597,7 +3597,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSubnetPublicGateway({});
@@ -3606,17 +3606,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSubnetPublicGatewayPromise = vpcService.getSubnetPublicGateway();
-        expectToBePromise(getSubnetPublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSubnetPublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        getSubnetPublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3694,7 +3694,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.setSubnetPublicGateway({});
@@ -3703,17 +3703,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const setSubnetPublicGatewayPromise = vpcService.setSubnetPublicGateway();
-        expectToBePromise(setSubnetPublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.setSubnetPublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        setSubnetPublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3779,7 +3779,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSubnetRoutingTable({});
@@ -3788,17 +3788,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSubnetRoutingTablePromise = vpcService.getSubnetRoutingTable();
-        expectToBePromise(getSubnetRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSubnetRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        getSubnetRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3876,7 +3876,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.replaceSubnetRoutingTable({});
@@ -3885,17 +3885,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const replaceSubnetRoutingTablePromise = vpcService.replaceSubnetRoutingTable();
-        expectToBePromise(replaceSubnetRoutingTablePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.replaceSubnetRoutingTable();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceSubnetRoutingTablePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -3970,7 +3970,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listSubnetReservedIps({});
@@ -3979,17 +3979,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listSubnetReservedIpsPromise = vpcService.listSubnetReservedIps();
-        expectToBePromise(listSubnetReservedIpsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listSubnetReservedIps();
+        } catch (e) {
+          err = e;
+        }
 
-        listSubnetReservedIpsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4071,7 +4071,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createSubnetReservedIp({});
@@ -4080,17 +4080,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createSubnetReservedIpPromise = vpcService.createSubnetReservedIp();
-        expectToBePromise(createSubnetReservedIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
 
-        createSubnetReservedIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4161,7 +4161,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSubnetReservedIp({});
@@ -4170,17 +4170,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSubnetReservedIpPromise = vpcService.deleteSubnetReservedIp();
-        expectToBePromise(deleteSubnetReservedIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSubnetReservedIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4251,7 +4251,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSubnetReservedIp({});
@@ -4260,17 +4260,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSubnetReservedIpPromise = vpcService.getSubnetReservedIp();
-        expectToBePromise(getSubnetReservedIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
 
-        getSubnetReservedIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4347,7 +4347,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateSubnetReservedIp({});
@@ -4356,17 +4356,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateSubnetReservedIpPromise = vpcService.updateSubnetReservedIp();
-        expectToBePromise(updateSubnetReservedIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
 
-        updateSubnetReservedIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4542,7 +4542,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createImage({});
@@ -4551,17 +4551,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createImagePromise = vpcService.createImage();
-        expectToBePromise(createImagePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createImage();
+        } catch (e) {
+          err = e;
+        }
 
-        createImagePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4627,7 +4627,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteImage({});
@@ -4636,17 +4636,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteImagePromise = vpcService.deleteImage();
-        expectToBePromise(deleteImagePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteImage();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteImagePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4712,7 +4712,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getImage({});
@@ -4721,17 +4721,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getImagePromise = vpcService.getImage();
-        expectToBePromise(getImagePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getImage();
+        } catch (e) {
+          err = e;
+        }
 
-        getImagePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4800,7 +4800,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateImage({});
@@ -4809,17 +4809,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateImagePromise = vpcService.updateImage();
-        expectToBePromise(updateImagePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateImage();
+        } catch (e) {
+          err = e;
+        }
 
-        updateImagePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4953,7 +4953,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getOperatingSystem({});
@@ -4962,17 +4962,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getOperatingSystemPromise = vpcService.getOperatingSystem();
-        expectToBePromise(getOperatingSystemPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getOperatingSystem();
+        } catch (e) {
+          err = e;
+        }
 
-        getOperatingSystemPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -4982,11 +4982,9 @@ describe('VpcV1', () => {
         // Construct the params object for operation listKeys
         const start = 'testString';
         const limit = 1;
-        const resourceGroupId = 'testString';
         const params = {
           start: start,
           limit: limit,
-          resourceGroupId: resourceGroupId,
         };
 
         const listKeysResult = vpcService.listKeys(params);
@@ -5007,7 +5005,6 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
         expect(mockRequestOptions.qs.start).toEqual(start);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
-        expect(mockRequestOptions.qs['resource_group.id']).toEqual(resourceGroupId);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
@@ -5059,7 +5056,7 @@ describe('VpcV1', () => {
       function __createKeyTest() {
         // Construct the params object for operation createKey
         const publicKey =
-          'AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En';
+          'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En';
         const name = 'my-key';
         const resourceGroup = resourceGroupIdentityModel;
         const type = 'rsa';
@@ -5110,7 +5107,7 @@ describe('VpcV1', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const publicKey =
-          'AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En';
+          'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
         const params = {
@@ -5127,7 +5124,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createKey({});
@@ -5136,17 +5133,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createKeyPromise = vpcService.createKey();
-        expectToBePromise(createKeyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createKey();
+        } catch (e) {
+          err = e;
+        }
 
-        createKeyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5212,7 +5209,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteKey({});
@@ -5221,17 +5218,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteKeyPromise = vpcService.deleteKey();
-        expectToBePromise(deleteKeyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteKey();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteKeyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5297,7 +5294,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getKey({});
@@ -5306,17 +5303,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getKeyPromise = vpcService.getKey();
-        expectToBePromise(getKeyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getKey();
+        } catch (e) {
+          err = e;
+        }
 
-        getKeyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5385,7 +5382,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateKey({});
@@ -5394,17 +5391,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateKeyPromise = vpcService.updateKey();
-        expectToBePromise(updateKeyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateKey();
+        } catch (e) {
+          err = e;
+        }
 
-        updateKeyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5531,7 +5528,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceProfile({});
@@ -5540,17 +5537,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceProfilePromise = vpcService.getInstanceProfile();
-        expectToBePromise(getInstanceProfilePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceProfile();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceProfilePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5790,7 +5787,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceTemplate({});
@@ -5799,17 +5796,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceTemplatePromise = vpcService.createInstanceTemplate();
-        expectToBePromise(createInstanceTemplatePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceTemplate();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceTemplatePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5875,7 +5872,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceTemplate({});
@@ -5884,17 +5881,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceTemplatePromise = vpcService.deleteInstanceTemplate();
-        expectToBePromise(deleteInstanceTemplatePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceTemplate();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceTemplatePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -5960,7 +5957,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceTemplate({});
@@ -5969,17 +5966,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceTemplatePromise = vpcService.getInstanceTemplate();
-        expectToBePromise(getInstanceTemplatePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceTemplate();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceTemplatePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6048,7 +6045,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceTemplate({});
@@ -6057,17 +6054,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceTemplatePromise = vpcService.updateInstanceTemplate();
-        expectToBePromise(updateInstanceTemplatePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceTemplate();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceTemplatePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6350,7 +6347,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstance({});
@@ -6359,17 +6356,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstancePromise = vpcService.createInstance();
-        expectToBePromise(createInstancePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstance();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstancePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6435,7 +6432,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstance({});
@@ -6444,17 +6441,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstancePromise = vpcService.deleteInstance();
-        expectToBePromise(deleteInstancePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstance();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstancePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6520,7 +6517,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstance({});
@@ -6529,17 +6526,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstancePromise = vpcService.getInstance();
-        expectToBePromise(getInstancePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstance();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstancePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6621,7 +6618,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstance({});
@@ -6630,17 +6627,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstancePromise = vpcService.updateInstance();
-        expectToBePromise(updateInstancePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstance();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstancePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6706,7 +6703,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceInitialization({});
@@ -6715,17 +6712,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceInitializationPromise = vpcService.getInstanceInitialization();
-        expectToBePromise(getInstanceInitializationPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceInitialization();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceInitializationPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6799,7 +6796,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceAction({});
@@ -6808,17 +6805,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceActionPromise = vpcService.createInstanceAction();
-        expectToBePromise(createInstanceActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceAction();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceActionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6898,7 +6895,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceConsoleAccessToken({});
@@ -6907,17 +6904,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceConsoleAccessTokenPromise = vpcService.createInstanceConsoleAccessToken();
-        expectToBePromise(createInstanceConsoleAccessTokenPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceConsoleAccessToken();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceConsoleAccessTokenPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -6983,7 +6980,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceDisks({});
@@ -6992,17 +6989,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceDisksPromise = vpcService.listInstanceDisks();
-        expectToBePromise(listInstanceDisksPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceDisks();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceDisksPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7073,7 +7070,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceDisk({});
@@ -7082,17 +7079,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceDiskPromise = vpcService.getInstanceDisk();
-        expectToBePromise(getInstanceDiskPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceDisk();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceDiskPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7166,7 +7163,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceDisk({});
@@ -7175,17 +7172,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceDiskPromise = vpcService.updateInstanceDisk();
-        expectToBePromise(updateInstanceDiskPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceDisk();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceDiskPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7253,7 +7250,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceNetworkInterfaces({});
@@ -7262,17 +7259,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceNetworkInterfacesPromise = vpcService.listInstanceNetworkInterfaces();
-        expectToBePromise(listInstanceNetworkInterfacesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceNetworkInterfaces();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceNetworkInterfacesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7373,7 +7370,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceNetworkInterface({});
@@ -7382,17 +7379,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceNetworkInterfacePromise = vpcService.createInstanceNetworkInterface();
-        expectToBePromise(createInstanceNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7469,7 +7466,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceNetworkInterface({});
@@ -7478,17 +7475,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceNetworkInterfacePromise = vpcService.deleteInstanceNetworkInterface();
-        expectToBePromise(deleteInstanceNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7563,7 +7560,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceNetworkInterface({});
@@ -7572,17 +7569,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceNetworkInterfacePromise = vpcService.getInstanceNetworkInterface();
-        expectToBePromise(getInstanceNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7665,7 +7662,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceNetworkInterface({});
@@ -7674,17 +7671,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceNetworkInterfacePromise = vpcService.updateInstanceNetworkInterface();
-        expectToBePromise(updateInstanceNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7761,7 +7758,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceNetworkInterfaceFloatingIps({});
@@ -7770,17 +7767,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceNetworkInterfaceFloatingIpsPromise = vpcService.listInstanceNetworkInterfaceFloatingIps();
-        expectToBePromise(listInstanceNetworkInterfaceFloatingIpsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceNetworkInterfaceFloatingIps();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceNetworkInterfaceFloatingIpsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7862,7 +7859,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.removeInstanceNetworkInterfaceFloatingIp({});
@@ -7871,17 +7868,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const removeInstanceNetworkInterfaceFloatingIpPromise = vpcService.removeInstanceNetworkInterfaceFloatingIp();
-        expectToBePromise(removeInstanceNetworkInterfaceFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.removeInstanceNetworkInterfaceFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        removeInstanceNetworkInterfaceFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -7963,7 +7960,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceNetworkInterfaceFloatingIp({});
@@ -7972,17 +7969,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceNetworkInterfaceFloatingIpPromise = vpcService.getInstanceNetworkInterfaceFloatingIp();
-        expectToBePromise(getInstanceNetworkInterfaceFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceNetworkInterfaceFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceNetworkInterfaceFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8064,7 +8061,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.addInstanceNetworkInterfaceFloatingIp({});
@@ -8073,17 +8070,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const addInstanceNetworkInterfaceFloatingIpPromise = vpcService.addInstanceNetworkInterfaceFloatingIp();
-        expectToBePromise(addInstanceNetworkInterfaceFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.addInstanceNetworkInterfaceFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        addInstanceNetworkInterfaceFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8151,7 +8148,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceVolumeAttachments({});
@@ -8160,17 +8157,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceVolumeAttachmentsPromise = vpcService.listInstanceVolumeAttachments();
-        expectToBePromise(listInstanceVolumeAttachmentsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceVolumeAttachments();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceVolumeAttachmentsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8262,7 +8259,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceVolumeAttachment({});
@@ -8271,17 +8268,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceVolumeAttachmentPromise = vpcService.createInstanceVolumeAttachment();
-        expectToBePromise(createInstanceVolumeAttachmentPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceVolumeAttachment();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceVolumeAttachmentPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8358,7 +8355,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceVolumeAttachment({});
@@ -8367,17 +8364,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceVolumeAttachmentPromise = vpcService.deleteInstanceVolumeAttachment();
-        expectToBePromise(deleteInstanceVolumeAttachmentPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceVolumeAttachment();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceVolumeAttachmentPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8452,7 +8449,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceVolumeAttachment({});
@@ -8461,17 +8458,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceVolumeAttachmentPromise = vpcService.getInstanceVolumeAttachment();
-        expectToBePromise(getInstanceVolumeAttachmentPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceVolumeAttachment();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceVolumeAttachmentPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8556,7 +8553,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceVolumeAttachment({});
@@ -8565,17 +8562,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceVolumeAttachmentPromise = vpcService.updateInstanceVolumeAttachment();
-        expectToBePromise(updateInstanceVolumeAttachmentPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceVolumeAttachment();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceVolumeAttachmentPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8759,7 +8756,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceGroup({});
@@ -8768,17 +8765,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceGroupPromise = vpcService.createInstanceGroup();
-        expectToBePromise(createInstanceGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8844,7 +8841,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroup({});
@@ -8853,17 +8850,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupPromise = vpcService.deleteInstanceGroup();
-        expectToBePromise(deleteInstanceGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -8929,7 +8926,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceGroup({});
@@ -8938,17 +8935,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceGroupPromise = vpcService.getInstanceGroup();
-        expectToBePromise(getInstanceGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9057,7 +9054,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceGroup({});
@@ -9066,17 +9063,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceGroupPromise = vpcService.updateInstanceGroup();
-        expectToBePromise(updateInstanceGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9148,7 +9145,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroupLoadBalancer({});
@@ -9157,17 +9154,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupLoadBalancerPromise = vpcService.deleteInstanceGroupLoadBalancer();
-        expectToBePromise(deleteInstanceGroupLoadBalancerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroupLoadBalancer();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupLoadBalancerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9243,7 +9240,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceGroupManagers({});
@@ -9252,17 +9249,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceGroupManagersPromise = vpcService.listInstanceGroupManagers();
-        expectToBePromise(listInstanceGroupManagersPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceGroupManagers();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceGroupManagersPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9350,7 +9347,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceGroupManager({});
@@ -9359,17 +9356,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceGroupManagerPromise = vpcService.createInstanceGroupManager();
-        expectToBePromise(createInstanceGroupManagerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceGroupManager();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceGroupManagerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9444,7 +9441,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroupManager({});
@@ -9453,17 +9450,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupManagerPromise = vpcService.deleteInstanceGroupManager();
-        expectToBePromise(deleteInstanceGroupManagerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroupManager();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupManagerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9538,7 +9535,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceGroupManager({});
@@ -9547,17 +9544,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceGroupManagerPromise = vpcService.getInstanceGroupManager();
-        expectToBePromise(getInstanceGroupManagerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceGroupManager();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceGroupManagerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9650,7 +9647,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceGroupManager({});
@@ -9659,17 +9656,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceGroupManagerPromise = vpcService.updateInstanceGroupManager();
-        expectToBePromise(updateInstanceGroupManagerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceGroupManager();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceGroupManagerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9752,7 +9749,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceGroupManagerActions({});
@@ -9761,17 +9758,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceGroupManagerActionsPromise = vpcService.listInstanceGroupManagerActions();
-        expectToBePromise(listInstanceGroupManagerActionsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceGroupManagerActions();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceGroupManagerActionsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9867,7 +9864,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceGroupManagerAction({});
@@ -9876,17 +9873,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceGroupManagerActionPromise = vpcService.createInstanceGroupManagerAction();
-        expectToBePromise(createInstanceGroupManagerActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceGroupManagerAction();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceGroupManagerActionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -9968,7 +9965,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroupManagerAction({});
@@ -9977,17 +9974,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupManagerActionPromise = vpcService.deleteInstanceGroupManagerAction();
-        expectToBePromise(deleteInstanceGroupManagerActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroupManagerAction();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupManagerActionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10069,7 +10066,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceGroupManagerAction({});
@@ -10078,17 +10075,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceGroupManagerActionPromise = vpcService.getInstanceGroupManagerAction();
-        expectToBePromise(getInstanceGroupManagerActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceGroupManagerAction();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceGroupManagerActionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10198,7 +10195,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceGroupManagerAction({});
@@ -10207,17 +10204,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceGroupManagerActionPromise = vpcService.updateInstanceGroupManagerAction();
-        expectToBePromise(updateInstanceGroupManagerActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceGroupManagerAction();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceGroupManagerActionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10300,7 +10297,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceGroupManagerPolicies({});
@@ -10309,17 +10306,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceGroupManagerPoliciesPromise = vpcService.listInstanceGroupManagerPolicies();
-        expectToBePromise(listInstanceGroupManagerPoliciesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceGroupManagerPolicies();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceGroupManagerPoliciesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10411,7 +10408,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createInstanceGroupManagerPolicy({});
@@ -10420,17 +10417,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createInstanceGroupManagerPolicyPromise = vpcService.createInstanceGroupManagerPolicy();
-        expectToBePromise(createInstanceGroupManagerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createInstanceGroupManagerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        createInstanceGroupManagerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10512,7 +10509,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroupManagerPolicy({});
@@ -10521,17 +10518,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupManagerPolicyPromise = vpcService.deleteInstanceGroupManagerPolicy();
-        expectToBePromise(deleteInstanceGroupManagerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroupManagerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupManagerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10613,7 +10610,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceGroupManagerPolicy({});
@@ -10622,17 +10619,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceGroupManagerPolicyPromise = vpcService.getInstanceGroupManagerPolicy();
-        expectToBePromise(getInstanceGroupManagerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceGroupManagerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceGroupManagerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10723,7 +10720,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceGroupManagerPolicy({});
@@ -10732,17 +10729,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceGroupManagerPolicyPromise = vpcService.updateInstanceGroupManagerPolicy();
-        expectToBePromise(updateInstanceGroupManagerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceGroupManagerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceGroupManagerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10814,7 +10811,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroupMemberships({});
@@ -10823,17 +10820,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupMembershipsPromise = vpcService.deleteInstanceGroupMemberships();
-        expectToBePromise(deleteInstanceGroupMembershipsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroupMemberships();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupMembershipsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -10909,7 +10906,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listInstanceGroupMemberships({});
@@ -10918,17 +10915,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listInstanceGroupMembershipsPromise = vpcService.listInstanceGroupMemberships();
-        expectToBePromise(listInstanceGroupMembershipsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceGroupMemberships();
+        } catch (e) {
+          err = e;
+        }
 
-        listInstanceGroupMembershipsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11005,7 +11002,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteInstanceGroupMembership({});
@@ -11014,17 +11011,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteInstanceGroupMembershipPromise = vpcService.deleteInstanceGroupMembership();
-        expectToBePromise(deleteInstanceGroupMembershipPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceGroupMembership();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteInstanceGroupMembershipPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11099,7 +11096,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getInstanceGroupMembership({});
@@ -11108,17 +11105,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getInstanceGroupMembershipPromise = vpcService.getInstanceGroupMembership();
-        expectToBePromise(getInstanceGroupMembershipPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceGroupMembership();
+        } catch (e) {
+          err = e;
+        }
 
-        getInstanceGroupMembershipPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11198,7 +11195,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateInstanceGroupMembership({});
@@ -11207,17 +11204,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateInstanceGroupMembershipPromise = vpcService.updateInstanceGroupMembership();
-        expectToBePromise(updateInstanceGroupMembershipPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceGroupMembership();
+        } catch (e) {
+          err = e;
+        }
 
-        updateInstanceGroupMembershipPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11229,11 +11226,13 @@ describe('VpcV1', () => {
         const limit = 1;
         const resourceGroupId = 'testString';
         const zoneName = 'testString';
+        const name = 'testString';
         const params = {
           start: start,
           limit: limit,
           resourceGroupId: resourceGroupId,
           zoneName: zoneName,
+          name: name,
         };
 
         const listDedicatedHostGroupsResult = vpcService.listDedicatedHostGroups(params);
@@ -11256,6 +11255,7 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs['resource_group.id']).toEqual(resourceGroupId);
         expect(mockRequestOptions.qs['zone.name']).toEqual(zoneName);
+        expect(mockRequestOptions.qs.name).toEqual(name);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
@@ -11446,7 +11446,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteDedicatedHostGroup({});
@@ -11455,17 +11455,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteDedicatedHostGroupPromise = vpcService.deleteDedicatedHostGroup();
-        expectToBePromise(deleteDedicatedHostGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteDedicatedHostGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteDedicatedHostGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11531,7 +11531,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getDedicatedHostGroup({});
@@ -11540,17 +11540,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getDedicatedHostGroupPromise = vpcService.getDedicatedHostGroup();
-        expectToBePromise(getDedicatedHostGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getDedicatedHostGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        getDedicatedHostGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11619,7 +11619,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateDedicatedHostGroup({});
@@ -11628,17 +11628,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateDedicatedHostGroupPromise = vpcService.updateDedicatedHostGroup();
-        expectToBePromise(updateDedicatedHostGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateDedicatedHostGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        updateDedicatedHostGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11772,7 +11772,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getDedicatedHostProfile({});
@@ -11781,17 +11781,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getDedicatedHostProfilePromise = vpcService.getDedicatedHostProfile();
-        expectToBePromise(getDedicatedHostProfilePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getDedicatedHostProfile();
+        } catch (e) {
+          err = e;
+        }
 
-        getDedicatedHostProfilePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -11804,12 +11804,14 @@ describe('VpcV1', () => {
         const limit = 1;
         const resourceGroupId = 'testString';
         const zoneName = 'testString';
+        const name = 'testString';
         const params = {
           dedicatedHostGroupId: dedicatedHostGroupId,
           start: start,
           limit: limit,
           resourceGroupId: resourceGroupId,
           zoneName: zoneName,
+          name: name,
         };
 
         const listDedicatedHostsResult = vpcService.listDedicatedHosts(params);
@@ -11833,6 +11835,7 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs['resource_group.id']).toEqual(resourceGroupId);
         expect(mockRequestOptions.qs['zone.name']).toEqual(zoneName);
+        expect(mockRequestOptions.qs.name).toEqual(name);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
@@ -11960,7 +11963,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createDedicatedHost({});
@@ -11969,17 +11972,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createDedicatedHostPromise = vpcService.createDedicatedHost();
-        expectToBePromise(createDedicatedHostPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createDedicatedHost();
+        } catch (e) {
+          err = e;
+        }
 
-        createDedicatedHostPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12045,7 +12048,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listDedicatedHostDisks({});
@@ -12054,17 +12057,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listDedicatedHostDisksPromise = vpcService.listDedicatedHostDisks();
-        expectToBePromise(listDedicatedHostDisksPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listDedicatedHostDisks();
+        } catch (e) {
+          err = e;
+        }
 
-        listDedicatedHostDisksPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12139,7 +12142,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getDedicatedHostDisk({});
@@ -12148,17 +12151,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getDedicatedHostDiskPromise = vpcService.getDedicatedHostDisk();
-        expectToBePromise(getDedicatedHostDiskPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getDedicatedHostDisk();
+        } catch (e) {
+          err = e;
+        }
 
-        getDedicatedHostDiskPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12236,7 +12239,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateDedicatedHostDisk({});
@@ -12245,17 +12248,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateDedicatedHostDiskPromise = vpcService.updateDedicatedHostDisk();
-        expectToBePromise(updateDedicatedHostDiskPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateDedicatedHostDisk();
+        } catch (e) {
+          err = e;
+        }
 
-        updateDedicatedHostDiskPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12321,7 +12324,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteDedicatedHost({});
@@ -12330,17 +12333,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteDedicatedHostPromise = vpcService.deleteDedicatedHost();
-        expectToBePromise(deleteDedicatedHostPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteDedicatedHost();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteDedicatedHostPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12406,7 +12409,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getDedicatedHost({});
@@ -12415,17 +12418,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getDedicatedHostPromise = vpcService.getDedicatedHost();
-        expectToBePromise(getDedicatedHostPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getDedicatedHost();
+        } catch (e) {
+          err = e;
+        }
 
-        getDedicatedHostPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12499,7 +12502,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateDedicatedHost({});
@@ -12508,17 +12511,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateDedicatedHostPromise = vpcService.updateDedicatedHost();
-        expectToBePromise(updateDedicatedHostPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateDedicatedHost();
+        } catch (e) {
+          err = e;
+        }
 
-        updateDedicatedHostPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12665,7 +12668,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createPlacementGroup({});
@@ -12674,17 +12677,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createPlacementGroupPromise = vpcService.createPlacementGroup();
-        expectToBePromise(createPlacementGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createPlacementGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        createPlacementGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12750,7 +12753,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deletePlacementGroup({});
@@ -12759,17 +12762,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deletePlacementGroupPromise = vpcService.deletePlacementGroup();
-        expectToBePromise(deletePlacementGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deletePlacementGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        deletePlacementGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12835,7 +12838,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getPlacementGroup({});
@@ -12844,17 +12847,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getPlacementGroupPromise = vpcService.getPlacementGroup();
-        expectToBePromise(getPlacementGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getPlacementGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        getPlacementGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -12923,7 +12926,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updatePlacementGroup({});
@@ -12932,17 +12935,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updatePlacementGroupPromise = vpcService.updatePlacementGroup();
-        expectToBePromise(updatePlacementGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updatePlacementGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        updatePlacementGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13076,7 +13079,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVolumeProfile({});
@@ -13085,17 +13088,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVolumeProfilePromise = vpcService.getVolumeProfile();
-        expectToBePromise(getVolumeProfilePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVolumeProfile();
+        } catch (e) {
+          err = e;
+        }
 
-        getVolumeProfilePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13269,7 +13272,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVolume({});
@@ -13278,17 +13281,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVolumePromise = vpcService.createVolume();
-        expectToBePromise(createVolumePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVolume();
+        } catch (e) {
+          err = e;
+        }
 
-        createVolumePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13354,7 +13357,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVolume({});
@@ -13363,17 +13366,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVolumePromise = vpcService.deleteVolume();
-        expectToBePromise(deleteVolumePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVolume();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVolumePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13439,7 +13442,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVolume({});
@@ -13448,17 +13451,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVolumePromise = vpcService.getVolume();
-        expectToBePromise(getVolumePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVolume();
+        } catch (e) {
+          err = e;
+        }
 
-        getVolumePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13543,7 +13546,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVolume({});
@@ -13552,17 +13555,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVolumePromise = vpcService.updateVolume();
-        expectToBePromise(updateVolumePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVolume();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVolumePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13628,7 +13631,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSnapshots({});
@@ -13637,17 +13640,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSnapshotsPromise = vpcService.deleteSnapshots();
-        expectToBePromise(deleteSnapshotsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSnapshots();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSnapshotsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13820,7 +13823,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createSnapshot({});
@@ -13829,17 +13832,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createSnapshotPromise = vpcService.createSnapshot();
-        expectToBePromise(createSnapshotPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createSnapshot();
+        } catch (e) {
+          err = e;
+        }
 
-        createSnapshotPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13905,7 +13908,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSnapshot({});
@@ -13914,17 +13917,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSnapshotPromise = vpcService.deleteSnapshot();
-        expectToBePromise(deleteSnapshotPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSnapshot();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSnapshotPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -13990,7 +13993,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSnapshot({});
@@ -13999,17 +14002,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSnapshotPromise = vpcService.getSnapshot();
-        expectToBePromise(getSnapshotPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSnapshot();
+        } catch (e) {
+          err = e;
+        }
 
-        getSnapshotPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14078,7 +14081,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateSnapshot({});
@@ -14087,17 +14090,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateSnapshotPromise = vpcService.updateSnapshot();
-        expectToBePromise(updateSnapshotPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateSnapshot();
+        } catch (e) {
+          err = e;
+        }
 
-        updateSnapshotPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14224,7 +14227,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getRegion({});
@@ -14233,17 +14236,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getRegionPromise = vpcService.getRegion();
-        expectToBePromise(getRegionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getRegion();
+        } catch (e) {
+          err = e;
+        }
 
-        getRegionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14309,7 +14312,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listRegionZones({});
@@ -14318,17 +14321,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listRegionZonesPromise = vpcService.listRegionZones();
-        expectToBePromise(listRegionZonesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listRegionZones();
+        } catch (e) {
+          err = e;
+        }
 
-        listRegionZonesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14399,7 +14402,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getRegionZone({});
@@ -14408,17 +14411,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getRegionZonePromise = vpcService.getRegionZone();
-        expectToBePromise(getRegionZonePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getRegionZone();
+        } catch (e) {
+          err = e;
+        }
 
-        getRegionZonePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14591,7 +14594,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createPublicGateway({});
@@ -14600,17 +14603,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createPublicGatewayPromise = vpcService.createPublicGateway();
-        expectToBePromise(createPublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createPublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        createPublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14676,7 +14679,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deletePublicGateway({});
@@ -14685,17 +14688,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deletePublicGatewayPromise = vpcService.deletePublicGateway();
-        expectToBePromise(deletePublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deletePublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        deletePublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14761,7 +14764,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getPublicGateway({});
@@ -14770,17 +14773,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getPublicGatewayPromise = vpcService.getPublicGateway();
-        expectToBePromise(getPublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getPublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        getPublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -14849,7 +14852,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updatePublicGateway({});
@@ -14858,17 +14861,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updatePublicGatewayPromise = vpcService.updatePublicGateway();
-        expectToBePromise(updatePublicGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updatePublicGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        updatePublicGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15024,7 +15027,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createFloatingIp({});
@@ -15033,17 +15036,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createFloatingIpPromise = vpcService.createFloatingIp();
-        expectToBePromise(createFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        createFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15109,7 +15112,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteFloatingIp({});
@@ -15118,17 +15121,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteFloatingIpPromise = vpcService.deleteFloatingIp();
-        expectToBePromise(deleteFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15194,7 +15197,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getFloatingIp({});
@@ -15203,17 +15206,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getFloatingIpPromise = vpcService.getFloatingIp();
-        expectToBePromise(getFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        getFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15292,7 +15295,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateFloatingIp({});
@@ -15301,17 +15304,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateFloatingIpPromise = vpcService.updateFloatingIp();
-        expectToBePromise(updateFloatingIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateFloatingIp();
+        } catch (e) {
+          err = e;
+        }
 
-        updateFloatingIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15543,7 +15546,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteNetworkAcl({});
@@ -15552,17 +15555,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteNetworkAclPromise = vpcService.deleteNetworkAcl();
-        expectToBePromise(deleteNetworkAclPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteNetworkAcl();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteNetworkAclPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15628,7 +15631,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getNetworkAcl({});
@@ -15637,17 +15640,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getNetworkAclPromise = vpcService.getNetworkAcl();
-        expectToBePromise(getNetworkAclPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getNetworkAcl();
+        } catch (e) {
+          err = e;
+        }
 
-        getNetworkAclPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15716,7 +15719,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateNetworkAcl({});
@@ -15725,17 +15728,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateNetworkAclPromise = vpcService.updateNetworkAcl();
-        expectToBePromise(updateNetworkAclPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateNetworkAcl();
+        } catch (e) {
+          err = e;
+        }
 
-        updateNetworkAclPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15810,7 +15813,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listNetworkAclRules({});
@@ -15819,17 +15822,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listNetworkAclRulesPromise = vpcService.listNetworkAclRules();
-        expectToBePromise(listNetworkAclRulesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listNetworkAclRules();
+        } catch (e) {
+          err = e;
+        }
 
-        listNetworkAclRulesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -15920,7 +15923,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createNetworkAclRule({});
@@ -15929,17 +15932,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createNetworkAclRulePromise = vpcService.createNetworkAclRule();
-        expectToBePromise(createNetworkAclRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createNetworkAclRule();
+        } catch (e) {
+          err = e;
+        }
 
-        createNetworkAclRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16014,7 +16017,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteNetworkAclRule({});
@@ -16023,17 +16026,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteNetworkAclRulePromise = vpcService.deleteNetworkAclRule();
-        expectToBePromise(deleteNetworkAclRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteNetworkAclRule();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteNetworkAclRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16104,7 +16107,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getNetworkAclRule({});
@@ -16113,17 +16116,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getNetworkAclRulePromise = vpcService.getNetworkAclRule();
-        expectToBePromise(getNetworkAclRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getNetworkAclRule();
+        } catch (e) {
+          err = e;
+        }
 
-        getNetworkAclRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16237,7 +16240,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateNetworkAclRule({});
@@ -16246,17 +16249,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateNetworkAclRulePromise = vpcService.updateNetworkAclRule();
-        expectToBePromise(updateNetworkAclRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateNetworkAclRule();
+        } catch (e) {
+          err = e;
+        }
 
-        updateNetworkAclRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16438,7 +16441,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createSecurityGroup({});
@@ -16447,17 +16450,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createSecurityGroupPromise = vpcService.createSecurityGroup();
-        expectToBePromise(createSecurityGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createSecurityGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        createSecurityGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16523,7 +16526,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSecurityGroup({});
@@ -16532,17 +16535,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSecurityGroupPromise = vpcService.deleteSecurityGroup();
-        expectToBePromise(deleteSecurityGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSecurityGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSecurityGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16608,7 +16611,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSecurityGroup({});
@@ -16617,17 +16620,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSecurityGroupPromise = vpcService.getSecurityGroup();
-        expectToBePromise(getSecurityGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSecurityGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        getSecurityGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16696,7 +16699,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateSecurityGroup({});
@@ -16705,17 +16708,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateSecurityGroupPromise = vpcService.updateSecurityGroup();
-        expectToBePromise(updateSecurityGroupPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateSecurityGroup();
+        } catch (e) {
+          err = e;
+        }
 
-        updateSecurityGroupPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16793,7 +16796,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listSecurityGroupNetworkInterfaces({});
@@ -16802,17 +16805,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listSecurityGroupNetworkInterfacesPromise = vpcService.listSecurityGroupNetworkInterfaces();
-        expectToBePromise(listSecurityGroupNetworkInterfacesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listSecurityGroupNetworkInterfaces();
+        } catch (e) {
+          err = e;
+        }
 
-        listSecurityGroupNetworkInterfacesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16889,7 +16892,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.removeSecurityGroupNetworkInterface({});
@@ -16898,17 +16901,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const removeSecurityGroupNetworkInterfacePromise = vpcService.removeSecurityGroupNetworkInterface();
-        expectToBePromise(removeSecurityGroupNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.removeSecurityGroupNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        removeSecurityGroupNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -16985,7 +16988,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSecurityGroupNetworkInterface({});
@@ -16994,17 +16997,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSecurityGroupNetworkInterfacePromise = vpcService.getSecurityGroupNetworkInterface();
-        expectToBePromise(getSecurityGroupNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSecurityGroupNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        getSecurityGroupNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17081,7 +17084,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.addSecurityGroupNetworkInterface({});
@@ -17090,17 +17093,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const addSecurityGroupNetworkInterfacePromise = vpcService.addSecurityGroupNetworkInterface();
-        expectToBePromise(addSecurityGroupNetworkInterfacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.addSecurityGroupNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
 
-        addSecurityGroupNetworkInterfacePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17166,7 +17169,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listSecurityGroupRules({});
@@ -17175,17 +17178,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listSecurityGroupRulesPromise = vpcService.listSecurityGroupRules();
-        expectToBePromise(listSecurityGroupRulesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listSecurityGroupRules();
+        } catch (e) {
+          err = e;
+        }
 
-        listSecurityGroupRulesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17273,7 +17276,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createSecurityGroupRule({});
@@ -17282,17 +17285,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createSecurityGroupRulePromise = vpcService.createSecurityGroupRule();
-        expectToBePromise(createSecurityGroupRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createSecurityGroupRule();
+        } catch (e) {
+          err = e;
+        }
 
-        createSecurityGroupRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17367,7 +17370,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSecurityGroupRule({});
@@ -17376,17 +17379,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSecurityGroupRulePromise = vpcService.deleteSecurityGroupRule();
-        expectToBePromise(deleteSecurityGroupRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSecurityGroupRule();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSecurityGroupRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17461,7 +17464,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSecurityGroupRule({});
@@ -17470,17 +17473,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSecurityGroupRulePromise = vpcService.getSecurityGroupRule();
-        expectToBePromise(getSecurityGroupRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSecurityGroupRule();
+        } catch (e) {
+          err = e;
+        }
 
-        getSecurityGroupRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17583,7 +17586,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateSecurityGroupRule({});
@@ -17592,17 +17595,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateSecurityGroupRulePromise = vpcService.updateSecurityGroupRule();
-        expectToBePromise(updateSecurityGroupRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateSecurityGroupRule();
+        } catch (e) {
+          err = e;
+        }
 
-        updateSecurityGroupRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17678,7 +17681,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listSecurityGroupTargets({});
@@ -17687,17 +17690,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listSecurityGroupTargetsPromise = vpcService.listSecurityGroupTargets();
-        expectToBePromise(listSecurityGroupTargetsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listSecurityGroupTargets();
+        } catch (e) {
+          err = e;
+        }
 
-        listSecurityGroupTargetsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17774,7 +17777,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteSecurityGroupTargetBinding({});
@@ -17783,17 +17786,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteSecurityGroupTargetBindingPromise = vpcService.deleteSecurityGroupTargetBinding();
-        expectToBePromise(deleteSecurityGroupTargetBindingPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteSecurityGroupTargetBinding();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteSecurityGroupTargetBindingPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17868,7 +17871,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getSecurityGroupTarget({});
@@ -17877,17 +17880,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getSecurityGroupTargetPromise = vpcService.getSecurityGroupTarget();
-        expectToBePromise(getSecurityGroupTargetPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getSecurityGroupTarget();
+        } catch (e) {
+          err = e;
+        }
 
-        getSecurityGroupTargetPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -17964,7 +17967,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createSecurityGroupTargetBinding({});
@@ -17973,17 +17976,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createSecurityGroupTargetBindingPromise = vpcService.createSecurityGroupTargetBinding();
-        expectToBePromise(createSecurityGroupTargetBindingPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createSecurityGroupTargetBinding();
+        } catch (e) {
+          err = e;
+        }
 
-        createSecurityGroupTargetBindingPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18067,8 +18070,8 @@ describe('VpcV1', () => {
       function __createIkePolicyTest() {
         // Construct the params object for operation createIkePolicy
         const authenticationAlgorithm = 'md5';
-        const dhGroup = 2;
-        const encryptionAlgorithm = 'triple_des';
+        const dhGroup = 14;
+        const encryptionAlgorithm = 'aes128';
         const ikeVersion = 1;
         const keyLifetime = 28800;
         const name = 'my-ike-policy';
@@ -18126,8 +18129,8 @@ describe('VpcV1', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const authenticationAlgorithm = 'md5';
-        const dhGroup = 2;
-        const encryptionAlgorithm = 'triple_des';
+        const dhGroup = 14;
+        const encryptionAlgorithm = 'aes128';
         const ikeVersion = 1;
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -18148,7 +18151,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createIkePolicy({});
@@ -18157,17 +18160,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createIkePolicyPromise = vpcService.createIkePolicy();
-        expectToBePromise(createIkePolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createIkePolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        createIkePolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18233,7 +18236,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteIkePolicy({});
@@ -18242,17 +18245,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteIkePolicyPromise = vpcService.deleteIkePolicy();
-        expectToBePromise(deleteIkePolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteIkePolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteIkePolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18318,7 +18321,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getIkePolicy({});
@@ -18327,17 +18330,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getIkePolicyPromise = vpcService.getIkePolicy();
-        expectToBePromise(getIkePolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getIkePolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        getIkePolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18347,8 +18350,8 @@ describe('VpcV1', () => {
         // Construct the params object for operation updateIkePolicy
         const id = 'testString';
         const authenticationAlgorithm = 'md5';
-        const dhGroup = 2;
-        const encryptionAlgorithm = 'triple_des';
+        const dhGroup = 14;
+        const encryptionAlgorithm = 'aes128';
         const ikeVersion = 1;
         const keyLifetime = 28800;
         const name = 'my-ike-policy';
@@ -18421,7 +18424,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateIkePolicy({});
@@ -18430,17 +18433,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateIkePolicyPromise = vpcService.updateIkePolicy();
-        expectToBePromise(updateIkePolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateIkePolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        updateIkePolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18506,7 +18509,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listIkePolicyConnections({});
@@ -18515,17 +18518,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listIkePolicyConnectionsPromise = vpcService.listIkePolicyConnections();
-        expectToBePromise(listIkePolicyConnectionsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listIkePolicyConnections();
+        } catch (e) {
+          err = e;
+        }
 
-        listIkePolicyConnectionsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18609,7 +18612,7 @@ describe('VpcV1', () => {
       function __createIpsecPolicyTest() {
         // Construct the params object for operation createIpsecPolicy
         const authenticationAlgorithm = 'md5';
-        const encryptionAlgorithm = 'triple_des';
+        const encryptionAlgorithm = 'aes128';
         const pfs = 'disabled';
         const keyLifetime = 3600;
         const name = 'my-ipsec-policy';
@@ -18665,7 +18668,7 @@ describe('VpcV1', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const authenticationAlgorithm = 'md5';
-        const encryptionAlgorithm = 'triple_des';
+        const encryptionAlgorithm = 'aes128';
         const pfs = 'disabled';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -18685,7 +18688,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createIpsecPolicy({});
@@ -18694,17 +18697,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createIpsecPolicyPromise = vpcService.createIpsecPolicy();
-        expectToBePromise(createIpsecPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createIpsecPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        createIpsecPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18770,7 +18773,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteIpsecPolicy({});
@@ -18779,17 +18782,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteIpsecPolicyPromise = vpcService.deleteIpsecPolicy();
-        expectToBePromise(deleteIpsecPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteIpsecPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteIpsecPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18855,7 +18858,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getIpsecPolicy({});
@@ -18864,17 +18867,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getIpsecPolicyPromise = vpcService.getIpsecPolicy();
-        expectToBePromise(getIpsecPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getIpsecPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        getIpsecPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -18884,7 +18887,7 @@ describe('VpcV1', () => {
         // Construct the params object for operation updateIpsecPolicy
         const id = 'testString';
         const authenticationAlgorithm = 'md5';
-        const encryptionAlgorithm = 'triple_des';
+        const encryptionAlgorithm = 'aes128';
         const keyLifetime = 3600;
         const name = 'my-ipsec-policy';
         const pfs = 'disabled';
@@ -18955,7 +18958,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateIpsecPolicy({});
@@ -18964,17 +18967,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateIpsecPolicyPromise = vpcService.updateIpsecPolicy();
-        expectToBePromise(updateIpsecPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateIpsecPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        updateIpsecPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19040,7 +19043,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listIpsecPolicyConnections({});
@@ -19049,17 +19052,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listIpsecPolicyConnectionsPromise = vpcService.listIpsecPolicyConnections();
-        expectToBePromise(listIpsecPolicyConnectionsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listIpsecPolicyConnections();
+        } catch (e) {
+          err = e;
+        }
 
-        listIpsecPolicyConnectionsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19219,7 +19222,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVpnGateway({});
@@ -19228,17 +19231,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVpnGatewayPromise = vpcService.createVpnGateway();
-        expectToBePromise(createVpnGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVpnGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        createVpnGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19304,7 +19307,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpnGateway({});
@@ -19313,17 +19316,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpnGatewayPromise = vpcService.deleteVpnGateway();
-        expectToBePromise(deleteVpnGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpnGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpnGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19389,7 +19392,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpnGateway({});
@@ -19398,17 +19401,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpnGatewayPromise = vpcService.getVpnGateway();
-        expectToBePromise(getVpnGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpnGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpnGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19477,7 +19480,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpnGateway({});
@@ -19486,17 +19489,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpnGatewayPromise = vpcService.updateVpnGateway();
-        expectToBePromise(updateVpnGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpnGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpnGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19565,7 +19568,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpnGatewayConnections({});
@@ -19574,17 +19577,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpnGatewayConnectionsPromise = vpcService.listVpnGatewayConnections();
-        expectToBePromise(listVpnGatewayConnectionsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpnGatewayConnections();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpnGatewayConnectionsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19599,13 +19602,13 @@ describe('VpcV1', () => {
         timeout: 120,
       };
 
-      // IKEPolicyIdentityById
-      const ikePolicyIdentityModel = {
+      // VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityById
+      const vpnGatewayConnectionIkePolicyPrototypeModel = {
         id: 'ddf51bec-3424-11e8-b467-0ed5f89f718b',
       };
 
-      // IPsecPolicyIdentityById
-      const iPsecPolicyIdentityModel = {
+      // VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityById
+      const vpnGatewayConnectionIPsecPolicyPrototypeModel = {
         id: 'ddf51bec-3424-11e8-b467-0ed5f89f718b',
       };
 
@@ -19613,8 +19616,8 @@ describe('VpcV1', () => {
       const vpnGatewayConnectionPrototypeModel = {
         admin_state_up: true,
         dead_peer_detection: vpnGatewayConnectionDpdPrototypeModel,
-        ike_policy: ikePolicyIdentityModel,
-        ipsec_policy: iPsecPolicyIdentityModel,
+        ike_policy: vpnGatewayConnectionIkePolicyPrototypeModel,
+        ipsec_policy: vpnGatewayConnectionIPsecPolicyPrototypeModel,
         name: 'my-vpn-connection',
         peer_address: '169.21.50.5',
         psk: 'lkj14b1oi0alcniejkso',
@@ -19686,7 +19689,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createVpnGatewayConnection({});
@@ -19695,17 +19698,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createVpnGatewayConnectionPromise = vpcService.createVpnGatewayConnection();
-        expectToBePromise(createVpnGatewayConnectionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createVpnGatewayConnection();
+        } catch (e) {
+          err = e;
+        }
 
-        createVpnGatewayConnectionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19780,7 +19783,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteVpnGatewayConnection({});
@@ -19789,17 +19792,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteVpnGatewayConnectionPromise = vpcService.deleteVpnGatewayConnection();
-        expectToBePromise(deleteVpnGatewayConnectionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteVpnGatewayConnection();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteVpnGatewayConnectionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19874,7 +19877,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getVpnGatewayConnection({});
@@ -19883,17 +19886,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getVpnGatewayConnectionPromise = vpcService.getVpnGatewayConnection();
-        expectToBePromise(getVpnGatewayConnectionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getVpnGatewayConnection();
+        } catch (e) {
+          err = e;
+        }
 
-        getVpnGatewayConnectionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -19901,29 +19904,29 @@ describe('VpcV1', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
-      // VPNGatewayConnectionDPDPrototype
-      const vpnGatewayConnectionDpdPrototypeModel = {
+      // VPNGatewayConnectionDPDPatch
+      const vpnGatewayConnectionDpdPatchModel = {
         action: 'restart',
         interval: 30,
         timeout: 120,
       };
 
-      // IKEPolicyIdentityById
-      const ikePolicyIdentityModel = {
+      // VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityById
+      const vpnGatewayConnectionIkePolicyPatchModel = {
         id: 'ddf51bec-3424-11e8-b467-0ed5f89f718b',
       };
 
-      // IPsecPolicyIdentityById
-      const iPsecPolicyIdentityModel = {
+      // VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityById
+      const vpnGatewayConnectionIPsecPolicyPatchModel = {
         id: 'ddf51bec-3424-11e8-b467-0ed5f89f718b',
       };
 
       // VPNGatewayConnectionPatchVPNGatewayConnectionStaticRouteModePatch
       const vpnGatewayConnectionPatchModel = {
         admin_state_up: true,
-        dead_peer_detection: vpnGatewayConnectionDpdPrototypeModel,
-        ike_policy: ikePolicyIdentityModel,
-        ipsec_policy: iPsecPolicyIdentityModel,
+        dead_peer_detection: vpnGatewayConnectionDpdPatchModel,
+        ike_policy: vpnGatewayConnectionIkePolicyPatchModel,
+        ipsec_policy: vpnGatewayConnectionIPsecPolicyPatchModel,
         name: 'my-vpn-connection',
         peer_address: '169.21.50.5',
         psk: 'lkj14b1oi0alcniejkso',
@@ -20004,7 +20007,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateVpnGatewayConnection({});
@@ -20013,17 +20016,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateVpnGatewayConnectionPromise = vpcService.updateVpnGatewayConnection();
-        expectToBePromise(updateVpnGatewayConnectionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateVpnGatewayConnection();
+        } catch (e) {
+          err = e;
+        }
 
-        updateVpnGatewayConnectionPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20100,7 +20103,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpnGatewayConnectionLocalCidrs({});
@@ -20109,17 +20112,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpnGatewayConnectionLocalCidrsPromise = vpcService.listVpnGatewayConnectionLocalCidrs();
-        expectToBePromise(listVpnGatewayConnectionLocalCidrsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpnGatewayConnectionLocalCidrs();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpnGatewayConnectionLocalCidrsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20206,7 +20209,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.removeVpnGatewayConnectionLocalCidr({});
@@ -20215,17 +20218,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const removeVpnGatewayConnectionLocalCidrPromise = vpcService.removeVpnGatewayConnectionLocalCidr();
-        expectToBePromise(removeVpnGatewayConnectionLocalCidrPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.removeVpnGatewayConnectionLocalCidr();
+        } catch (e) {
+          err = e;
+        }
 
-        removeVpnGatewayConnectionLocalCidrPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20312,7 +20315,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.checkVpnGatewayConnectionLocalCidr({});
@@ -20321,17 +20324,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const checkVpnGatewayConnectionLocalCidrPromise = vpcService.checkVpnGatewayConnectionLocalCidr();
-        expectToBePromise(checkVpnGatewayConnectionLocalCidrPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.checkVpnGatewayConnectionLocalCidr();
+        } catch (e) {
+          err = e;
+        }
 
-        checkVpnGatewayConnectionLocalCidrPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20418,7 +20421,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.addVpnGatewayConnectionLocalCidr({});
@@ -20427,17 +20430,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const addVpnGatewayConnectionLocalCidrPromise = vpcService.addVpnGatewayConnectionLocalCidr();
-        expectToBePromise(addVpnGatewayConnectionLocalCidrPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.addVpnGatewayConnectionLocalCidr();
+        } catch (e) {
+          err = e;
+        }
 
-        addVpnGatewayConnectionLocalCidrPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20514,7 +20517,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listVpnGatewayConnectionPeerCidrs({});
@@ -20523,17 +20526,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listVpnGatewayConnectionPeerCidrsPromise = vpcService.listVpnGatewayConnectionPeerCidrs();
-        expectToBePromise(listVpnGatewayConnectionPeerCidrsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listVpnGatewayConnectionPeerCidrs();
+        } catch (e) {
+          err = e;
+        }
 
-        listVpnGatewayConnectionPeerCidrsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20620,7 +20623,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.removeVpnGatewayConnectionPeerCidr({});
@@ -20629,17 +20632,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const removeVpnGatewayConnectionPeerCidrPromise = vpcService.removeVpnGatewayConnectionPeerCidr();
-        expectToBePromise(removeVpnGatewayConnectionPeerCidrPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.removeVpnGatewayConnectionPeerCidr();
+        } catch (e) {
+          err = e;
+        }
 
-        removeVpnGatewayConnectionPeerCidrPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20726,7 +20729,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.checkVpnGatewayConnectionPeerCidr({});
@@ -20735,17 +20738,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const checkVpnGatewayConnectionPeerCidrPromise = vpcService.checkVpnGatewayConnectionPeerCidr();
-        expectToBePromise(checkVpnGatewayConnectionPeerCidrPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.checkVpnGatewayConnectionPeerCidr();
+        } catch (e) {
+          err = e;
+        }
 
-        checkVpnGatewayConnectionPeerCidrPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20832,7 +20835,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.addVpnGatewayConnectionPeerCidr({});
@@ -20841,17 +20844,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const addVpnGatewayConnectionPeerCidrPromise = vpcService.addVpnGatewayConnectionPeerCidr();
-        expectToBePromise(addVpnGatewayConnectionPeerCidrPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.addVpnGatewayConnectionPeerCidr();
+        } catch (e) {
+          err = e;
+        }
 
-        addVpnGatewayConnectionPeerCidrPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -20985,7 +20988,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerProfile({});
@@ -20994,17 +20997,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerProfilePromise = vpcService.getLoadBalancerProfile();
-        expectToBePromise(getLoadBalancerProfilePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerProfile();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerProfilePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21096,6 +21099,8 @@ describe('VpcV1', () => {
         connection_limit: 2000,
         default_pool: loadBalancerPoolIdentityByNameModel,
         port: 443,
+        port_max: 499,
+        port_min: 443,
         protocol: 'http',
       };
 
@@ -21134,7 +21139,7 @@ describe('VpcV1', () => {
       // LoadBalancerPoolSessionPersistencePrototype
       const loadBalancerPoolSessionPersistencePrototypeModel = {
         cookie_name: 'my-cookie-name',
-        type: 'source_ip',
+        type: 'app_cookie',
       };
 
       // LoadBalancerPoolPrototype
@@ -21173,6 +21178,7 @@ describe('VpcV1', () => {
         const pools = [loadBalancerPoolPrototypeModel];
         const profile = loadBalancerProfileIdentityModel;
         const resourceGroup = resourceGroupIdentityModel;
+        const routeMode = true;
         const securityGroups = [securityGroupIdentityModel];
         const params = {
           isPublic: isPublic,
@@ -21183,6 +21189,7 @@ describe('VpcV1', () => {
           pools: pools,
           profile: profile,
           resourceGroup: resourceGroup,
+          routeMode: routeMode,
           securityGroups: securityGroups,
         };
 
@@ -21208,6 +21215,7 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.body.pools).toEqual(pools);
         expect(mockRequestOptions.body.profile).toEqual(profile);
         expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.route_mode).toEqual(routeMode);
         expect(mockRequestOptions.body.security_groups).toEqual(securityGroups);
         expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
         expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
@@ -21249,7 +21257,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createLoadBalancer({});
@@ -21258,17 +21266,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createLoadBalancerPromise = vpcService.createLoadBalancer();
-        expectToBePromise(createLoadBalancerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createLoadBalancer();
+        } catch (e) {
+          err = e;
+        }
 
-        createLoadBalancerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21334,7 +21342,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteLoadBalancer({});
@@ -21343,17 +21351,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteLoadBalancerPromise = vpcService.deleteLoadBalancer();
-        expectToBePromise(deleteLoadBalancerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteLoadBalancer();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteLoadBalancerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21419,7 +21427,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancer({});
@@ -21428,17 +21436,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerPromise = vpcService.getLoadBalancer();
-        expectToBePromise(getLoadBalancerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancer();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21522,7 +21530,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateLoadBalancer({});
@@ -21531,17 +21539,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateLoadBalancerPromise = vpcService.updateLoadBalancer();
-        expectToBePromise(updateLoadBalancerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateLoadBalancer();
+        } catch (e) {
+          err = e;
+        }
 
-        updateLoadBalancerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21607,7 +21615,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerStatistics({});
@@ -21616,17 +21624,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerStatisticsPromise = vpcService.getLoadBalancerStatistics();
-        expectToBePromise(getLoadBalancerStatisticsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerStatistics();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerStatisticsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21696,7 +21704,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listLoadBalancerListeners({});
@@ -21705,17 +21713,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listLoadBalancerListenersPromise = vpcService.listLoadBalancerListeners();
-        expectToBePromise(listLoadBalancerListenersPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listLoadBalancerListeners();
+        } catch (e) {
+          err = e;
+        }
 
-        listLoadBalancerListenersPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21750,7 +21758,7 @@ describe('VpcV1', () => {
       const loadBalancerListenerPolicyRulePrototypeModel = {
         condition: 'contains',
         field: 'MY-APP-HEADER',
-        type: 'header',
+        type: 'body',
         value: 'testString',
       };
 
@@ -21771,7 +21779,6 @@ describe('VpcV1', () => {
       function __createLoadBalancerListenerTest() {
         // Construct the params object for operation createLoadBalancerListener
         const loadBalancerId = 'testString';
-        const port = 443;
         const protocol = 'http';
         const acceptProxyProtocol = true;
         const certificateInstance = certificateInstanceIdentityModel;
@@ -21779,9 +21786,11 @@ describe('VpcV1', () => {
         const defaultPool = loadBalancerPoolIdentityModel;
         const httpsRedirect = loadBalancerListenerHttpsRedirectPrototypeModel;
         const policies = [loadBalancerListenerPolicyPrototypeModel];
+        const port = 443;
+        const portMax = 499;
+        const portMin = 443;
         const params = {
           loadBalancerId: loadBalancerId,
-          port: port,
           protocol: protocol,
           acceptProxyProtocol: acceptProxyProtocol,
           certificateInstance: certificateInstance,
@@ -21789,6 +21798,9 @@ describe('VpcV1', () => {
           defaultPool: defaultPool,
           httpsRedirect: httpsRedirect,
           policies: policies,
+          port: port,
+          portMax: portMax,
+          portMin: portMin,
         };
 
         const createLoadBalancerListenerResult = vpcService.createLoadBalancerListener(params);
@@ -21809,7 +21821,6 @@ describe('VpcV1', () => {
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.body.port).toEqual(port);
         expect(mockRequestOptions.body.protocol).toEqual(protocol);
         expect(mockRequestOptions.body.accept_proxy_protocol).toEqual(acceptProxyProtocol);
         expect(mockRequestOptions.body.certificate_instance).toEqual(certificateInstance);
@@ -21817,6 +21828,9 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.body.default_pool).toEqual(defaultPool);
         expect(mockRequestOptions.body.https_redirect).toEqual(httpsRedirect);
         expect(mockRequestOptions.body.policies).toEqual(policies);
+        expect(mockRequestOptions.body.port).toEqual(port);
+        expect(mockRequestOptions.body.port_max).toEqual(portMax);
+        expect(mockRequestOptions.body.port_min).toEqual(portMin);
         expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
         expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
         expect(mockRequestOptions.path.load_balancer_id).toEqual(loadBalancerId);
@@ -21840,13 +21854,11 @@ describe('VpcV1', () => {
       test('should prioritize user-given headers', () => {
         // parameters
         const loadBalancerId = 'testString';
-        const port = 443;
         const protocol = 'http';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
         const params = {
           loadBalancerId,
-          port,
           protocol,
           headers: {
             Accept: userAccept,
@@ -21860,7 +21872,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createLoadBalancerListener({});
@@ -21869,17 +21881,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createLoadBalancerListenerPromise = vpcService.createLoadBalancerListener();
-        expectToBePromise(createLoadBalancerListenerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createLoadBalancerListener();
+        } catch (e) {
+          err = e;
+        }
 
-        createLoadBalancerListenerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -21954,7 +21966,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteLoadBalancerListener({});
@@ -21963,17 +21975,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteLoadBalancerListenerPromise = vpcService.deleteLoadBalancerListener();
-        expectToBePromise(deleteLoadBalancerListenerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteLoadBalancerListener();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteLoadBalancerListenerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22048,7 +22060,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerListener({});
@@ -22057,17 +22069,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerListenerPromise = vpcService.getLoadBalancerListener();
-        expectToBePromise(getLoadBalancerListenerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerListener();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerListenerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22108,6 +22120,8 @@ describe('VpcV1', () => {
         const defaultPool = loadBalancerPoolIdentityModel;
         const httpsRedirect = loadBalancerListenerHttpsRedirectPatchModel;
         const port = 443;
+        const portMax = 499;
+        const portMin = 443;
         const protocol = 'http';
         const params = {
           loadBalancerId: loadBalancerId,
@@ -22118,6 +22132,8 @@ describe('VpcV1', () => {
           defaultPool: defaultPool,
           httpsRedirect: httpsRedirect,
           port: port,
+          portMax: portMax,
+          portMin: portMin,
           protocol: protocol,
         };
 
@@ -22145,6 +22161,8 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.body.default_pool).toEqual(defaultPool);
         expect(mockRequestOptions.body.https_redirect).toEqual(httpsRedirect);
         expect(mockRequestOptions.body.port).toEqual(port);
+        expect(mockRequestOptions.body.port_max).toEqual(portMax);
+        expect(mockRequestOptions.body.port_min).toEqual(portMin);
         expect(mockRequestOptions.body.protocol).toEqual(protocol);
         expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
         expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
@@ -22188,7 +22206,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateLoadBalancerListener({});
@@ -22197,17 +22215,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateLoadBalancerListenerPromise = vpcService.updateLoadBalancerListener();
-        expectToBePromise(updateLoadBalancerListenerPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateLoadBalancerListener();
+        } catch (e) {
+          err = e;
+        }
 
-        updateLoadBalancerListenerPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22284,7 +22302,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listLoadBalancerListenerPolicies({});
@@ -22293,17 +22311,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listLoadBalancerListenerPoliciesPromise = vpcService.listLoadBalancerListenerPolicies();
-        expectToBePromise(listLoadBalancerListenerPoliciesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listLoadBalancerListenerPolicies();
+        } catch (e) {
+          err = e;
+        }
 
-        listLoadBalancerListenerPoliciesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22315,7 +22333,7 @@ describe('VpcV1', () => {
       const loadBalancerListenerPolicyRulePrototypeModel = {
         condition: 'contains',
         field: 'MY-APP-HEADER',
-        type: 'header',
+        type: 'body',
         value: 'testString',
       };
 
@@ -22414,7 +22432,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createLoadBalancerListenerPolicy({});
@@ -22423,17 +22441,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createLoadBalancerListenerPolicyPromise = vpcService.createLoadBalancerListenerPolicy();
-        expectToBePromise(createLoadBalancerListenerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createLoadBalancerListenerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        createLoadBalancerListenerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22515,7 +22533,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteLoadBalancerListenerPolicy({});
@@ -22524,17 +22542,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteLoadBalancerListenerPolicyPromise = vpcService.deleteLoadBalancerListenerPolicy();
-        expectToBePromise(deleteLoadBalancerListenerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteLoadBalancerListenerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteLoadBalancerListenerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22616,7 +22634,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerListenerPolicy({});
@@ -22625,17 +22643,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerListenerPolicyPromise = vpcService.getLoadBalancerListenerPolicy();
-        expectToBePromise(getLoadBalancerListenerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerListenerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerListenerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22733,7 +22751,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateLoadBalancerListenerPolicy({});
@@ -22742,17 +22760,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateLoadBalancerListenerPolicyPromise = vpcService.updateLoadBalancerListenerPolicy();
-        expectToBePromise(updateLoadBalancerListenerPolicyPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateLoadBalancerListenerPolicy();
+        } catch (e) {
+          err = e;
+        }
 
-        updateLoadBalancerListenerPolicyPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22834,7 +22852,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listLoadBalancerListenerPolicyRules({});
@@ -22843,17 +22861,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listLoadBalancerListenerPolicyRulesPromise = vpcService.listLoadBalancerListenerPolicyRules();
-        expectToBePromise(listLoadBalancerListenerPolicyRulesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listLoadBalancerListenerPolicyRules();
+        } catch (e) {
+          err = e;
+        }
 
-        listLoadBalancerListenerPolicyRulesPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -22865,7 +22883,7 @@ describe('VpcV1', () => {
         const listenerId = 'testString';
         const policyId = 'testString';
         const condition = 'contains';
-        const type = 'header';
+        const type = 'body';
         const value = 'testString';
         const field = 'MY-APP-HEADER';
         const params = {
@@ -22930,7 +22948,7 @@ describe('VpcV1', () => {
         const listenerId = 'testString';
         const policyId = 'testString';
         const condition = 'contains';
-        const type = 'header';
+        const type = 'body';
         const value = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
@@ -22953,7 +22971,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createLoadBalancerListenerPolicyRule({});
@@ -22962,17 +22980,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createLoadBalancerListenerPolicyRulePromise = vpcService.createLoadBalancerListenerPolicyRule();
-        expectToBePromise(createLoadBalancerListenerPolicyRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createLoadBalancerListenerPolicyRule();
+        } catch (e) {
+          err = e;
+        }
 
-        createLoadBalancerListenerPolicyRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23059,7 +23077,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteLoadBalancerListenerPolicyRule({});
@@ -23068,17 +23086,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteLoadBalancerListenerPolicyRulePromise = vpcService.deleteLoadBalancerListenerPolicyRule();
-        expectToBePromise(deleteLoadBalancerListenerPolicyRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteLoadBalancerListenerPolicyRule();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteLoadBalancerListenerPolicyRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23165,7 +23183,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerListenerPolicyRule({});
@@ -23174,17 +23192,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerListenerPolicyRulePromise = vpcService.getLoadBalancerListenerPolicyRule();
-        expectToBePromise(getLoadBalancerListenerPolicyRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerListenerPolicyRule();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerListenerPolicyRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23198,7 +23216,7 @@ describe('VpcV1', () => {
         const id = 'testString';
         const condition = 'contains';
         const field = 'MY-APP-HEADER';
-        const type = 'header';
+        const type = 'body';
         const value = 'testString';
         const params = {
           loadBalancerId: loadBalancerId,
@@ -23283,7 +23301,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateLoadBalancerListenerPolicyRule({});
@@ -23292,17 +23310,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateLoadBalancerListenerPolicyRulePromise = vpcService.updateLoadBalancerListenerPolicyRule();
-        expectToBePromise(updateLoadBalancerListenerPolicyRulePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateLoadBalancerListenerPolicyRule();
+        } catch (e) {
+          err = e;
+        }
 
-        updateLoadBalancerListenerPolicyRulePromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23368,7 +23386,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listLoadBalancerPools({});
@@ -23377,17 +23395,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listLoadBalancerPoolsPromise = vpcService.listLoadBalancerPools();
-        expectToBePromise(listLoadBalancerPoolsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listLoadBalancerPools();
+        } catch (e) {
+          err = e;
+        }
 
-        listLoadBalancerPoolsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23420,7 +23438,7 @@ describe('VpcV1', () => {
       // LoadBalancerPoolSessionPersistencePrototype
       const loadBalancerPoolSessionPersistencePrototypeModel = {
         cookie_name: 'my-cookie-name',
-        type: 'source_ip',
+        type: 'app_cookie',
       };
 
       function __createLoadBalancerPoolTest() {
@@ -23510,7 +23528,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createLoadBalancerPool({});
@@ -23519,17 +23537,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createLoadBalancerPoolPromise = vpcService.createLoadBalancerPool();
-        expectToBePromise(createLoadBalancerPoolPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createLoadBalancerPool();
+        } catch (e) {
+          err = e;
+        }
 
-        createLoadBalancerPoolPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23604,7 +23622,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteLoadBalancerPool({});
@@ -23613,17 +23631,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteLoadBalancerPoolPromise = vpcService.deleteLoadBalancerPool();
-        expectToBePromise(deleteLoadBalancerPoolPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteLoadBalancerPool();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteLoadBalancerPoolPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23698,7 +23716,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerPool({});
@@ -23707,17 +23725,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerPoolPromise = vpcService.getLoadBalancerPool();
-        expectToBePromise(getLoadBalancerPoolPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerPool();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerPoolPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23738,7 +23756,7 @@ describe('VpcV1', () => {
       // LoadBalancerPoolSessionPersistencePatch
       const loadBalancerPoolSessionPersistencePatchModel = {
         cookie_name: 'my-cookie-name',
-        type: 'source_ip',
+        type: 'app_cookie',
       };
 
       function __updateLoadBalancerPoolTest() {
@@ -23828,7 +23846,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateLoadBalancerPool({});
@@ -23837,17 +23855,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateLoadBalancerPoolPromise = vpcService.updateLoadBalancerPool();
-        expectToBePromise(updateLoadBalancerPoolPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateLoadBalancerPool();
+        } catch (e) {
+          err = e;
+        }
 
-        updateLoadBalancerPoolPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -23922,7 +23940,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listLoadBalancerPoolMembers({});
@@ -23931,17 +23949,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listLoadBalancerPoolMembersPromise = vpcService.listLoadBalancerPoolMembers();
-        expectToBePromise(listLoadBalancerPoolMembersPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listLoadBalancerPoolMembers();
+        } catch (e) {
+          err = e;
+        }
 
-        listLoadBalancerPoolMembersPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24036,7 +24054,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createLoadBalancerPoolMember({});
@@ -24045,17 +24063,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createLoadBalancerPoolMemberPromise = vpcService.createLoadBalancerPoolMember();
-        expectToBePromise(createLoadBalancerPoolMemberPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createLoadBalancerPoolMember();
+        } catch (e) {
+          err = e;
+        }
 
-        createLoadBalancerPoolMemberPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24151,7 +24169,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.replaceLoadBalancerPoolMembers({});
@@ -24160,17 +24178,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const replaceLoadBalancerPoolMembersPromise = vpcService.replaceLoadBalancerPoolMembers();
-        expectToBePromise(replaceLoadBalancerPoolMembersPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.replaceLoadBalancerPoolMembers();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceLoadBalancerPoolMembersPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24250,7 +24268,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteLoadBalancerPoolMember({});
@@ -24259,17 +24277,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteLoadBalancerPoolMemberPromise = vpcService.deleteLoadBalancerPoolMember();
-        expectToBePromise(deleteLoadBalancerPoolMemberPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteLoadBalancerPoolMember();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteLoadBalancerPoolMemberPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24349,7 +24367,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getLoadBalancerPoolMember({});
@@ -24358,17 +24376,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getLoadBalancerPoolMemberPromise = vpcService.getLoadBalancerPoolMember();
-        expectToBePromise(getLoadBalancerPoolMemberPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getLoadBalancerPoolMember();
+        } catch (e) {
+          err = e;
+        }
 
-        getLoadBalancerPoolMemberPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24464,7 +24482,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateLoadBalancerPoolMember({});
@@ -24473,17 +24491,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateLoadBalancerPoolMemberPromise = vpcService.updateLoadBalancerPoolMember();
-        expectToBePromise(updateLoadBalancerPoolMemberPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateLoadBalancerPoolMember();
+        } catch (e) {
+          err = e;
+        }
 
-        updateLoadBalancerPoolMemberPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24661,7 +24679,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createEndpointGateway({});
@@ -24670,17 +24688,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createEndpointGatewayPromise = vpcService.createEndpointGateway();
-        expectToBePromise(createEndpointGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createEndpointGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        createEndpointGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24759,7 +24777,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.listEndpointGatewayIps({});
@@ -24768,17 +24786,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const listEndpointGatewayIpsPromise = vpcService.listEndpointGatewayIps();
-        expectToBePromise(listEndpointGatewayIpsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listEndpointGatewayIps();
+        } catch (e) {
+          err = e;
+        }
 
-        listEndpointGatewayIpsPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24853,7 +24871,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.removeEndpointGatewayIp({});
@@ -24862,17 +24880,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const removeEndpointGatewayIpPromise = vpcService.removeEndpointGatewayIp();
-        expectToBePromise(removeEndpointGatewayIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.removeEndpointGatewayIp();
+        } catch (e) {
+          err = e;
+        }
 
-        removeEndpointGatewayIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -24947,7 +24965,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getEndpointGatewayIp({});
@@ -24956,17 +24974,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getEndpointGatewayIpPromise = vpcService.getEndpointGatewayIp();
-        expectToBePromise(getEndpointGatewayIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getEndpointGatewayIp();
+        } catch (e) {
+          err = e;
+        }
 
-        getEndpointGatewayIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25041,7 +25059,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.addEndpointGatewayIp({});
@@ -25050,17 +25068,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const addEndpointGatewayIpPromise = vpcService.addEndpointGatewayIp();
-        expectToBePromise(addEndpointGatewayIpPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.addEndpointGatewayIp();
+        } catch (e) {
+          err = e;
+        }
 
-        addEndpointGatewayIpPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25126,7 +25144,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteEndpointGateway({});
@@ -25135,17 +25153,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteEndpointGatewayPromise = vpcService.deleteEndpointGateway();
-        expectToBePromise(deleteEndpointGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteEndpointGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteEndpointGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25211,7 +25229,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getEndpointGateway({});
@@ -25220,17 +25238,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getEndpointGatewayPromise = vpcService.getEndpointGateway();
-        expectToBePromise(getEndpointGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getEndpointGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        getEndpointGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25299,7 +25317,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateEndpointGateway({});
@@ -25308,17 +25326,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateEndpointGatewayPromise = vpcService.updateEndpointGateway();
-        expectToBePromise(updateEndpointGatewayPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateEndpointGateway();
+        } catch (e) {
+          err = e;
+        }
 
-        updateEndpointGatewayPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25334,7 +25352,7 @@ describe('VpcV1', () => {
         const vpcCrn = 'testString';
         const vpcName = 'testString';
         const targetId = 'testString';
-        const targetResourceType = 'vpc';
+        const targetResourceType = 'instance';
         const params = {
           start: start,
           limit: limit,
@@ -25504,7 +25522,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.createFlowLogCollector({});
@@ -25513,17 +25531,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const createFlowLogCollectorPromise = vpcService.createFlowLogCollector();
-        expectToBePromise(createFlowLogCollectorPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createFlowLogCollector();
+        } catch (e) {
+          err = e;
+        }
 
-        createFlowLogCollectorPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25589,7 +25607,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.deleteFlowLogCollector({});
@@ -25598,17 +25616,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const deleteFlowLogCollectorPromise = vpcService.deleteFlowLogCollector();
-        expectToBePromise(deleteFlowLogCollectorPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteFlowLogCollector();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteFlowLogCollectorPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25674,7 +25692,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.getFlowLogCollector({});
@@ -25683,17 +25701,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const getFlowLogCollectorPromise = vpcService.getFlowLogCollector();
-        expectToBePromise(getFlowLogCollectorPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getFlowLogCollector();
+        } catch (e) {
+          err = e;
+        }
 
-        getFlowLogCollectorPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
@@ -25765,7 +25783,7 @@ describe('VpcV1', () => {
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async done => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await vpcService.updateFlowLogCollector({});
@@ -25774,17 +25792,17 @@ describe('VpcV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', done => {
-        const updateFlowLogCollectorPromise = vpcService.updateFlowLogCollector();
-        expectToBePromise(updateFlowLogCollectorPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateFlowLogCollector();
+        } catch (e) {
+          err = e;
+        }
 
-        updateFlowLogCollectorPromise.catch(err => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });

--- a/vpc/v1.ts
+++ b/vpc/v1.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2021.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.39.0-748eb4ca-20210917-165907
+ * IBM OpenAPI SDK Code Generator Version: 3.43.0-49eab5c7-20211117-152138
  */
 
 import * as extend from 'extend';
@@ -30,10 +30,10 @@ import {
 import { getSdkHeaders } from '../lib/common';
 
 /**
- * The IBM Cloud Virtual Private Cloud (VPC) API can be used to programmatically provision and manage infrastructure
- * resources, including virtual server instances, subnets, volumes, and load balancers.
+ * The IBM Cloud Virtual Private Cloud (VPC) API can be used to programmatically provision and manage virtual server
+ * instances, along with subnets, volumes, load balancers, and more.
  *
- * API Version: 2021-09-21
+ * API Version: 2021-11-23
  */
 
 class VpcV1 extends BaseService {
@@ -72,8 +72,8 @@ class VpcV1 extends BaseService {
     return service;
   }
 
-  /** Requests the version of the API as of a date in the format `YYYY-MM-DD`. Any date up to the current date may
-   *  be provided. Specify the current date to request the latest version.
+  /** Requests the API version as of a date, in format `YYYY-MM-DD`. Any date between `2019-01-01` and the current
+   *  date may be specified. Specify the current date to request the latest version.
    */
   version: string;
 
@@ -84,8 +84,8 @@ class VpcV1 extends BaseService {
    * Construct a VpcV1 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} options.version - Requests the version of the API as of a date in the format `YYYY-MM-DD`. Any date
-   * up to the current date may be provided. Specify the current date to request the latest version.
+   * @param {string} options.version - Requests the API version as of a date, in format `YYYY-MM-DD`. Any date between
+   * `2019-01-01` and the current date may be specified. Specify the current date to request the latest version.
    * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {Authenticator} options.authenticator - The Authenticator object used to authenticate requests to the service
@@ -102,7 +102,7 @@ class VpcV1 extends BaseService {
     } else {
       this.setServiceUrl(VpcV1.DEFAULT_SERVICE_URL);
     }
-    this.version = options.version || '2021-09-21';
+    this.version = options.version || '2021-11-23';
     this.generation = options.generation;
   }
 
@@ -120,8 +120,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {boolean} [params.classicAccess] - Filters the collection to VPCs with the specified `classic_access` value.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.VPCCollection>>}
@@ -177,6 +177,9 @@ class VpcV1 extends BaseService {
    * @param {string} [params.addressPrefixManagement] - Indicates whether a default address prefix should be
    * automatically created for each zone in this VPC. If `manual`, this VPC will be created with no default address
    * prefixes.
+   *
+   * This property's value is used only when creating the VPC. Since address prefixes are managed identically regardless
+   * of whether they were automatically created, the value is not preserved as a VPC property.
    * @param {boolean} [params.classicAccess] - Indicates whether this VPC should be connected to Classic Infrastructure.
    * If true, this VPC's resources will have private network connectivity to the account's Classic Infrastructure
    * resources. Only one VPC, per region, may be connected in this way. This value is set at creation and subsequently
@@ -540,8 +543,9 @@ class VpcV1 extends BaseService {
   /**
    * Retrieve a VPC's default security group.
    *
-   * This request retrieves the default security group for the VPC specified by the identifier in the URL. The default
-   * security group is applied to any new network interfaces in the VPC that do not specify a security group.
+   * This request retrieves the default security group for the VPC specified by the identifier in the URL. Resources
+   * that optionally allow a security group to be specified upon creation will be attached to this security group if a
+   * security group is not specified.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The VPC identifier.
@@ -676,9 +680,8 @@ class VpcV1 extends BaseService {
    *
    * The prefix length of the address prefix's CIDR must be between `/9` (8,388,608 addresses) and `/29` (8 addresses).
    * @param {ZoneIdentity} params.zone - The zone this address prefix will reside in.
-   * @param {boolean} [params.isDefault] - Indicates whether this is the default prefix for this zone in this VPC. If
-   * true, this prefix will become the default prefix for this zone in this VPC. This fails if the VPC currently has a
-   * default address prefix for this zone.
+   * @param {boolean} [params.isDefault] - Indicates whether this will be the default address prefix for this zone in
+   * this VPC. If `true`, the VPC must not have a default address prefix for this zone.
    * @param {string} [params.name] - The user-defined name for this address prefix. Names must be unique within the VPC
    * the address prefix resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -1279,7 +1282,7 @@ class VpcV1 extends BaseService {
    *
    * This request lists all user-defined routing tables for a VPC.  Each subnet in a VPC is associated with a routing
    * table, which controls delivery of packets sent on that subnet according to the action of the most specific matching
-   * route in the table.  If multiple equally-specific routes exist, traffic will be distributed across them.  If no
+   * route in the table.  If multiple equally-specific routes exist, traffic will be distributed across them. If no
    * routes match, delivery will be controlled by the system's built-in routes.
    *
    * @param {Object} params - The parameters to send to the service.
@@ -2030,8 +2033,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.routingTableId] - Filters the collection to subnets attached to the routing table with the
    * specified identifier.
    * @param {string} [params.routingTableName] - Filters the collection to subnets attached to the routing table with
@@ -2831,10 +2834,10 @@ class VpcV1 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.subnetId - The subnet identifier.
-   * @param {boolean} [params.autoDelete] - If set to `true`, this reserved IP will be automatically deleted when the
-   * target is deleted or when the reserved IP is unbound. The value cannot be set to `true` if the reserved IP is
-   * unbound.
-   * @param {string} [params.name] - The user-defined name for this reserved IP. If not specified, the name will be a
+   * @param {boolean} [params.autoDelete] - Indicates whether this reserved IP member will be automatically deleted when
+   * either
+   * `target` is deleted, or the reserved IP is unbound. Must be `false` if the reserved IP is unbound.
+   * @param {string} [params.name] - The user-defined name for this reserved IP. If unspecified, the name will be a
    * hyphenated list of randomly-selected words. Names must be unique within the subnet the reserved IP resides in.
    * Names beginning with `ibm-` are reserved for provider-owned resources.
    * @param {ReservedIPTargetPrototype} [params.target] - The target this reserved IP is to be bound to.
@@ -3025,9 +3028,9 @@ class VpcV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.subnetId - The subnet identifier.
    * @param {string} params.id - The reserved IP identifier.
-   * @param {boolean} [params.autoDelete] - If set to `true`, this reserved IP will be automatically deleted when the
-   * target is deleted or when the reserved IP is unbound. The value cannot be set to `true` if the reserved IP is
-   * unbound.
+   * @param {boolean} [params.autoDelete] - Indicates whether this reserved IP member will be automatically deleted when
+   * either
+   * `target` is deleted, or the reserved IP is unbound. Must be `false` if the reserved IP is unbound.
    * @param {string} [params.name] - The user-defined name for this reserved IP. Names must be unique within the subnet
    * the reserved IP resides in. Names beginning with `ibm-` are reserved for provider-owned resources.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -3104,8 +3107,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {string} [params.visibility] - Filters the collection to images with the specified `visibility`.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -3517,8 +3520,6 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.KeyCollection>>}
    */
@@ -3532,7 +3533,6 @@ class VpcV1 extends BaseService {
       'generation': this.generation,
       'start': _params.start,
       'limit': _params.limit,
-      'resource_group.id': _params.resourceGroupId,
     };
 
     const sdkHeaders = getSdkHeaders(
@@ -4218,8 +4218,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {string} [params.vpcId] - Filters the collection to resources in the VPC with the specified identifier.
    * @param {string} [params.vpcCrn] - Filters the collection to resources in the VPC with the specified CRN.
@@ -5006,8 +5006,9 @@ class VpcV1 extends BaseService {
    * @param {SubnetIdentity} params.subnet - The associated subnet.
    * @param {boolean} [params.allowIpSpoofing] - Indicates whether source IP spoofing is allowed on this interface. If
    * false, source IP spoofing is prevented on this interface. If true, source IP spoofing is allowed on this interface.
-   * @param {string} [params.name] - The user-defined name for this network interface. If unspecified, the name will be
-   * a hyphenated list of randomly-selected words.
+   * @param {string} [params.name] - The user-defined name for network interface. Names must be unique within the
+   * instance the network interface resides in. If unspecified, the name will be a hyphenated list of randomly-selected
+   * words.
    * @param {string} [params.primaryIpv4Address] - The primary IPv4 address. If specified, it must be an available
    * address on the network interface's subnet. If unspecified, an available address on the subnet will be automatically
    * selected.
@@ -5206,7 +5207,8 @@ class VpcV1 extends BaseService {
    * @param {string} params.id - The network interface identifier.
    * @param {boolean} [params.allowIpSpoofing] - Indicates whether source IP spoofing is allowed on this interface. If
    * false, source IP spoofing is prevented on this interface. If true, source IP spoofing is allowed on this interface.
-   * @param {string} [params.name] - The user-defined name for this network interface.
+   * @param {string} [params.name] - The user-defined name for network interface. Names must be unique within the
+   * instance the network interface resides in.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.NetworkInterface>>}
    */
@@ -5587,8 +5589,9 @@ class VpcV1 extends BaseService {
    * prototype object for a new volume.
    * @param {boolean} [params.deleteVolumeOnInstanceDelete] - If set to true, when deleting the instance the volume will
    * also be deleted.
-   * @param {string} [params.name] - The user-defined name for this volume attachment. If unspecified, the name will be
-   * a hyphenated list of randomly-selected words.
+   * @param {string} [params.name] - The user-defined name for this volume attachment. Names must be unique within the
+   * instance the volume attachment resides in. If unspecified, the name will be a hyphenated list of randomly-selected
+   * words.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.VolumeAttachment>>}
    */
@@ -5779,7 +5782,8 @@ class VpcV1 extends BaseService {
    * @param {string} params.id - The volume attachment identifier.
    * @param {boolean} [params.deleteVolumeOnInstanceDelete] - If set to true, when deleting the instance the volume will
    * also be deleted.
-   * @param {string} [params.name] - The user-defined name for this volume attachment.
+   * @param {string} [params.name] - The user-defined name for this volume attachment. Names must be unique within the
+   * instance the volume attachment resides in.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.VolumeAttachment>>}
    */
@@ -6487,7 +6491,7 @@ class VpcV1 extends BaseService {
    * @param {number} [params.aggregationWindow] - The time window in seconds to aggregate metrics prior to evaluation.
    * @param {number} [params.cooldown] - The duration of time in seconds to pause further scale actions after scaling
    * has taken place.
-   * @param {boolean} [params.managementEnabled] - If set to `true`, this manager will control the instance group.
+   * @param {boolean} [params.managementEnabled] - Indicates whether this manager will control the instance group.
    * @param {number} [params.maxMembershipCount] - The maximum number of members in a managed instance group.
    * @param {number} [params.minMembershipCount] - The minimum number of members in a managed instance group.
    * @param {string} [params.name] - The user-defined name for this instance group manager. Names must be unique within
@@ -7532,9 +7536,10 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.zoneName] - Filters the collection to resources in the zone with the exact specified name.
+   * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.DedicatedHostGroupCollection>>}
    */
@@ -7550,6 +7555,7 @@ class VpcV1 extends BaseService {
       'limit': _params.limit,
       'resource_group.id': _params.resourceGroupId,
       'zone.name': _params.zoneName,
+      'name': _params.name,
     };
 
     const sdkHeaders = getSdkHeaders(
@@ -7767,8 +7773,7 @@ class VpcV1 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The dedicated host group identifier.
-   * @param {string} [params.name] - The unique user-defined name for this dedicated host group. If unspecified, the
-   * name will be a hyphenated list of randomly-selected words.
+   * @param {string} [params.name] - The unique user-defined name for this dedicated host group.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.DedicatedHostGroup>>}
    */
@@ -7945,9 +7950,10 @@ class VpcV1 extends BaseService {
    * identifier.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.zoneName] - Filters the collection to resources in the zone with the exact specified name.
+   * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.DedicatedHostCollection>>}
    */
@@ -7964,6 +7970,7 @@ class VpcV1 extends BaseService {
       'limit': _params.limit,
       'resource_group.id': _params.resourceGroupId,
       'zone.name': _params.zoneName,
+      'name': _params.name,
     };
 
     const sdkHeaders = getSdkHeaders(
@@ -8362,8 +8369,7 @@ class VpcV1 extends BaseService {
    * @param {string} params.id - The dedicated host identifier.
    * @param {boolean} [params.instancePlacementEnabled] - If set to true, instances can be placed on this dedicated
    * host.
-   * @param {string} [params.name] - The unique user-defined name for this dedicated host. If unspecified, the name will
-   * be a hyphenated list of randomly-selected words.
+   * @param {string} [params.name] - The unique user-defined name for this dedicated host.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.DedicatedHost>>}
    */
@@ -9079,7 +9085,8 @@ class VpcV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The volume identifier.
    * @param {number} [params.capacity] - The capacity to use for the volume (in gigabytes). The volume must be attached
-   * as a data volume to a virtual server instance, and the specified value must not be less than the current capacity.
+   * as a data volume to a running virtual server instance, and the specified value must not be less than the current
+   * capacity.
    *
    * The minimum and maximum capacity limits for creating or updating volumes may expand in the future.
    * @param {number} [params.iops] - The maximum I/O operations per second (IOPS) to use for the volume. Applicable only
@@ -9216,8 +9223,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {string} [params.sourceVolumeId] - Filters the collection to resources with the source volume with the
    * specified identifier.
@@ -9776,8 +9783,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.PublicGatewayCollection>>}
    */
@@ -10091,8 +10098,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.FloatingIPCollection>>}
    */
@@ -10391,8 +10398,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.NetworkACLCollection>>}
    */
@@ -11025,8 +11032,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.vpcId] - Filters the collection to resources in the VPC with the specified identifier.
    * @param {string} [params.vpcCrn] - Filters the collection to resources in the VPC with the specified CRN.
    * @param {string} [params.vpcName] - Filters the collection to resources in the VPC with the exact specified name.
@@ -12306,7 +12313,8 @@ class VpcV1 extends BaseService {
   /**
    * Delete an IKE policy.
    *
-   * This request deletes an IKE policy. This operation cannot be reversed.
+   * This request deletes an IKE policy. This operation cannot be reversed. For this request to succeed, there must not
+   * be any VPN gateway connections using this policy.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The IKE policy identifier.
@@ -12675,7 +12683,8 @@ class VpcV1 extends BaseService {
   /**
    * Delete an IPsec policy.
    *
-   * This request deletes an IPsec policy. This operation cannot be reversed.
+   * This request deletes an IPsec policy. This operation cannot be reversed. For this request to succeed, there must
+   * not be any VPN gateway connections using this policy.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The IPsec policy identifier.
@@ -12926,8 +12935,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.mode] - Filters the collection to VPN gateways with the specified mode.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.VPNGatewayCollection>>}
@@ -13032,8 +13041,9 @@ class VpcV1 extends BaseService {
   /**
    * Delete a VPN gateway.
    *
-   * This request deletes a VPN gateway. A VPN gateway with a `status` of `pending` cannot be deleted. This operation
-   * deletes all VPN gateway connections associated with this VPN gateway.  This operation cannot be reversed.
+   * This request deletes a VPN gateway. This operation cannot be reversed. For this request to succeed, the VPN gateway
+   * must not have a `status` of `pending`, and there must not be any VPC routes using the VPN gateway's connections as
+   * a next hop.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The VPN gateway identifier.
@@ -13336,7 +13346,8 @@ class VpcV1 extends BaseService {
   /**
    * Delete a VPN gateway connection.
    *
-   * This request deletes a VPN gateway connection. This operation cannot be reversed.
+   * This request deletes a VPN gateway connection. This operation cannot be reversed. For this request to succeed,
+   * there must not be VPC routes using this VPN connection as a next hop.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.vpnGatewayId - The VPN gateway identifier.
@@ -14185,6 +14196,8 @@ class VpcV1 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {boolean} params.isPublic - Indicates whether this load balancer is public or private.
+   *
+   * At present, if route mode is enabled, the load balancer must be private.
    * @param {SubnetIdentity[]} params.subnets - The subnets to provision this load balancer.
    * @param {LoadBalancerListenerPrototypeLoadBalancerContext[]} [params.listeners] - The listeners of this load
    * balancer.
@@ -14202,6 +14215,9 @@ class VpcV1 extends BaseService {
    * @param {ResourceGroupIdentity} [params.resourceGroup] - The resource group to use. If unspecified, the account's
    * [default resource
    * group](https://cloud.ibm.com/apidocs/resource-manager#introduction) is used.
+   * @param {boolean} [params.routeMode] - Indicates whether route mode is enabled for this load balancer.
+   *
+   * At present, public load balancers are not supported with route mode enabled.
    * @param {SecurityGroupIdentity[]} [params.securityGroups] - The security groups to use for this load balancer.
    *
    * The load balancer profile must support security groups.
@@ -14228,6 +14244,7 @@ class VpcV1 extends BaseService {
       'pools': _params.pools,
       'profile': _params.profile,
       'resource_group': _params.resourceGroup,
+      'route_mode': _params.routeMode,
       'security_groups': _params.securityGroups,
     };
 
@@ -14572,8 +14589,6 @@ class VpcV1 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.loadBalancerId - The load balancer identifier.
-   * @param {number} params.port - The listener port number. Each listener in the load balancer must have a unique
-   * `port` and `protocol` combination.
    * @param {string} params.protocol - The listener protocol. Each listener in the load balancer must have a unique
    * `port` and `protocol` combination.  Additional restrictions:
    * - If this load balancer is in the `network` family, the protocol must be `tcp`.
@@ -14600,6 +14615,22 @@ class VpcV1 extends BaseService {
    * be redirected to. This listener must have a
    * `protocol` of `http`, and the target listener must have a `protocol` of `https`.
    * @param {LoadBalancerListenerPolicyPrototype[]} [params.policies] - The policy prototype objects for this listener.
+   * @param {number} [params.port] - The listener port number, or the inclusive lower bound of the port range. Each
+   * listener in the load balancer must have a unique `port` and `protocol` combination.
+   *
+   * Not supported for load balancers operating with route mode enabled.
+   * @param {number} [params.portMax] - The inclusive upper bound of the range of ports used by this listener. Must not
+   * be less than `port_min`.
+   *
+   * At present, only load balancers operating with route mode enabled support different values for `port_min` and
+   * `port_max`.  When route mode is enabled, only a value of
+   * `65535` is supported for `port_max`.
+   * @param {number} [params.portMin] - The inclusive lower bound of the range of ports used by this listener. Must not
+   * be greater than `port_max`.
+   *
+   * At present, only load balancers operating with route mode enabled support different values for `port_min` and
+   * `port_max`.  When route mode is enabled, only a value of
+   * `1` is supported for `port_min`.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.LoadBalancerListener>>}
    */
@@ -14607,7 +14638,7 @@ class VpcV1 extends BaseService {
     params: VpcV1.CreateLoadBalancerListenerParams
   ): Promise<VpcV1.Response<VpcV1.LoadBalancerListener>> {
     const _params = { ...params };
-    const requiredParams = ['loadBalancerId', 'port', 'protocol'];
+    const requiredParams = ['loadBalancerId', 'protocol'];
 
     const missingParams = getMissingParams(_params, requiredParams);
     if (missingParams) {
@@ -14615,7 +14646,6 @@ class VpcV1 extends BaseService {
     }
 
     const body = {
-      'port': _params.port,
       'protocol': _params.protocol,
       'accept_proxy_protocol': _params.acceptProxyProtocol,
       'certificate_instance': _params.certificateInstance,
@@ -14623,6 +14653,9 @@ class VpcV1 extends BaseService {
       'default_pool': _params.defaultPool,
       'https_redirect': _params.httpsRedirect,
       'policies': _params.policies,
+      'port': _params.port,
+      'port_max': _params.portMax,
+      'port_min': _params.portMin,
     };
 
     const query = {
@@ -14813,8 +14846,22 @@ class VpcV1 extends BaseService {
    * redirected to. This listener must have a
    * `protocol` of `http`, and the target listener must have a `protocol` of `https`.
    * Specify `null` to remove any existing https redirect.
-   * @param {number} [params.port] - The listener port number. Each listener in the load balancer must have a unique
-   * `port` and `protocol` combination.
+   * @param {number} [params.port] - The listener port number, or the inclusive lower bound of the port range. Each
+   * listener in the load balancer must have a unique `port` and `protocol` combination.
+   *
+   * Not supported for load balancers operating with route mode enabled.
+   * @param {number} [params.portMax] - The inclusive upper bound of the range of ports used by this listener. Must not
+   * be less than `port_min`.
+   *
+   * At present, only load balancers operating with route mode enabled support different values for `port_min` and
+   * `port_max`.  When route mode is enabled, only a value of
+   * `65535` is supported for `port_max`.
+   * @param {number} [params.portMin] - The inclusive lower bound of the range of ports used by this listener. Must not
+   * be greater than `port_max`.
+   *
+   * At present, only load balancers operating with route mode enabled support different values for `port_min` and
+   * `port_max`.  When route mode is enabled, only a value of
+   * `1` is supported for `port_min`.
    * @param {string} [params.protocol] - The listener protocol. Each listener in the load balancer must have a unique
    * `port` and `protocol` combination.  Additional restrictions:
    * - If this load balancer is in the `network` family, the protocol must be `tcp`.
@@ -14841,6 +14888,8 @@ class VpcV1 extends BaseService {
       'default_pool': _params.defaultPool,
       'https_redirect': _params.httpsRedirect,
       'port': _params.port,
+      'port_max': _params.portMax,
+      'port_min': _params.portMin,
       'protocol': _params.protocol,
     };
 
@@ -16359,8 +16408,8 @@ class VpcV1 extends BaseService {
    * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.EndpointGatewayCollection>>}
    */
@@ -16924,8 +16973,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-supplied token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
-   * @param {string} [params.resourceGroupId] - Filters the collection to resources within one of the resource groups
-   * identified in a comma-separated list of resource group identifiers.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources in the resource group with the
+   * specified identifier.
    * @param {string} [params.name] - Filters the collection to resources with the exact specified name.
    * @param {string} [params.vpcId] - Filters the collection to resources in the VPC with the specified identifier.
    * @param {string} [params.vpcCrn] - Filters the collection to resources in the VPC with the specified CRN.
@@ -17065,8 +17114,9 @@ class VpcV1 extends BaseService {
   /**
    * Delete a flow log collector.
    *
-   * This request stops and deletes a flow log collector. Collected flow logs remain available within the flow log
-   * collector's bucket.
+   * This request stops and deletes a flow log collector. This operation cannot be reversed.
+   *
+   * Collected flow logs remain available within the flow log collector's Cloud Object Storage bucket.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.id - The flow log collector identifier.
@@ -17256,8 +17306,8 @@ class VpcV1 extends BaseService {
 namespace VpcV1 {
   /** Options for the `VpcV1` constructor. */
   export interface Options extends UserOptions {
-    /** Requests the version of the API as of a date in the format `YYYY-MM-DD`. Any date up to the current date may
-     *  be provided. Specify the current date to request the latest version.
+    /** Requests the API version as of a date, in format `YYYY-MM-DD`. Any date between `2019-01-01` and the current
+     *  date may be specified. Specify the current date to request the latest version.
      */
     version: string;
     /** The infrastructure generation for the request. For the API behavior documented here, use `2`. */
@@ -17293,9 +17343,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to VPCs with the specified `classic_access` value. */
     classicAccess?: boolean;
@@ -17306,6 +17354,9 @@ namespace VpcV1 {
   export interface CreateVpcParams {
     /** Indicates whether a default address prefix should be automatically created for each zone in this VPC. If
      *  `manual`, this VPC will be created with no default address prefixes.
+     *
+     *  This property's value is used only when creating the VPC. Since address prefixes are managed identically
+     *  regardless of whether they were automatically created, the value is not preserved as a VPC property.
      */
     addressPrefixManagement?: CreateVpcConstants.AddressPrefixManagement | string;
     /** Indicates whether this VPC should be connected to Classic Infrastructure. If true, this VPC's resources will
@@ -17326,7 +17377,7 @@ namespace VpcV1 {
 
   /** Constants for the `createVpc` operation. */
   export namespace CreateVpcConstants {
-    /** Indicates whether a default address prefix should be automatically created for each zone in this VPC. If `manual`, this VPC will be created with no default address prefixes. */
+    /** Indicates whether a default address prefix should be automatically created for each zone in this VPC. If `manual`, this VPC will be created with no default address prefixes. This property's value is used only when creating the VPC. Since address prefixes are managed identically regardless of whether they were automatically created, the value is not preserved as a VPC property. */
     export enum AddressPrefixManagement {
       AUTO = 'auto',
       MANUAL = 'manual',
@@ -17406,9 +17457,8 @@ namespace VpcV1 {
     cidr: string;
     /** The zone this address prefix will reside in. */
     zone: ZoneIdentity;
-    /** Indicates whether this is the default prefix for this zone in this VPC. If true, this prefix will become the
-     *  default prefix for this zone in this VPC. This fails if the VPC currently has a default address prefix for this
-     *  zone.
+    /** Indicates whether this will be the default address prefix for this zone in this VPC. If `true`, the VPC must
+     *  not have a default address prefix for this zone.
      */
     isDefault?: boolean;
     /** The user-defined name for this address prefix. Names must be unique within the VPC the address prefix
@@ -17770,9 +17820,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to subnets attached to the routing table with the specified identifier. */
     routingTableId?: string;
@@ -17896,9 +17944,9 @@ namespace VpcV1 {
   export namespace ListSubnetReservedIpsConstants {
     /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending order. */
     export enum Sort {
+      ADDRESS = 'address',
       CREATED_AT = 'created_at',
       NAME = 'name',
-      ADDRESS = 'address',
     }
   }
 
@@ -17906,11 +17954,11 @@ namespace VpcV1 {
   export interface CreateSubnetReservedIpParams {
     /** The subnet identifier. */
     subnetId: string;
-    /** If set to `true`, this reserved IP will be automatically deleted when the target is deleted or when the
-     *  reserved IP is unbound. The value cannot be set to `true` if the reserved IP is unbound.
+    /** Indicates whether this reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the reserved IP is unbound. Must be `false` if the reserved IP is unbound.
      */
     autoDelete?: boolean;
-    /** The user-defined name for this reserved IP. If not specified, the name will be a hyphenated list of
+    /** The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of
      *  randomly-selected words. Names must be unique within the subnet the reserved IP resides in. Names beginning with
      *  `ibm-` are reserved for provider-owned resources.
      */
@@ -17944,8 +17992,8 @@ namespace VpcV1 {
     subnetId: string;
     /** The reserved IP identifier. */
     id: string;
-    /** If set to `true`, this reserved IP will be automatically deleted when the target is deleted or when the
-     *  reserved IP is unbound. The value cannot be set to `true` if the reserved IP is unbound.
+    /** Indicates whether this reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the reserved IP is unbound. Must be `false` if the reserved IP is unbound.
      */
     autoDelete?: boolean;
     /** The user-defined name for this reserved IP. Names must be unique within the subnet the reserved IP resides
@@ -17961,9 +18009,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources with the exact specified name. */
     name?: string;
@@ -18033,10 +18079,6 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
-    resourceGroupId?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -18144,9 +18186,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources with the exact specified name. */
     name?: string;
@@ -18264,8 +18304,8 @@ namespace VpcV1 {
   export namespace CreateInstanceConsoleAccessTokenConstants {
     /** The instance console type for which this token may be used. */
     export enum ConsoleType {
-      VNC = 'vnc',
       SERIAL = 'serial',
+      VNC = 'vnc',
     }
   }
 
@@ -18313,8 +18353,8 @@ namespace VpcV1 {
      *  on this interface. If true, source IP spoofing is allowed on this interface.
      */
     allowIpSpoofing?: boolean;
-    /** The user-defined name for this network interface. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
+    /** The user-defined name for network interface. Names must be unique within the instance the network interface
+     *  resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
      */
     name?: string;
     /** The primary IPv4 address. If specified, it must be an available address on the network interface's subnet.
@@ -18354,7 +18394,9 @@ namespace VpcV1 {
      *  on this interface. If true, source IP spoofing is allowed on this interface.
      */
     allowIpSpoofing?: boolean;
-    /** The user-defined name for this network interface. */
+    /** The user-defined name for network interface. Names must be unique within the instance the network interface
+     *  resides in.
+     */
     name?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -18416,8 +18458,8 @@ namespace VpcV1 {
     volume: VolumeAttachmentPrototypeVolume;
     /** If set to true, when deleting the instance the volume will also be deleted. */
     deleteVolumeOnInstanceDelete?: boolean;
-    /** The user-defined name for this volume attachment. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
+    /** The user-defined name for this volume attachment. Names must be unique within the instance the volume
+     *  attachment resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
      */
     name?: string;
     headers?: OutgoingHttpHeaders;
@@ -18449,7 +18491,9 @@ namespace VpcV1 {
     id: string;
     /** If set to true, when deleting the instance the volume will also be deleted. */
     deleteVolumeOnInstanceDelete?: boolean;
-    /** The user-defined name for this volume attachment. */
+    /** The user-defined name for this volume attachment. Names must be unique within the instance the volume
+     *  attachment resides in.
+     */
     name?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -18592,7 +18636,7 @@ namespace VpcV1 {
     aggregationWindow?: number;
     /** The duration of time in seconds to pause further scale actions after scaling has taken place. */
     cooldown?: number;
-    /** If set to `true`, this manager will control the instance group. */
+    /** Indicates whether this manager will control the instance group. */
     managementEnabled?: boolean;
     /** The maximum number of members in a managed instance group. */
     maxMembershipCount?: number;
@@ -18801,12 +18845,12 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources in the zone with the exact specified name. */
     zoneName?: string;
+    /** Filters the collection to resources with the exact specified name. */
+    name?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -18833,9 +18877,9 @@ namespace VpcV1 {
   export namespace CreateDedicatedHostGroupConstants {
     /** The dedicated host profile family for hosts in this group. */
     export enum Family {
-      MEMORY = 'memory',
       BALANCED = 'balanced',
       COMPUTE = 'compute',
+      MEMORY = 'memory',
     }
   }
 
@@ -18857,9 +18901,7 @@ namespace VpcV1 {
   export interface UpdateDedicatedHostGroupParams {
     /** The dedicated host group identifier. */
     id: string;
-    /** The unique user-defined name for this dedicated host group. If unspecified, the name will be a hyphenated
-     *  list of randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host group. */
     name?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -18888,12 +18930,12 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources in the zone with the exact specified name. */
     zoneName?: string;
+    /** Filters the collection to resources with the exact specified name. */
+    name?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -18951,9 +18993,7 @@ namespace VpcV1 {
     id: string;
     /** If set to true, instances can be placed on this dedicated host. */
     instancePlacementEnabled?: boolean;
-    /** The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host. */
     name?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -19075,8 +19115,8 @@ namespace VpcV1 {
   export interface UpdateVolumeParams {
     /** The volume identifier. */
     id: string;
-    /** The capacity to use for the volume (in gigabytes). The volume must be attached as a data volume to a virtual
-     *  server instance, and the specified value must not be less than the current capacity.
+    /** The capacity to use for the volume (in gigabytes). The volume must be attached as a data volume to a running
+     *  virtual server instance, and the specified value must not be less than the current capacity.
      *
      *  The minimum and maximum capacity limits for creating or updating volumes may expand in the future.
      */
@@ -19108,9 +19148,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources with the exact specified name. */
     name?: string;
@@ -19220,9 +19258,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -19276,9 +19312,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -19324,9 +19358,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -19463,9 +19495,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources in the VPC with the specified identifier. */
     vpcId?: string;
@@ -19718,9 +19748,9 @@ namespace VpcV1 {
     }
     /** The encryption algorithm. */
     export enum EncryptionAlgorithm {
-      TRIPLE_DES = 'triple_des',
       AES128 = 'aes128',
       AES256 = 'aes256',
+      TRIPLE_DES = 'triple_des',
     }
   }
 
@@ -19768,9 +19798,9 @@ namespace VpcV1 {
     }
     /** The encryption algorithm. */
     export enum EncryptionAlgorithm {
-      TRIPLE_DES = 'triple_des',
       AES128 = 'aes128',
       AES256 = 'aes256',
+      TRIPLE_DES = 'triple_des',
     }
   }
 
@@ -19820,9 +19850,9 @@ namespace VpcV1 {
     }
     /** The encryption algorithm. */
     export enum EncryptionAlgorithm {
-      TRIPLE_DES = 'triple_des',
       AES128 = 'aes128',
       AES256 = 'aes256',
+      TRIPLE_DES = 'triple_des',
     }
     /** Perfect Forward Secrecy. */
     export enum Pfs {
@@ -19876,9 +19906,9 @@ namespace VpcV1 {
     }
     /** The encryption algorithm. */
     export enum EncryptionAlgorithm {
-      TRIPLE_DES = 'triple_des',
       AES128 = 'aes128',
       AES256 = 'aes256',
+      TRIPLE_DES = 'triple_des',
     }
     /** Perfect Forward Secrecy. */
     export enum Pfs {
@@ -19903,9 +19933,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to VPN gateways with the specified mode. */
     mode?: ListVpnGatewaysConstants.Mode | string;
@@ -20121,7 +20149,10 @@ namespace VpcV1 {
 
   /** Parameters for the `createLoadBalancer` operation. */
   export interface CreateLoadBalancerParams {
-    /** Indicates whether this load balancer is public or private. */
+    /** Indicates whether this load balancer is public or private.
+     *
+     *  At present, if route mode is enabled, the load balancer must be private.
+     */
     isPublic: boolean;
     /** The subnets to provision this load balancer. */
     subnets: SubnetIdentity[];
@@ -20147,6 +20178,11 @@ namespace VpcV1 {
      *  group](https://cloud.ibm.com/apidocs/resource-manager#introduction) is used.
      */
     resourceGroup?: ResourceGroupIdentity;
+    /** Indicates whether route mode is enabled for this load balancer.
+     *
+     *  At present, public load balancers are not supported with route mode enabled.
+     */
+    routeMode?: boolean;
     /** The security groups to use for this load balancer.
      *
      *  The load balancer profile must support security groups.
@@ -20201,10 +20237,6 @@ namespace VpcV1 {
   export interface CreateLoadBalancerListenerParams {
     /** The load balancer identifier. */
     loadBalancerId: string;
-    /** The listener port number. Each listener in the load balancer must have a unique
-     *  `port` and `protocol` combination.
-     */
-    port: number;
     /** The listener protocol. Each listener in the load balancer must have a unique `port` and `protocol`
      *  combination.  Additional restrictions:
      *  - If this load balancer is in the `network` family, the protocol must be `tcp`.
@@ -20237,6 +20269,26 @@ namespace VpcV1 {
     httpsRedirect?: LoadBalancerListenerHTTPSRedirectPrototype;
     /** The policy prototype objects for this listener. */
     policies?: LoadBalancerListenerPolicyPrototype[];
+    /** The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer
+     *  must have a unique `port` and `protocol` combination.
+     *
+     *  Not supported for load balancers operating with route mode enabled.
+     */
+    port?: number;
+    /** The inclusive upper bound of the range of ports used by this listener. Must not be less than `port_min`.
+     *
+     *  At present, only load balancers operating with route mode enabled support different values for `port_min` and
+     *  `port_max`.  When route mode is enabled, only a value of
+     *  `65535` is supported for `port_max`.
+     */
+    portMax?: number;
+    /** The inclusive lower bound of the range of ports used by this listener. Must not be greater than `port_max`.
+     *
+     *  At present, only load balancers operating with route mode enabled support different values for `port_min` and
+     *  `port_max`.  When route mode is enabled, only a value of
+     *  `1` is supported for `port_min`.
+     */
+    portMin?: number;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -20298,10 +20350,26 @@ namespace VpcV1 {
      *  Specify `null` to remove any existing https redirect.
      */
     httpsRedirect?: LoadBalancerListenerHTTPSRedirectPatch;
-    /** The listener port number. Each listener in the load balancer must have a unique
-     *  `port` and `protocol` combination.
+    /** The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer
+     *  must have a unique `port` and `protocol` combination.
+     *
+     *  Not supported for load balancers operating with route mode enabled.
      */
     port?: number;
+    /** The inclusive upper bound of the range of ports used by this listener. Must not be less than `port_min`.
+     *
+     *  At present, only load balancers operating with route mode enabled support different values for `port_min` and
+     *  `port_max`.  When route mode is enabled, only a value of
+     *  `65535` is supported for `port_max`.
+     */
+    portMax?: number;
+    /** The inclusive lower bound of the range of ports used by this listener. Must not be greater than `port_max`.
+     *
+     *  At present, only load balancers operating with route mode enabled support different values for `port_min` and
+     *  `port_max`.  When route mode is enabled, only a value of
+     *  `1` is supported for `port_min`.
+     */
+    portMin?: number;
     /** The listener protocol. Each listener in the load balancer must have a unique `port` and `protocol`
      *  combination.  Additional restrictions:
      *  - If this load balancer is in the `network` family, the protocol must be `tcp`.
@@ -20366,9 +20434,9 @@ namespace VpcV1 {
     /** The policy action. The enumerated values for this property are expected to expand in the future. When processing this property, check for and log unknown values. Optionally halt processing and surface the error, or bypass the policy on which the unexpected property value was encountered. */
     export enum Action {
       FORWARD = 'forward',
+      HTTPS_REDIRECT = 'https_redirect',
       REDIRECT = 'redirect',
       REJECT = 'reject',
-      HTTPS_REDIRECT = 'https_redirect',
     }
   }
 
@@ -20471,11 +20539,11 @@ namespace VpcV1 {
     }
     /** The type of the rule. Body rules are applied to form-encoded request bodies using the `UTF-8` character set. */
     export enum Type {
+      BODY = 'body',
       HEADER = 'header',
       HOSTNAME = 'hostname',
       PATH = 'path',
       QUERY = 'query',
-      BODY = 'body',
     }
   }
 
@@ -20550,11 +20618,11 @@ namespace VpcV1 {
     }
     /** The type of the rule. Body rules are applied to form-encoded request bodies using the `UTF-8` character set. */
     export enum Type {
+      BODY = 'body',
       HEADER = 'header',
       HOSTNAME = 'hostname',
       PATH = 'path',
       QUERY = 'query',
-      BODY = 'body',
     }
   }
 
@@ -20610,8 +20678,8 @@ namespace VpcV1 {
     /** The protocol used for this load balancer pool. Load balancers in the `network` family support `tcp`. Load balancers in the `application` family support `tcp`, `http`, and `https`. */
     export enum Protocol {
       HTTP = 'http',
-      TCP = 'tcp',
       HTTPS = 'https',
+      TCP = 'tcp',
     }
     /** The PROXY protocol setting for this pool: - `v1`: Enabled with version 1 (human-readable header format) - `v2`: Enabled with version 2 (binary header format) - `disabled`: Disabled Supported by load balancers in the `application` family (otherwise always `disabled`). */
     export enum ProxyProtocol {
@@ -20682,8 +20750,8 @@ namespace VpcV1 {
     /** The protocol used for this load balancer pool. The enumerated values for this property are expected to expand in the future. When processing this property, check for and log unknown values. Optionally halt processing and surface the error, or bypass the pool on which the unexpected property value was encountered. */
     export enum Protocol {
       HTTP = 'http',
-      TCP = 'tcp',
       HTTPS = 'https',
+      TCP = 'tcp',
     }
     /** The PROXY protocol setting for this pool: - `v1`: Enabled with version 1 (human-readable header format) - `v2`: Enabled with version 2 (binary header format) - `disabled`: Disabled Supported by load balancers in the `application` family (otherwise always `disabled`). */
     export enum ProxyProtocol {
@@ -20779,9 +20847,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     headers?: OutgoingHttpHeaders;
   }
@@ -20826,9 +20892,9 @@ namespace VpcV1 {
   export namespace ListEndpointGatewayIpsConstants {
     /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending order. */
     export enum Sort {
+      ADDRESS = 'address',
       CREATED_AT = 'created_at',
       NAME = 'name',
-      ADDRESS = 'address',
     }
   }
 
@@ -20890,9 +20956,7 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
-    /** Filters the collection to resources within one of the resource groups identified in a comma-separated list
-     *  of resource group identifiers.
-     */
+    /** Filters the collection to resources in the resource group with the specified identifier. */
     resourceGroupId?: string;
     /** Filters the collection to resources with the exact specified name. */
     name?: string;
@@ -20913,10 +20977,10 @@ namespace VpcV1 {
   export namespace ListFlowLogCollectorsConstants {
     /** Filters the collection to flow log collectors that target the specified resource type. */
     export enum TargetResourceType {
-      VPC = 'vpc',
-      SUBNET = 'subnet',
       INSTANCE = 'instance',
       NETWORK_INTERFACE = 'network_interface',
+      SUBNET = 'subnet',
+      VPC = 'vpc',
     }
   }
 
@@ -21074,9 +21138,7 @@ namespace VpcV1 {
     lifecycle_state: string;
     /** The total amount of memory in gibibytes for this host. */
     memory: number;
-    /** The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host. */
     name: string;
     /** The profile this dedicated host uses. */
     profile: DedicatedHostProfileReference;
@@ -21084,7 +21146,7 @@ namespace VpcV1 {
     provisionable: boolean;
     /** The resource group for this dedicated host. */
     resource_group: ResourceGroupReference;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
     /** The total number of sockets for this host. */
     socket_count: number;
@@ -21154,7 +21216,7 @@ namespace VpcV1 {
     name: string;
     /** Indicates whether this dedicated host disk is available for instance disk creation. */
     provisionable: boolean;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
     /** The size of the disk in GB (gigabytes). */
     size: number;
@@ -21184,13 +21246,11 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this dedicated host group. */
     id: string;
-    /** The unique user-defined name for this dedicated host group. If unspecified, the name will be a hyphenated
-     *  list of randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host group. */
     name: string;
     /** The resource group for this dedicated host group. */
     resource_group: ResourceGroupReference;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
     /** The instance profiles usable by instances placed on this dedicated host group. */
     supported_instance_profiles: InstanceProfileReference[];
@@ -21230,9 +21290,7 @@ namespace VpcV1 {
 
   /** DedicatedHostGroupPrototypeDedicatedHostByZoneContext. */
   export interface DedicatedHostGroupPrototypeDedicatedHostByZoneContext {
-    /** The unique user-defined name for this dedicated host group. If unspecified, the name will be a hyphenated
-     *  list of randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host group. */
     name?: string;
     /** The resource group to use. If unspecified, the host's resource group is used. */
     resource_group?: ResourceGroupIdentity;
@@ -21250,11 +21308,9 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this dedicated host group. */
     id: string;
-    /** The unique user-defined name for this dedicated host group. If unspecified, the name will be a hyphenated
-     *  list of randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host group. */
     name: string;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
   }
 
@@ -21422,11 +21478,9 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this dedicated host. */
     id: string;
-    /** The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host. */
     name: string;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
   }
 
@@ -21452,8 +21506,8 @@ namespace VpcV1 {
     name: string;
     /** The resource group for the default network ACL for a VPC. Set to the VPC's resource group at creation. */
     resource_group: ResourceGroupReference;
-    /** The ordered rules for the default network ACL for a VPC.  Defaults to two rules which allow all inbound and
-     *  outbound traffic, respectively.  Rules for the default network ACL may be changed, added, or removed.
+    /** The ordered rules for the default network ACL for a VPC. Defaults to two rules which allow all inbound and
+     *  outbound traffic, respectively. Rules for the default network ACL may be changed, added, or removed.
      */
     rules: NetworkACLRuleItem[];
     /** The subnets to which this network ACL is attached. */
@@ -21532,7 +21586,7 @@ namespace VpcV1 {
     /** The resource group for this security group. */
     resource_group: ResourceGroupReference;
     /** The rules for the default security group for a VPC. Defaults to allowing all outbound traffic, and allowing
-     *  all inbound traffic from other interfaces in the VPC's default security group. Rules in the default security
+     *  all inbound traffic from other interfaces in the VPC's default security group. Rules for the default security
      *  group may be changed, added or removed.
      */
     rules: SecurityGroupRule[];
@@ -21580,7 +21634,7 @@ namespace VpcV1 {
     name: string;
     /** The resource group for this endpoint gateway. */
     resource_group: ResourceGroupReference;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
     /** The fully qualified domain name for the target service. */
     service_endpoint?: string;
@@ -21746,7 +21800,9 @@ namespace VpcV1 {
   export interface FlowLogCollector {
     /** Indicates whether this collector is active. */
     active: boolean;
-    /** If set to `true`, this flow log collector will be automatically deleted when the target is deleted. */
+    /** Indicates whether this flow log collector will be automatically deleted when `target` is deleted. At
+     *  present, this is always `true`, but may be modifiable in the future.
+     */
     auto_delete: boolean;
     /** The date and time that the flow log collector was created. */
     created_at: string;
@@ -21863,10 +21919,6 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** Identifies an IKE policy by a unique property. */
-  export interface IKEPolicyIdentity {
-  }
-
   /** IKEPolicyReference. */
   export interface IKEPolicyReference {
     /** If present, this property indicates the referenced resource has been deleted and provides
@@ -21960,11 +22012,6 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** Identifies an IPsec policy by a unique property. */
-  // tslint:disable-next-line: interface-name
-  export interface IPsecPolicyIdentity {
-  }
-
   /** IPsecPolicyReference. */
   // tslint:disable-next-line: interface-name
   export interface IPsecPolicyReference {
@@ -21998,7 +22045,7 @@ namespace VpcV1 {
     /** The type of encryption used on the image. */
     encryption: string;
     /** The key that will be used to encrypt volumes created from this image (unless an
-     *  alternate `encryption_key` is provided at volume creation).
+     *  alternate `encryption_key` is specified at volume creation).
      *
      *  This property will be present for images with an `encryption` type of `user_managed`.
      */
@@ -22165,6 +22212,8 @@ namespace VpcV1 {
     created_at: string;
     /** The CRN for this virtual server instance. */
     crn: string;
+    /** If present, the dedicated host this virtual server instance has been placed on. */
+    dedicated_host?: DedicatedHostReference;
     /** The instance disks for this virtual server instance. */
     disks: InstanceDisk[];
     /** The virtual server instance GPU configuration. */
@@ -22424,7 +22473,7 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this instance group manager. */
     id: string;
-    /** If set to `true`, this manager will control the instance group. */
+    /** Indicates whether this manager will control the instance group. */
     management_enabled: boolean;
     /** The user-defined name for this instance group manager. Names must be unique within the instance group. */
     name: string;
@@ -22434,12 +22483,14 @@ namespace VpcV1 {
 
   /** InstanceGroupManagerAction. */
   export interface InstanceGroupManagerAction {
-    /** If set to `true`, this scheduled action will be automatically deleted after it has finished and the
-     *  `auto_delete_timeout` time has passed.
+    /** Indicates whether this scheduled action will be automatically deleted after it has completed and
+     *  `auto_delete_timeout` hours have passed. At present, this is always
+     *  `true`, but may be modifiable in the future.
      */
     auto_delete: boolean;
-    /** Amount of time in hours that are required to pass before the scheduled action will be automatically deleted
-     *  once it has finished. If this value is 0, the action will be deleted on completion.
+    /** If `auto_delete` is `true`, and this scheduled action has finished, the hours after which it will be
+     *  automatically deleted. If the value is `0`, the action will be deleted once it has finished. This value may be
+     *  modifiable in the future.
      */
     auto_delete_timeout: number;
     /** The date and time that the instance group manager action was created. */
@@ -22638,7 +22689,7 @@ namespace VpcV1 {
 
   /** InstanceGroupManagerPrototype. */
   export interface InstanceGroupManagerPrototype {
-    /** If set to `true`, this manager will control the instance group. */
+    /** Indicates whether this manager will control the instance group. */
     management_enabled?: boolean;
     /** The user-defined name for this instance group manager. Names must be unique within the instance group. */
     name?: string;
@@ -22793,6 +22844,10 @@ namespace VpcV1 {
     disks: InstanceProfileDisk[];
     /** The product family this virtual server instance profile belongs to. */
     family?: string;
+    gpu_count?: InstanceProfileGPU;
+    gpu_manufacturer?: InstanceProfileGPUManufacturer;
+    gpu_memory?: InstanceProfileGPUMemory;
+    gpu_model?: InstanceProfileGPUModel;
     /** The URL for this virtual server instance profile. */
     href: string;
     memory: InstanceProfileMemory;
@@ -22842,6 +22897,30 @@ namespace VpcV1 {
     /** The type for this profile field. */
     type: string;
     /** The supported disk interfaces used for attaching the disk. */
+    values: string[];
+  }
+
+  /** InstanceProfileGPU. */
+  export interface InstanceProfileGPU {
+  }
+
+  /** InstanceProfileGPUManufacturer. */
+  export interface InstanceProfileGPUManufacturer {
+    /** The type for this profile field. */
+    type: string;
+    /** The possible GPU manufacturer(s) for an instance with this profile. */
+    values: string[];
+  }
+
+  /** InstanceProfileGPUMemory. */
+  export interface InstanceProfileGPUMemory {
+  }
+
+  /** InstanceProfileGPUModel. */
+  export interface InstanceProfileGPUModel {
+    /** The type for this profile field. */
+    type: string;
+    /** The possible GPU model(s) for an instance with this profile. */
     values: string[];
   }
 
@@ -22903,6 +22982,10 @@ namespace VpcV1 {
      *  password](https://cloud.ibm.com/apidocs/vpc#get-instance-initialization). Keys are optional for other images,
      *  but if no keys are specified, the instance will be inaccessible unless the specified image provides another
      *  means of access.
+     *
+     *  This property's value is used when provisioning the virtual server instance, but not subsequently managed.
+     *  Accordingly, it is reflected as an [instance
+     *  initialization](https://cloud.ibm.com/apidocs/vpc#get-instance-initialization) property.
      */
     keys?: KeyIdentity[];
     /** The unique user-defined name for this virtual server instance (and default system hostname). If unspecified,
@@ -22928,8 +23011,8 @@ namespace VpcV1 {
     user_data?: string;
     /** The volume attachments for this virtual server instance. */
     volume_attachments?: VolumeAttachmentPrototypeInstanceContext[];
-    /** The VPC the virtual server instance is to be a part of. If provided, must match the
-     *  VPC tied to the subnets of the instance's network interfaces.
+    /** The VPC the virtual server instance is to be a part of. If specified, it must match
+     *  the VPC referenced by the subnets of the instance's network interfaces.
      */
     vpc?: VPCIdentity;
   }
@@ -22984,6 +23067,10 @@ namespace VpcV1 {
      *  password](https://cloud.ibm.com/apidocs/vpc#get-instance-initialization). Keys are optional for other images,
      *  but if no keys are specified, the instance will be inaccessible unless the specified image provides another
      *  means of access.
+     *
+     *  This property's value is used when provisioning the virtual server instance, but not subsequently managed.
+     *  Accordingly, it is reflected as an [instance
+     *  initialization](https://cloud.ibm.com/apidocs/vpc#get-instance-initialization) property.
      */
     keys?: KeyIdentity[];
     /** The unique user-defined name for this instance template. */
@@ -23005,8 +23092,8 @@ namespace VpcV1 {
     user_data?: string;
     /** The volume attachments for this virtual server instance. */
     volume_attachments?: VolumeAttachmentPrototypeInstanceContext[];
-    /** The VPC the virtual server instance is to be a part of. If provided, must match the
-     *  VPC tied to the subnets of the instance's network interfaces.
+    /** The VPC the virtual server instance is to be a part of. If specified, it must match
+     *  the VPC referenced by the subnets of the instance's network interfaces.
      */
     vpc?: VPCIdentity;
   }
@@ -23051,6 +23138,10 @@ namespace VpcV1 {
      *  password](https://cloud.ibm.com/apidocs/vpc#get-instance-initialization). Keys are optional for other images,
      *  but if no keys are specified, the instance will be inaccessible unless the specified image provides another
      *  means of access.
+     *
+     *  This property's value is used when provisioning the virtual server instance, but not subsequently managed.
+     *  Accordingly, it is reflected as an [instance
+     *  initialization](https://cloud.ibm.com/apidocs/vpc#get-instance-initialization) property.
      */
     keys?: KeyIdentity[];
     /** The unique user-defined name for this virtual server instance (and default system hostname). If unspecified,
@@ -23076,8 +23167,8 @@ namespace VpcV1 {
     user_data?: string;
     /** The volume attachments for this virtual server instance. */
     volume_attachments?: VolumeAttachmentPrototypeInstanceContext[];
-    /** The VPC the virtual server instance is to be a part of. If provided, must match the
-     *  VPC tied to the subnets of the instance's network interfaces.
+    /** The VPC the virtual server instance is to be a part of. If specified, it must match
+     *  the VPC referenced by the subnets of the instance's network interfaces.
      */
     vpc?: VPCIdentity;
   }
@@ -23132,7 +23223,9 @@ namespace VpcV1 {
      *  randomly-selected words.
      */
     name: string;
-    /** The public SSH key. */
+    /** The public SSH key, consisting of two space-separated fields: the algorithm name, and the base64-encoded
+     *  key.
+     */
     public_key: string;
     /** The resource group for this key. */
     resource_group: ResourceGroupReference;
@@ -23233,6 +23326,11 @@ namespace VpcV1 {
     public_ips: IP[];
     /** The resource group for this load balancer. */
     resource_group: ResourceGroupReference;
+    /** Indicates whether route mode is enabled for this load balancer.
+     *
+     *  At present, public load balancers are not supported with route mode enabled.
+     */
+    route_mode: boolean;
     /** The security groups targeting this load balancer.
      *
      *  Applicable only for load balancers that support security groups.
@@ -23294,16 +23392,26 @@ namespace VpcV1 {
     default_pool?: LoadBalancerPoolReference;
     /** The listener's canonical URL. */
     href: string;
-    /** If provided, the target listener that requests are redirected to. */
+    /** If specified, the target listener that requests are redirected to. */
     https_redirect?: LoadBalancerListenerHTTPSRedirect;
     /** The unique identifier for this load balancer listener. */
     id: string;
     /** The policies for this listener. */
     policies?: LoadBalancerListenerPolicyReference[];
-    /** The listener port number. Each listener in the load balancer must have a unique
-     *  `port` and `protocol` combination.
+    /** The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer
+     *  must have a unique `port` and `protocol` combination.
      */
     port: number;
+    /** The inclusive upper bound of the range of ports used by this listener.
+     *
+     *  Only load balancers in the `network` family support more than one port per listener.
+     */
+    port_max: number;
+    /** The inclusive lower bound of the range of ports used by this listener.
+     *
+     *  Only load balancers in the `network` family support more than one port per listener.
+     */
+    port_min: number;
     /** The listener protocol. Load balancers in the `network` family support `tcp`. Load balancers in the
      *  `application` family support `tcp`, `http`, and `https`. Each listener in the load balancer must have a unique
      *  `port` and `protocol` combination.
@@ -23541,10 +23649,26 @@ namespace VpcV1 {
     connection_limit?: number;
     /** The default pool associated with the listener. */
     default_pool?: LoadBalancerPoolIdentityByName;
-    /** The listener port number. Each listener in the load balancer must have a unique
-     *  `port` and `protocol` combination.
+    /** The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer
+     *  must have a unique `port` and `protocol` combination.
+     *
+     *  Not supported for load balancers operating with route mode enabled.
      */
-    port: number;
+    port?: number;
+    /** The inclusive upper bound of the range of ports used by this listener. Must not be less than `port_min`.
+     *
+     *  At present, only load balancers operating with route mode enabled support different values for `port_min` and
+     *  `port_max`.  When route mode is enabled, only a value of
+     *  `65535` is supported for `port_max`.
+     */
+    port_max?: number;
+    /** The inclusive lower bound of the range of ports used by this listener. Must not be greater than `port_max`.
+     *
+     *  At present, only load balancers operating with route mode enabled support different values for `port_min` and
+     *  `port_max`.  When route mode is enabled, only a value of
+     *  `1` is supported for `port_min`.
+     */
+    port_min?: number;
     /** The listener protocol. Load balancers in the `network` family support `tcp`. Load balancers in the
      *  `application` family support `tcp`, `http`, and `https`. Each listener in the load balancer must have a unique
      *  `port` and `protocol` combination.
@@ -23578,7 +23702,7 @@ namespace VpcV1 {
 
   /** The datapath logging configuration for this load balancer. */
   export interface LoadBalancerLoggingDatapath {
-    /** If set to `true`, datapath logging is active for this load balancer. */
+    /** Indicates whether datapath logging is active for this load balancer. */
     active: boolean;
   }
 
@@ -23874,6 +23998,7 @@ namespace VpcV1 {
     logging_supported: LoadBalancerProfileLoggingSupported;
     /** The globally unique name for this load balancer profile. */
     name: string;
+    route_mode_supported: LoadBalancerProfileRouteModeSupported;
     security_groups_supported: LoadBalancerProfileSecurityGroupsSupported;
   }
 
@@ -23923,6 +24048,10 @@ namespace VpcV1 {
     href: string;
     /** The globally unique name for this load balancer profile. */
     name: string;
+  }
+
+  /** LoadBalancerProfileRouteModeSupported. */
+  export interface LoadBalancerProfileRouteModeSupported {
   }
 
   /** LoadBalancerProfileSecurityGroupsSupported. */
@@ -24283,8 +24412,8 @@ namespace VpcV1 {
      *  on this interface. If true, source IP spoofing is allowed on this interface.
      */
     allow_ip_spoofing?: boolean;
-    /** The user-defined name for this network interface. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
+    /** The user-defined name for network interface. Names must be unique within the instance the network interface
+     *  resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
      */
     name?: string;
     /** The primary IPv4 address. If specified, it must be an available address on the network interface's subnet.
@@ -24592,8 +24721,8 @@ namespace VpcV1 {
      *  the error, or bypass the resource on which the unexpected IP address format was encountered.
      */
     address: string;
-    /** If set to `true`, this reserved IP will be automatically deleted when the target is deleted or when the
-     *  reserved IP is unbound.
+    /** Indicates whether this reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the reserved IP is unbound.
      */
     auto_delete: boolean;
     /** The date and time that the reserved IP was created. */
@@ -25021,9 +25150,9 @@ namespace VpcV1 {
      *  if they are used. Alternatively, if `remote` references a security group, then this rule only applies to IP
      *  addresses (network interfaces) in that group matching this IP version.
      */
-    ip_version?: string;
+    ip_version: string;
     /** The protocol to enforce. */
-    protocol?: string;
+    protocol: string;
     /** The IP addresses or security groups from which this rule allows traffic (or to which,
      *  for outbound rules). Can be specified as an IP address, a CIDR block, or a security
      *  group. A CIDR block of `0.0.0.0/0` allows traffic from any source (or to any source,
@@ -25107,9 +25236,7 @@ namespace VpcV1 {
     created_at: string;
     /** The CRN for this snapshot. */
     crn: string;
-    /** Indicates whether this snapshot can be deleted. This value will not be `true` if any other snapshots depend
-     *  on it.
-     */
+    /** Indicates whether this snapshot can be deleted. This value will always be `true`. */
     deletable: boolean;
     /** The type of encryption used on the source volume. */
     encryption: string;
@@ -25486,9 +25613,13 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this VPN gateway connection. */
     id: string;
-    /** Optional IKE policy configuration. The absence of a policy indicates autonegotiation. */
+    /** The IKE policy. If absent, [auto-negotiation is
+     *  used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1).
+     */
     ike_policy?: IKEPolicyReference;
-    /** Optional IPsec policy configuration. The absence of a policy indicates autonegotiation. */
+    /** The IPsec policy. If absent, [auto-negotiation is
+     *  used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
+     */
     ipsec_policy?: IPsecPolicyReference;
     /** The mode of the VPN gateway. */
     mode: string;
@@ -25521,6 +25652,16 @@ namespace VpcV1 {
   }
 
   /** The Dead Peer Detection settings. */
+  export interface VPNGatewayConnectionDPDPatch {
+    /** Dead Peer Detection actions. */
+    action?: string;
+    /** Dead Peer Detection interval in seconds. */
+    interval?: number;
+    /** Dead Peer Detection timeout in seconds. Must be at least the interval. */
+    timeout?: number;
+  }
+
+  /** The Dead Peer Detection settings. */
   export interface VPNGatewayConnectionDPDPrototype {
     /** Dead Peer Detection actions. */
     action?: string;
@@ -25528,6 +25669,22 @@ namespace VpcV1 {
     interval?: number;
     /** Dead Peer Detection timeout in seconds. Must be at least the interval. */
     timeout?: number;
+  }
+
+  /** The IKE policy to use. Specify `null` to remove any existing policy, [resulting in auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1). */
+  export interface VPNGatewayConnectionIKEPolicyPatch {
+  }
+
+  /** The IKE policy to use. If unspecified, [auto-negotiation will be used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1). */
+  export interface VPNGatewayConnectionIKEPolicyPrototype {
+  }
+
+  /** The IPsec policy to use. Specify `null` to remove any existing policy, [resulting in auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2). */
+  export interface VPNGatewayConnectionIPsecPolicyPatch {
+  }
+
+  /** The IPsec policy to use. If unspecified, [auto-negotiation will be used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2). */
+  export interface VPNGatewayConnectionIPsecPolicyPrototype {
   }
 
   /** VPNGatewayConnectionLocalCIDRs. */
@@ -25541,11 +25698,15 @@ namespace VpcV1 {
     /** If set to false, the VPN gateway connection is shut down. */
     admin_state_up?: boolean;
     /** The Dead Peer Detection settings. */
-    dead_peer_detection?: VPNGatewayConnectionDPDPrototype;
-    /** Optional IKE policy configuration. The absence of a policy indicates autonegotiation. */
-    ike_policy?: IKEPolicyIdentity;
-    /** Optional IPsec policy configuration. The absence of a policy indicates autonegotiation. */
-    ipsec_policy?: IPsecPolicyIdentity;
+    dead_peer_detection?: VPNGatewayConnectionDPDPatch;
+    /** The IKE policy to use. Specify `null` to remove any existing policy, [resulting in
+     *  auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1).
+     */
+    ike_policy?: VPNGatewayConnectionIKEPolicyPatch;
+    /** The IPsec policy to use. Specify `null` to remove any existing policy, [resulting in
+     *  auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
+     */
+    ipsec_policy?: VPNGatewayConnectionIPsecPolicyPatch;
     /** The user-defined name for this VPN gateway connection. */
     name?: string;
     /** The IP address of the peer VPN gateway. */
@@ -25566,10 +25727,14 @@ namespace VpcV1 {
     admin_state_up?: boolean;
     /** The Dead Peer Detection settings. */
     dead_peer_detection?: VPNGatewayConnectionDPDPrototype;
-    /** Optional IKE policy configuration. The absence of a policy indicates autonegotiation. */
-    ike_policy?: IKEPolicyIdentity;
-    /** Optional IPsec policy configuration. The absence of a policy indicates autonegotiation. */
-    ipsec_policy?: IPsecPolicyIdentity;
+    /** The IKE policy to use. If unspecified, [auto-negotiation will be
+     *  used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1).
+     */
+    ike_policy?: VPNGatewayConnectionIKEPolicyPrototype;
+    /** The IPsec policy to use. If unspecified, [auto-negotiation will be
+     *  used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
+     */
+    ipsec_policy?: VPNGatewayConnectionIPsecPolicyPrototype;
     /** The user-defined name for this VPN gateway connection. */
     name?: string;
     /** The IP address of the peer VPN gateway. */
@@ -25641,8 +25806,8 @@ namespace VpcV1 {
     active: boolean;
     /** The maximum bandwidth (in megabits per second) for the volume. */
     bandwidth: number;
-    /** Indicates whether this volume is performing an operation that must be serialized. If an operation specifies
-     *  that it requires serialization, the operation will fail unless this property is `false`.
+    /** Indicates whether this volume is performing an operation that must be serialized. This must be `false` to
+     *  perform an operation that is specified to require serialization.
      */
     busy: boolean;
     /** The capacity to use for the volume (in gigabytes). The specified minimum and maximum capacity values for
@@ -25665,7 +25830,9 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this volume. */
     id: string;
-    /** The maximum I/O operations per second (IOPS) for the volume. */
+    /** The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a
+     *  profile `family` of `custom`.
+     */
     iops: number;
     /** The unique user-defined name for this volume. */
     name: string;
@@ -25713,7 +25880,7 @@ namespace VpcV1 {
     /** The date and time that the volume was attached. */
     created_at: string;
     /** If set to true, when deleting the instance the volume will also be deleted. */
-    delete_volume_on_instance_delete?: boolean;
+    delete_volume_on_instance_delete: boolean;
     /** Information about how the volume is exposed to the instance operating system.
      *
      *  This property may be absent if the volume attachment's `status` is not `attached`.
@@ -25749,7 +25916,9 @@ namespace VpcV1 {
   export interface VolumeAttachmentPrototypeInstanceByImageContext {
     /** If set to true, when deleting the instance the volume will also be deleted. */
     delete_volume_on_instance_delete?: boolean;
-    /** The user-defined name for this volume attachment. */
+    /** The user-defined name for this volume attachment. Names must be unique within the instance the volume
+     *  attachment resides in.
+     */
     name?: string;
     /** A prototype object for a new volume. */
     volume: VolumePrototypeInstanceByImageContext;
@@ -25759,7 +25928,9 @@ namespace VpcV1 {
   export interface VolumeAttachmentPrototypeInstanceByVolumeContext {
     /** If set to true, when deleting the instance the volume will also be deleted. */
     delete_volume_on_instance_delete?: boolean;
-    /** The user-defined name for this volume attachment. */
+    /** The user-defined name for this volume attachment. Names must be unique within the instance the volume
+     *  attachment resides in.
+     */
     name?: string;
     /** An existing volume to attach to the instance, or a prototype object for a new volume. */
     volume: VolumeAttachmentVolumePrototypeInstanceByVolumeContext;
@@ -25769,7 +25940,9 @@ namespace VpcV1 {
   export interface VolumeAttachmentPrototypeInstanceContext {
     /** If set to true, when deleting the instance the volume will also be deleted. */
     delete_volume_on_instance_delete?: boolean;
-    /** The user-defined name for this volume attachment. */
+    /** The user-defined name for this volume attachment. Names must be unique within the instance the volume
+     *  attachment resides in.
+     */
     name?: string;
     /** An existing volume to attach to the instance, or a prototype object for a new volume. */
     volume: VolumeAttachmentVolumePrototypeInstanceContext;
@@ -25929,7 +26102,7 @@ namespace VpcV1 {
   /** VolumePrototype. */
   export interface VolumePrototype {
     /** The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a
-     *  profile `family` of `custom`. The volume must be attached as a data volume to a running virtual server instance.
+     *  profile `family` of `custom`.
      */
     iops?: number;
     /** The unique user-defined name for this volume. */
@@ -25954,12 +26127,13 @@ namespace VpcV1 {
     capacity?: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided but the image is encrypted, the image's
-     *  `encryption_key` will be used. Otherwise, the `encryption` type for the
-     *  volume will be `provider_managed`.
+     *  If unspecified, and the image is encrypted, the image's `encryption_key` will be
+     *  used. Otherwise, the `encryption` type for the volume will be `provider_managed`.
      */
     encryption_key?: EncryptionKeyIdentity;
-    /** The maximum I/O operations per second (IOPS) for the volume. */
+    /** The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a
+     *  profile `family` of `custom`.
+     */
     iops?: number;
     /** The unique user-defined name for this volume. */
     name?: string;
@@ -26213,11 +26387,11 @@ namespace VpcV1 {
 
   /** EndpointGatewayReservedIPReservedIPPrototypeTargetContext. */
   export interface EndpointGatewayReservedIPReservedIPPrototypeTargetContext extends EndpointGatewayReservedIP {
-    /** If set to `true`, this reserved IP will be automatically deleted when the target is deleted or when the
-     *  reserved IP is unbound.
+    /** Indicates whether this reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the reserved IP is unbound.
      */
     auto_delete?: boolean;
-    /** The user-defined name for this reserved IP. If not specified, the name will be a hyphenated list of
+    /** The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of
      *  randomly-selected words. Names must be unique within the subnet the reserved IP resides in. Names beginning with
      *  `ibm-` are reserved for provider-owned resources.
      */
@@ -26407,32 +26581,6 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** IKEPolicyIdentityByHref. */
-  export interface IKEPolicyIdentityByHref extends IKEPolicyIdentity {
-    /** The IKE policy's canonical URL. */
-    href: string;
-  }
-
-  /** IKEPolicyIdentityById. */
-  export interface IKEPolicyIdentityById extends IKEPolicyIdentity {
-    /** The unique identifier for this IKE policy. */
-    id: string;
-  }
-
-  /** IPsecPolicyIdentityByHref. */
-  // tslint:disable-next-line: interface-name
-  export interface IPsecPolicyIdentityByHref extends IPsecPolicyIdentity {
-    /** The IPsec policy's canonical URL. */
-    href: string;
-  }
-
-  /** IPsecPolicyIdentityById. */
-  // tslint:disable-next-line: interface-name
-  export interface IPsecPolicyIdentityById extends IPsecPolicyIdentity {
-    /** The unique identifier for this IPsec policy. */
-    id: string;
-  }
-
   /** ImageIdentityByCRN. */
   export interface ImageIdentityByCRN extends ImageIdentity {
     /** The CRN for this image. */
@@ -26456,19 +26604,19 @@ namespace VpcV1 {
     /** A base64-encoded, encrypted representation of the key that was used to encrypt the data for this image.
      *
      *  That representation is created by wrapping the key's value with the `encryption_key` root key (which must also
-     *  be provided), using either [Key Protect](https://cloud.ibm.com/docs/key-protect?topic=key-protect-wrap-keys) or
+     *  be specified), using either [Key Protect](https://cloud.ibm.com/docs/key-protect?topic=key-protect-wrap-keys) or
      *  the
      *  [Hyper Protect Crypto Service](https://cloud.ibm.com/docs/services/hs-crypto?topic=hs-crypto-wrap-keys).
      *
-     *  If this property is not provided, the imported image is treated as unencrypted.
+     *  If unspecified, the imported image is treated as unencrypted.
      */
     encrypted_data_key?: string;
     /** The root key that was used to wrap the data key (which is ultimately represented as
      *  `encrypted_data_key`). Additionally, the root key will be used to encrypt volumes
-     *  created from this image (unless an alternate `encryption_key` is provided at volume
+     *  created from this image (unless an alternate `encryption_key` is specified at volume
      *  creation).
      *
-     *  If this property is not provided, the imported image is treated as unencrypted.
+     *  If unspecified, the imported image is treated as unencrypted.
      */
     encryption_key?: EncryptionKeyIdentity;
     /** The file from which to create the image. */
@@ -26484,7 +26632,7 @@ namespace VpcV1 {
   export interface ImagePrototypeImageBySourceVolume extends ImagePrototype {
     /** The root key used to wrap the system-generated data encryption key for the image.
      *
-     *  If this property is not provided, the root key from `source_volume` will be used.
+     *  If unspecified, the root key from `source_volume` will be used.
      */
     encryption_key?: EncryptionKeyIdentity;
     /** The volume from which to create the image. The specified volume must:
@@ -26509,10 +26657,10 @@ namespace VpcV1 {
      *  a 5 min period.
      */
     cron_spec?: string;
-    /** The date and time the scheduled action was last applied. If empty the action has never been applied. */
+    /** The date and time the scheduled action was last applied. If absent, the action has never been applied. */
     last_applied_at?: string;
-    /** The date and time the scheduled action will next run. If empty the system is currently calculating the next
-     *  run time.
+    /** The date and time the scheduled action will next run. If absent, the system is currently calculating the
+     *  next run time.
      */
     next_run_at?: string;
   }
@@ -26599,7 +26747,7 @@ namespace VpcV1 {
     min_membership_count?: number;
   }
 
-  /** The auto scale manager to update and the property or properties to be updated. Exactly one of `id` or `href` must be provided in addition to at least one of `min_membership_count` and `max_membership_count`. */
+  /** The auto scale manager to update, and one or more properties to be updated. Either `id` or `href` must be specified, in addition to at least one of `min_membership_count` and `max_membership_count`. */
   export interface InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototype extends InstanceGroupManagerScheduledActionManagerPrototype {
     /** The maximum number of members the instance group should have at the scheduled time. */
     max_membership_count?: number;
@@ -26643,11 +26791,9 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this dedicated host group. */
     id: string;
-    /** The unique user-defined name for this dedicated host group. If unspecified, the name will be a hyphenated
-     *  list of randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host group. */
     name: string;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
   }
 
@@ -26663,11 +26809,9 @@ namespace VpcV1 {
     href: string;
     /** The unique identifier for this dedicated host. */
     id: string;
-    /** The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-     *  randomly-selected words.
-     */
+    /** The unique user-defined name for this dedicated host. */
     name: string;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
   }
 
@@ -26791,6 +26935,82 @@ namespace VpcV1 {
 
   /** The permitted range for the disk size of this configuration in GB (gigabytes) for an instance with this profile. */
   export interface InstanceProfileDiskSizeRange extends InstanceProfileDiskSize {
+    /** The default value for this profile field. */
+    default: number;
+    /** The maximum value for this profile field. */
+    max: number;
+    /** The minimum value for this profile field. */
+    min: number;
+    /** The increment step value for this profile field. */
+    step: number;
+    /** The type for this profile field. */
+    type: string;
+  }
+
+  /** The GPU count for an instance with this profile depends on its configuration. */
+  export interface InstanceProfileGPUDependent extends InstanceProfileGPU {
+    /** The type for this profile field. */
+    type: string;
+  }
+
+  /** The permitted GPU count values for an instance with this profile. */
+  export interface InstanceProfileGPUEnum extends InstanceProfileGPU {
+    /** The default value for this profile field. */
+    default: number;
+    /** The type for this profile field. */
+    type: string;
+    /** The permitted values for this profile field. */
+    values: number[];
+  }
+
+  /** The GPU count for an instance with this profile. */
+  export interface InstanceProfileGPUFixed extends InstanceProfileGPU {
+    /** The type for this profile field. */
+    type: string;
+    /** The value for this profile field. */
+    value: number;
+  }
+
+  /** The overall GPU memory value for an instance with this profile depends on its configuration. */
+  export interface InstanceProfileGPUMemoryDependent extends InstanceProfileGPUMemory {
+    /** The type for this profile field. */
+    type: string;
+  }
+
+  /** The permitted overall GPU memory values in GiB (gibibytes) for an instance with this profile. */
+  export interface InstanceProfileGPUMemoryEnum extends InstanceProfileGPUMemory {
+    /** The default value for this profile field. */
+    default: number;
+    /** The type for this profile field. */
+    type: string;
+    /** The permitted values for this profile field. */
+    values: number[];
+  }
+
+  /** The overall GPU memory in GiB (gibibytes) for an instance with this profile. */
+  export interface InstanceProfileGPUMemoryFixed extends InstanceProfileGPUMemory {
+    /** The type for this profile field. */
+    type: string;
+    /** The value for this profile field. */
+    value: number;
+  }
+
+  /** The permitted overall GPU memory range in GiB (gibibytes) for an instance with this profile. */
+  export interface InstanceProfileGPUMemoryRange extends InstanceProfileGPUMemory {
+    /** The default value for this profile field. */
+    default: number;
+    /** The maximum value for this profile field. */
+    max: number;
+    /** The minimum value for this profile field. */
+    min: number;
+    /** The increment step value for this profile field. */
+    step: number;
+    /** The type for this profile field. */
+    type: string;
+  }
+
+  /** The permitted GPU count range for an instance with this profile. */
+  export interface InstanceProfileGPURange extends InstanceProfileGPU {
     /** The default value for this profile field. */
     default: number;
     /** The maximum value for this profile field. */
@@ -27252,6 +27472,20 @@ namespace VpcV1 {
     name: string;
   }
 
+  /** The route mode support for a load balancer with this profile depends on its configuration. */
+  export interface LoadBalancerProfileRouteModeSupportedDependent extends LoadBalancerProfileRouteModeSupported {
+    /** The type for this profile field. */
+    type: string;
+  }
+
+  /** The route mode support for a load balancer with this profile. */
+  export interface LoadBalancerProfileRouteModeSupportedFixed extends LoadBalancerProfileRouteModeSupported {
+    /** The type for this profile field. */
+    type: string;
+    /** The value for this profile field. */
+    value: boolean;
+  }
+
   /** The security group support for a load balancer with this profile depends on its configuration. */
   export interface LoadBalancerProfileSecurityGroupsSupportedDependent extends LoadBalancerProfileSecurityGroupsSupported {
     /** The type for this profile field. */
@@ -27514,7 +27748,7 @@ namespace VpcV1 {
     id: string;
     /** The unique user-defined name for this endpoint gateway. */
     name: string;
-    /** The type of resource referenced. */
+    /** The resource type. */
     resource_type: string;
   }
 
@@ -27886,6 +28120,54 @@ namespace VpcV1 {
     id: string;
   }
 
+  /** VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityByHref. */
+  export interface VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityByHref extends VPNGatewayConnectionIKEPolicyPatch {
+    /** The IKE policy's canonical URL. */
+    href: string;
+  }
+
+  /** VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityById. */
+  export interface VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityById extends VPNGatewayConnectionIKEPolicyPatch {
+    /** The unique identifier for this IKE policy. */
+    id: string;
+  }
+
+  /** VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityByHref. */
+  export interface VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityByHref extends VPNGatewayConnectionIKEPolicyPrototype {
+    /** The IKE policy's canonical URL. */
+    href: string;
+  }
+
+  /** VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityById. */
+  export interface VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityById extends VPNGatewayConnectionIKEPolicyPrototype {
+    /** The unique identifier for this IKE policy. */
+    id: string;
+  }
+
+  /** VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityByHref. */
+  export interface VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityByHref extends VPNGatewayConnectionIPsecPolicyPatch {
+    /** The IPsec policy's canonical URL. */
+    href: string;
+  }
+
+  /** VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityById. */
+  export interface VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityById extends VPNGatewayConnectionIPsecPolicyPatch {
+    /** The unique identifier for this IPsec policy. */
+    id: string;
+  }
+
+  /** VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityByHref. */
+  export interface VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityByHref extends VPNGatewayConnectionIPsecPolicyPrototype {
+    /** The IPsec policy's canonical URL. */
+    href: string;
+  }
+
+  /** VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityById. */
+  export interface VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityById extends VPNGatewayConnectionIPsecPolicyPrototype {
+    /** The unique identifier for this IPsec policy. */
+    id: string;
+  }
+
   /** VPNGatewayConnectionPatchVPNGatewayConnectionStaticRouteModePatch. */
   export interface VPNGatewayConnectionPatchVPNGatewayConnectionStaticRouteModePatch extends VPNGatewayConnectionPatch {
     /** Routing protocols are disabled for this VPN gateway connection. */
@@ -27952,7 +28234,9 @@ namespace VpcV1 {
 
   /** VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext. */
   export interface VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext extends VolumeAttachmentPrototypeVolume {
-    /** The maximum I/O operations per second (IOPS) for the volume. */
+    /** The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a
+     *  profile `family` of `custom`.
+     */
     iops?: number;
     /** The unique user-defined name for this volume. */
     name?: string;
@@ -27970,10 +28254,12 @@ namespace VpcV1 {
     capacity?: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided, the snapshot's `encryption_key` will be used.
+     *  If unspecified, the snapshot's `encryption_key` will be used.
      */
     encryption_key?: EncryptionKeyIdentity;
-    /** The maximum I/O operations per second (IOPS) for the volume. */
+    /** The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a
+     *  profile `family` of `custom`.
+     */
     iops?: number;
     /** The unique user-defined name for this volume. */
     name?: string;
@@ -27989,7 +28275,9 @@ namespace VpcV1 {
 
   /** VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext. */
   export interface VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext extends VolumeAttachmentVolumePrototypeInstanceContext {
-    /** The maximum I/O operations per second (IOPS) for the volume. */
+    /** The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a
+     *  profile `family` of `custom`.
+     */
     iops?: number;
     /** The unique user-defined name for this volume. */
     name?: string;
@@ -28035,8 +28323,7 @@ namespace VpcV1 {
     capacity: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided, the `encryption` type for the volume will be
-     *  `provider_managed`.
+     *  If unspecified, the `encryption` type for the volume will be `provider_managed`.
      */
     encryption_key?: EncryptionKeyIdentity;
   }
@@ -28393,22 +28680,22 @@ namespace VpcV1 {
     capacity: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided, the `encryption` type for the volume will be
-     *  `provider_managed`.
+     *  If unspecified, the `encryption` type for the volume will be `provider_managed`.
      */
     encryption_key?: EncryptionKeyIdentity;
   }
 
   /** VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot. */
   export interface VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot extends VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext {
-    /** The capacity to use for the volume (in gigabytes). The allowed values are expected to expand in the future.
+    /** The capacity to use for the volume (in gigabytes). The only allowed value is the source snapshot's
+     *  `minimum_capacity`, but the allowed values are expected to expand in the future.
      *
      *  If unspecified, the capacity will be the source snapshot's `minimum_capacity`.
      */
     capacity?: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided, the snapshot's `encryption_key` will be used.
+     *  If unspecified, the snapshot's `encryption_key` will be used.
      */
     encryption_key?: EncryptionKeyIdentity;
     /** The snapshot from which to clone the volume. */
@@ -28441,22 +28728,22 @@ namespace VpcV1 {
     capacity: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided, the `encryption` type for the volume will be
-     *  `provider_managed`.
+     *  If unspecified, the `encryption` type for the volume will be `provider_managed`.
      */
     encryption_key?: EncryptionKeyIdentity;
   }
 
   /** VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot. */
   export interface VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot extends VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext {
-    /** The capacity to use for the volume (in gigabytes). The allowed values are expected to expand in the future.
+    /** The capacity to use for the volume (in gigabytes). The only allowed value is the source snapshot's
+     *  `minimum_capacity`, but the allowed values are expected to expand in the future.
      *
      *  If unspecified, the capacity will be the source snapshot's `minimum_capacity`.
      */
     capacity?: number;
     /** The root key to use to wrap the data encryption key for the volume.
      *
-     *  If this property is not provided, the snapshot's `encryption_key` will be used.
+     *  If unspecified, the snapshot's `encryption_key` will be used.
      */
     encryption_key?: EncryptionKeyIdentity;
     /** The snapshot from which to clone the volume. */


### PR DESCRIPTION
Breaking changes:

In VPNGatewayConnectionPrototype
```

Type of ike_policy  is changed from IKEPolicyIdentity -> VPNGatewayConnectionIKEPolicyPrototype
Type of ipsec_policy  is changed from IPsecPolicyIdentity -> VPNGatewayConnectionIPsecPolicyPrototype
```

In VPNGatewayConnectionPatch
```

Type of ike_policy  is changed from IKEPolicyIdentity -> VPNGatewayConnectionIKEPolicyPatch
Type of ipsec_policy  is changed from IPsecPolicyIdentity -> VPNGatewayConnectionIPsecPolicyPatch
Type of dead_peer_detection  is changed from VPNGatewayConnectionDPDPrototype -> VPNGatewayConnectionDPDPatch
```

In ListKeysParams
`resourceGroupId is removed`


In CreateLoadBalancerListener()
`'port' is not a required parameter. It is optional`