### PR TITLE
feat(release): Update SDK to use API generated on 2024-11-12

### DIFF
--- a/examples/vpc.v1.test.js
+++ b/examples/vpc.v1.test.js
@@ -2299,6 +2299,136 @@ describe('VpcV1', () => {
 
   });
 
+
+  test('listInstanceClusterNetworkAttachments request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('listInstanceClusterNetworkAttachments() result:');
+    // begin-list_instance_cluster_network_attachments
+
+    const params = {
+      instanceId: data.instanceId,
+      limit: 10,
+    };
+
+    const allResults = [];
+    try {
+      const pager = new VpcV1.InstanceClusterNetworkAttachmentsPager(vpcService, params);
+      while (pager.hasNext()) {
+        const nextPage = await pager.getNext();
+        expect(nextPage).not.toBeNull();
+        allResults.push(...nextPage);
+      }
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-list_instance_cluster_network_attachments
+  });
+
+  test('createClusterNetworkAttachment request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('createClusterNetworkAttachment() result:');
+    // begin-create_cluster_network_attachment
+
+    // Request models needed by this operation.
+
+    // InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceInstanceClusterNetworkInterfacePrototypeInstanceClusterNetworkAttachment
+    const instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel = {
+      name: 'my-instance-cluster-network-attachment',
+    };
+
+    const params = {
+      instanceId: data.instanceId,
+      clusterNetworkInterface: instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel,
+    };
+
+    let res;
+    try {
+      res = await vpcService.createClusterNetworkAttachment(params);
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+    data.clusterNetworkAttachmentId = res.result.id;
+    // end-create_cluster_network_attachment
+  });
+
+  test('getInstanceClusterNetworkAttachment request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getInstanceClusterNetworkAttachment() result:');
+    // begin-get_instance_cluster_network_attachment
+
+    const params = {
+      instanceId: data.instanceId,
+      id: data.clusterNetworkAttachmentId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.getInstanceClusterNetworkAttachment(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+
+    // end-get_instance_cluster_network_attachment
+  });
+
+  test('updateInstanceClusterNetworkAttachment request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('updateInstanceClusterNetworkAttachment() result:');
+    // begin-update_instance_cluster_network_attachment
+
+    const params = {
+      instanceId: data.instanceId,
+      id: data.clusterNetworkAttachmentId,
+      name: 'my-instance-network-attachment-updated',
+    };
+
+    let res;
+    try {
+      res = await vpcService.updateInstanceClusterNetworkAttachment(params);
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+
+    // end-update_instance_cluster_network_attachment
+  });
+
   test.skip('createInstanceConsoleAccessToken request example', async () => {
 
     consoleLogMock.mockImplementation((output) => {
@@ -5087,6 +5217,587 @@ describe('VpcV1', () => {
     // end-get_region_zone
     expect(response.result).not.toBeNull();
 
+  });
+
+
+  test('listClusterNetworkProfiles request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('listClusterNetworkProfiles() result:');
+    // begin-list_cluster_network_profiles
+
+    const params = {
+      limit: 10,
+    };
+
+    const allResults = [];
+    try {
+      const pager = new VpcV1.ClusterNetworkProfilesPager(vpcService, params);
+      while (pager.hasNext()) {
+        const nextPage = await pager.getNext();
+        expect(nextPage).not.toBeNull();
+        allResults.push(...nextPage);
+      }
+      console.log(JSON.stringify(allResults, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+    data.clusterNetworkProfileName = allResults[0].name;
+    // end-list_cluster_network_profiles
+  });
+
+  test('getClusterNetworkProfile request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getClusterNetworkProfile() result:');
+    // begin-get_cluster_network_profile
+
+    const params = {
+      name: data.clusterNetworkProfileName,
+    };
+
+    let res;
+    try {
+      res = await vpcService.getClusterNetworkProfile(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_cluster_network_profile
+  });
+
+  test('listClusterNetworks request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('listClusterNetworks() result:');
+    // begin-list_cluster_networks
+
+    const params = {
+      limit: 10,
+      sort: 'name',
+      vpcId: data.vpcId,
+    };
+
+    const allResults = [];
+    try {
+      const pager = new VpcV1.ClusterNetworksPager(vpcService, params);
+      while (pager.hasNext()) {
+        const nextPage = await pager.getNext();
+        expect(nextPage).not.toBeNull();
+        allResults.push(...nextPage);
+      }
+      console.log(JSON.stringify(allResults, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-list_cluster_networks
+  });
+
+  test('createClusterNetwork request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('createClusterNetwork() result:');
+    // begin-create_cluster_network
+
+    // Request models needed by this operation.
+
+    // ClusterNetworkProfileIdentityByName
+    const clusterNetworkProfileIdentityModel = {
+      name: data.clusterNetworkProfileName,
+    };
+
+    // VPCIdentityById
+    const vpcIdentityModel = {
+      id: data.vpcId,
+    };
+
+    // ZoneIdentityByName
+    const zoneIdentityModel = {
+      name: data.zone,
+    };
+
+    const params = {
+      profile: clusterNetworkProfileIdentityModel,
+      vpc: vpcIdentityModel,
+      zone: zoneIdentityModel,
+    };
+
+    let res;
+    try {
+      res = await vpcService.createClusterNetwork(params);
+      data.clusterNetworkId = res.result.id;
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-create_cluster_network
+  });
+
+  test('listClusterNetworkInterfaces request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('listClusterNetworkInterfaces() result:');
+    // begin-list_cluster_network_interfaces
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      limit: 10,
+      name: 'my-name',
+      sort: 'name',
+    };
+
+    const allResults = [];
+    try {
+      const pager = new VpcV1.ClusterNetworkInterfacesPager(vpcService, params);
+      while (pager.hasNext()) {
+        const nextPage = await pager.getNext();
+        expect(nextPage).not.toBeNull();
+        allResults.push(...nextPage);
+      }
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-list_cluster_network_interfaces
+  });
+
+  test('createClusterNetworkInterface request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('createClusterNetworkInterface() result:');
+    // begin-create_cluster_network_interface
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.createClusterNetworkInterface(params);
+      data.clusterNetworkInterfaceId = res.result.id;
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-create_cluster_network_interface
+  });
+
+  test('getClusterNetworkInterface request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getClusterNetworkInterface() result:');
+    // begin-get_cluster_network_interface
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      id: data.clusterNetworkInterfaceId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.getClusterNetworkInterface(params);
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_cluster_network_interface
+  });
+
+  test('updateClusterNetworkInterface request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('updateClusterNetworkInterface() result:');
+    // begin-update_cluster_network_interface
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      id: data.clusterNetworkInterfaceId,
+      name: 'my-cluster-network-interface-updated',
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.updateClusterNetworkInterface(params);
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-update_cluster_network_interface
+  });
+
+  test('listClusterNetworkSubnets request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('listClusterNetworkSubnets() result:');
+    // begin-list_cluster_network_subnets
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      limit: 10,
+      name: 'my-name',
+      sort: 'name',
+    };
+
+    const allResults = [];
+    try {
+      const pager = new VpcV1.ClusterNetworkSubnetsPager(vpcService, params);
+      while (pager.hasNext()) {
+        const nextPage = await pager.getNext();
+        expect(nextPage).not.toBeNull();
+        allResults.push(...nextPage);
+      }
+      console.log(JSON.stringify(allResults, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-list_cluster_network_subnets
+  });
+
+  test('createClusterNetworkSubnet request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('createClusterNetworkSubnet() result:');
+    // begin-create_cluster_network_subnet
+
+    // Request models needed by this operation.
+
+    // ClusterNetworkSubnetPrototypeClusterNetworkSubnetByTotalCountPrototype
+    const clusterNetworkSubnetPrototypeModel = {
+      total_ipv4_address_count: 256,
+    };
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      clusterNetworkSubnetPrototype: clusterNetworkSubnetPrototypeModel,
+    };
+
+    let res;
+    try {
+      res = await vpcService.createClusterNetworkSubnet(params);
+      data.clusterNetworkSubnetId = res.result.id;
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-create_cluster_network_subnet
+  });
+
+  test('listClusterNetworkSubnetReservedIps request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('listClusterNetworkSubnetReservedIps() result:');
+    // begin-list_cluster_network_subnet_reserved_ips
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      clusterNetworkSubnetId: data.clusterNetworkSubnetId,
+      limit: 10,
+      name: 'my-name',
+      sort: 'name',
+    };
+
+    const allResults = [];
+    try {
+      const pager = new VpcV1.ClusterNetworkSubnetReservedIpsPager(vpcService, params);
+      while (pager.hasNext()) {
+        const nextPage = await pager.getNext();
+        expect(nextPage).not.toBeNull();
+        allResults.push(...nextPage);
+      }
+      console.log(JSON.stringify(allResults, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-list_cluster_network_subnet_reserved_ips
+  });
+
+  test('createClusterNetworkSubnetReservedIp request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('createClusterNetworkSubnetReservedIp() result:');
+    // begin-create_cluster_network_subnet_reserved_ip
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      clusterNetworkSubnetId: data.clusterNetworkSubnetId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.createClusterNetworkSubnetReservedIp(params);
+    } catch (err) {
+      console.warn(err);
+    }
+    data.clusterNetworkSubnetReservedIpId = res.result.id;
+    // end-create_cluster_network_subnet_reserved_ip
+  });
+
+  test('getClusterNetworkSubnetReservedIp request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getClusterNetworkSubnetReservedIp() result:');
+    // begin-get_cluster_network_subnet_reserved_ip
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      clusterNetworkSubnetId: data.clusterNetworkSubnetId,
+      id: data.clusterNetworkSubnetReservedIpId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.getClusterNetworkSubnetReservedIp(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_cluster_network_subnet_reserved_ip
+  });
+
+  test('updateClusterNetworkSubnetReservedIp request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('updateClusterNetworkSubnetReservedIp() result:');
+    // begin-update_cluster_network_subnet_reserved_ip
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      clusterNetworkSubnetId: data.clusterNetworkSubnetId,
+      id: data.clusterNetworkSubnetReservedIpId,
+      name: 'my-cluster-network-subnet-reserved-ip-updated',
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.updateClusterNetworkSubnetReservedIp(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-update_cluster_network_subnet_reserved_ip
+  });
+
+  test('getClusterNetworkSubnet request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getClusterNetworkSubnet() result:');
+    // begin-get_cluster_network_subnet
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      id: data.clusterNetworkSubnetId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.getClusterNetworkSubnet(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_cluster_network_subnet
+  });
+
+  test('updateClusterNetworkSubnet request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('updateClusterNetworkSubnet() result:');
+    // begin-update_cluster_network_subnet
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      id: data.clusterNetworkSubnetId,
+      name: 'my-cluster-network-subnet-updated',
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.updateClusterNetworkSubnet(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-update_cluster_network_subnet
+  });
+
+  test('getClusterNetwork request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getClusterNetwork() result:');
+    // begin-get_cluster_network
+
+    const params = {
+      id: data.clusterNetworkId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.getClusterNetwork(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_cluster_network
+  });
+
+  test('updateClusterNetwork request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('updateClusterNetwork() result:');
+    // begin-update_cluster_network
+
+    const params = {
+      id: data.clusterNetworkId,
+      name: 'my-cluster-network-updated',
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.updateClusterNetwork(params);
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-update_cluster_network
   });
 
 
@@ -9142,6 +9853,36 @@ describe('VpcV1', () => {
 
   });
 
+
+  test('deleteInstanceClusterNetworkAttachment request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('deleteInstanceClusterNetworkAttachment() result:');
+    // begin-delete_instance_cluster_network_attachment
+
+    const params = {
+      instanceId: data.instanceId,
+      id: data.clusterNetworkAttachmentId,
+    };
+
+    let res;
+    try {
+      res = await vpcService.deleteInstanceClusterNetworkAttachment(params);
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+    // end-delete_instance_cluster_network_attachment
+  });
+
+
   test('deleteInstanceNetworkInterface request example', async () => {
 
     consoleLogMock.mockImplementation((output) => {
@@ -9561,6 +10302,131 @@ describe('VpcV1', () => {
     }
 
     // end-delete_share
+  });
+
+
+  test('deleteClusterNetworkInterface request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('deleteClusterNetworkInterface() result:');
+    // begin-delete_cluster_network_interface
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      id: data.clusterNetworkInterfaceId,
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.deleteClusterNetworkInterface(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+
+    // end-delete_cluster_network_interface
+  });
+
+  test('deleteClusterNetworkSubnetReservedIp request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('deleteClusterNetworkSubnetReservedIp() result:');
+    // begin-delete_cluster_network_subnet_reserved_ip
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      clusterNetworkSubnetId: data.clusterNetworkSubnetId,
+      id: data.clusterNetworkSubnetReservedIpId,
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.deleteClusterNetworkSubnetReservedIp(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+
+    // end-delete_cluster_network_subnet_reserved_ip
+  });
+
+  test('deleteClusterNetworkSubnet request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('deleteClusterNetworkSubnet() result:');
+    // begin-delete_cluster_network_subnet
+
+    const params = {
+      clusterNetworkId: data.clusterNetworkId,
+      id: data.clusterNetworkSubnetId,
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.deleteClusterNetworkSubnet(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+
+    // end-delete_cluster_network_subnet
+  });
+
+  test('deleteClusterNetwork request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('deleteClusterNetwork() result:');
+    // begin-delete_cluster_network
+
+    const params = {
+      id: data.clusterNetworkId,
+      ifMatch: 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"',
+    };
+
+    let res;
+    try {
+      res = await vpcService.deleteClusterNetwork(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+    expect(res.result).not.toBeNull();
+
+    // end-delete_cluster_network
   });
 
   test('deletePublicGateway request example', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@types/node": "^14.0.0",
         "extend": "^3.0.2",
-        "ibm-cloud-sdk-core": "^5.0.0",
+        "ibm-cloud-sdk-core": "^5.1.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@ibm-cloud/sdk-test-utilities": "^1.0.0",
-        "@semantic-release/changelog": "6.0.1",
+        "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "axios": "1.2.1",
         "dotenv": "^8.2.0",
@@ -29,7 +29,7 @@
         "jest": "^29.3.1",
         "nock": "^13.2.4",
         "prettier": "^2.3.0",
-        "semantic-release": "^19.0.3",
+        "semantic-release": "^23.1.1",
         "tsc-publish": "^0.5.2",
         "typescript": "~4.9.4"
       },
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1213,170 +1213,158 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/graphql": "^5.0.0",
-        "@octokit/request": "^6.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.0.0",
+        "@octokit/request": "^9.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+      "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^6.0.0",
-        "@octokit/types": "^9.0.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/request": "^9.0.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.5.tgz",
+      "integrity": "sha512-cgwIRtKrpwhLoBi0CUNuY83DPGRMaWVjqVI/bGKsLJ4PzyWZNaEmhHroI2xlrVXkk6nFv0IsZpOp+ZWSWUS2AQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
+        "@octokit/types": "^13.6.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=4"
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@octokit/plugin-retry": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
-      "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.2.tgz",
+      "integrity": "sha512-XOWnPpH2kJ5VTwozsxGurw+svB2e61aWlmk5EVIYZPwFK5F9h4cyPyj9CIKRyMXMHSwpIsI3mPOdpMmrRhe7UQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
+        "@octokit/request-error": "^6.0.0",
+        "@octokit/types": "^13.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=3"
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
-      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.2.tgz",
+      "integrity": "sha512-FqpvcTpIWFpMMwIeSoypoJXysSAQ3R+ALJhXXSG1HTP3YZOIeLmcNcimKaXxTcws+Sh6yoRl13SJ5r8sXc1Fhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^13.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": "^4.0.0"
+        "@octokit/core": "^6.0.0"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^7.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.5.tgz",
+      "integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
+        "@octokit/types": "^13.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
-    "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
+      "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -1424,16 +1412,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@semantic-release/changelog": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
-      "integrity": "sha512-FT+tAGdWHr0RCM3EpWegWnvXJ05LQtBkQUaQRIExONoXjVjLuOILNm4DEKNaV+GAQyJjbLRVs57ti//GypH6PA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
       },
       "engines": {
@@ -1444,25 +1439,25 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
+      "integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-commits-filter": "^4.0.0",
+        "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
-        "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "import-from-esm": "^1.0.3",
+        "lodash-es": "^4.17.21",
         "micromatch": "^4.0.2"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
+        "semantic-release": ">=20.1.0"
       }
     },
     "node_modules/@semantic-release/error": {
@@ -1499,118 +1494,387 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
-      "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.3.5.tgz",
+      "integrity": "sha512-svvRglGmvqvxjmDgkXhrjf0lC88oZowFhOfifTldbgX9Dzj0inEtMLaC+3/MkDEmxmaQjWmF5Q/0CMIvPNSVdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^6.1.2",
-        "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/plugin-throttling": "^5.2.3",
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "globby": "^11.0.0",
+        "@octokit/core": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
+        "@octokit/plugin-retry": "^7.0.0",
+        "@octokit/plugin-throttling": "^9.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "debug": "^4.3.4",
+        "dir-glob": "^3.0.1",
+        "globby": "^14.0.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
-        "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
-        "mime": "^3.0.0",
-        "p-filter": "^2.0.0",
-        "url-join": "^4.0.0"
+        "issue-parser": "^7.0.0",
+        "lodash-es": "^4.17.21",
+        "mime": "^4.0.0",
+        "p-filter": "^4.0.0",
+        "url-join": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
+        "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+    "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/clean-stack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
-      "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
+      "integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
-        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
-        "npm": "^8.3.0",
+        "normalize-url": "^8.0.0",
+        "npm": "^10.5.0",
         "rc": "^1.2.8",
-        "read-pkg": "^5.0.0",
+        "read-pkg": "^9.0.0",
         "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
-        "tempy": "^1.0.0"
+        "tempy": "^3.0.0"
       },
       "engines": {
-        "node": ">=16 || ^14.17"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
-        "semantic-release": ">=19.0.0"
+        "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/npm/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+    "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/clean-stack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/execa": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.1.tgz",
+      "integrity": "sha512-QY5PPtSonnGwhhHDNI7+3RvY285c7iuJFFB+lU+oEzMY/gEGJ808owqJsrr8Otd1E/x07po1LkUBmdAc5duPAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/human-signals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
-      "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-13.0.0.tgz",
+      "integrity": "sha512-LEeZWb340keMYuREMyxrODPXJJ0JOL8D/mCl74B4LdzbxhtXV2LrPN2QBEcGJrlQhoqLO0RhxQb6masHytKw+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-changelog-writer": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-changelog-writer": "^7.0.0",
+        "conventional-commits-filter": "^4.0.0",
+        "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^6.0.0",
-        "import-from": "^4.0.0",
-        "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
-        "read-pkg-up": "^7.0.0"
+        "get-stream": "^7.0.0",
+        "import-from-esm": "^1.0.3",
+        "into-stream": "^7.0.0",
+        "lodash-es": "^4.17.21",
+        "read-pkg-up": "^11.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=20.8.1"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+      "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1619,6 +1883,32 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1747,13 +2037,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
@@ -1770,13 +2053,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1966,10 +2242,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansicolors": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2011,26 +2287,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -2063,16 +2319,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/axios": {
       "version": "1.2.1",
@@ -2219,9 +2465,9 @@
       "license": "MIT"
     },
     "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -2334,34 +2580,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001669",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
@@ -2382,20 +2600,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/cardinal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansicolors": "~0.3.2",
-        "redeyed": "~2.1.0"
-      },
-      "bin": {
-        "cdl": "bin/cdl.js"
-      }
     },
     "node_modules/cartesian-product": {
       "version": "2.1.2",
@@ -2462,6 +2666,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cli-table3": {
@@ -2582,86 +2839,79 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
+      "integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "conventional-commits-filter": "^2.0.7",
-        "dateformat": "^3.0.0",
+        "conventional-commits-filter": "^4.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "semver": "^6.0.0",
-        "split": "^1.0.0",
-        "through2": "^4.0.0"
+        "meow": "^12.0.1",
+        "semver": "^7.5.2",
+        "split2": "^4.0.0"
       },
       "bin": {
-        "conventional-changelog-writer": "cli.js"
+        "conventional-changelog-writer": "cli.mjs"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-commits-filter": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-text-path": "^1.0.1",
-        "JSONStream": "^1.0.4",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
       },
       "bin": {
-        "conventional-commits-parser": "cli.js"
+        "conventional-commits-parser": "cli.mjs"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/convert-source-map": {
@@ -2679,20 +2929,50 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/create-jest": {
@@ -2733,13 +3013,32 @@
       }
     },
     "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dashdash": {
@@ -2753,16 +3052,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2791,43 +3080,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -2872,45 +3124,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2919,13 +3132,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3086,6 +3292,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -3101,18 +3314,184 @@
       }
     },
     "node_modules/env-ci": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
-      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.1.0.tgz",
+      "integrity": "sha512-Z8dnwSDbV1XYM9SBF2J0GcNVvmfmfh3a49qddGIROhBoVro6MZVTji15z/sJbQ2ko2ei8n988EU1wzoLU/tF+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "execa": "^5.0.0",
-        "fromentries": "^1.3.2",
-        "java-properties": "^1.0.0"
+        "execa": "^8.0.0",
+        "java-properties": "^1.0.2"
       },
       "engines": {
-        "node": ">=10.17"
+        "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/env-ci/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/env-ci/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/env-ci/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/env-ci/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -3653,29 +4032,19 @@
       }
     },
     "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "escape-string-regexp": "^1.0.5"
+        "is-unicode-supported": "^2.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3735,17 +4104,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-versions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+      "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver-regex": "^3.1.2"
+        "semver-regex": "^4.0.5",
+        "super-regex": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3851,41 +4234,19 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -3918,6 +4279,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/functional-red-black-tree": {
@@ -4091,21 +4465,21 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4119,6 +4493,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -4150,16 +4550,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4183,14 +4573,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/hook-std": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
-      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+      "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/hosted-git-info": {
@@ -4371,17 +4774,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+    "node_modules/import-from-esm": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
+      "integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12.2"
+      "dependencies": {
+        "debug": "^4.3.4",
+        "import-meta-resolve": "^4.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=16.20"
       }
     },
     "node_modules/import-local": {
@@ -4404,6 +4808,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4422,6 +4837,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -4559,9 +4987,9 @@
       }
     },
     "node_modules/into-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
+      "integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4569,7 +4997,7 @@
         "p-is-promise": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4671,44 +5099,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -4725,16 +5126,29 @@
       }
     },
     "node_modules/is-text-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -4758,9 +5172,9 @@
       "license": "MIT"
     },
     "node_modules/issue-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
-      "integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
+      "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4771,7 +5185,7 @@
         "lodash.uniqby": "^4.7.0"
       },
       "engines": {
-        "node": ">=10.13"
+        "node": "^18.17 || >=20.6.1"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5621,16 +6035,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5732,6 +6136,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -5762,13 +6173,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.ismatch": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -5865,64 +6269,68 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/marked-terminal": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
-      "integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.2.1.tgz",
+      "integrity": "sha512-rQ1MoMFXZICWNsKMiiHwP/Z+92PLKskTPXj+e7uwXmuMPkNn7iTqC+IvDekVm1MPeC9wYQeLxeFaOvudRR/XbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^6.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^5.2.0",
-        "cli-table3": "^0.6.3",
-        "node-emoji": "^1.11.0",
-        "supports-hyperlinks": "^2.3.0"
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.3.0",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.1.3",
+        "supports-hyperlinks": "^3.1.0"
       },
       "engines": {
-        "node": ">=14.13.1 || >=16.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+        "marked": ">=1 <15"
       }
     },
     "node_modules/marked-terminal/node_modules/ansi-escapes": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/marked-terminal/node_modules/chalk": {
@@ -5939,92 +6347,17 @@
       }
     },
     "node_modules/meow": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=16.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/meow/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6058,16 +6391,19 @@
       }
     },
     "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {
@@ -6101,16 +6437,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6134,36 +6460,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/modify-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6202,34 +6515,19 @@
       }
     },
     "node_modules/node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+      "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node": ">=18"
       }
     },
     "node_modules/node-int64": {
@@ -6280,39 +6578,39 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm": {
-      "version": "8.19.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
-      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.0.tgz",
+      "integrity": "sha512-ZanDioFylI9helNhl2LNd+ErmVD+H5I53ry41ixlLyCBgkuYb+58CvbAp99hW+zr5L9W4X7CchSoeqKdngOLSw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
-        "@npmcli/ci-detect",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
+        "@npmcli/redact",
         "@npmcli/run-script",
+        "@sigstore/tuf",
         "abbrev",
         "archy",
         "cacache",
         "chalk",
-        "chownr",
+        "ci-info",
         "cli-columns",
-        "cli-table3",
-        "columnify",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -6337,11 +6635,10 @@
         "minimatch",
         "minipass",
         "minipass-pipeline",
-        "mkdirp",
-        "mkdirp-infer-owner",
         "ms",
         "node-gyp",
         "nopt",
+        "normalize-package-data",
         "npm-audit-report",
         "npm-install-checks",
         "npm-package-arg",
@@ -6349,20 +6646,16 @@
         "npm-profile",
         "npm-registry-fetch",
         "npm-user-validate",
-        "npmlog",
-        "opener",
         "p-map",
         "pacote",
         "parse-conflict-json",
         "proc-log",
         "qrcode-terminal",
         "read",
-        "read-package-json",
-        "read-package-json-fast",
-        "readdir-scoped-modules",
-        "rimraf",
         "semver",
+        "spdx-expression-parse",
         "ssri",
+        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
@@ -6376,89 +6669,86 @@
       "workspaces": [
         "docs",
         "smoke-tests",
+        "mock-globals",
+        "mock-registry",
         "workspaces/*"
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.6.3",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.2.1",
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^4.2.1",
-        "abbrev": "~1.1.1",
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/config": "^9.0.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/promise-spawn": "^8.0.1",
+        "@npmcli/redact": "^3.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "@sigstore/tuf": "^2.3.4",
+        "abbrev": "^3.0.0",
         "archy": "~1.0.0",
-        "cacache": "^16.1.3",
-        "chalk": "^4.1.2",
-        "chownr": "^2.0.0",
+        "cacache": "^19.0.1",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.2",
-        "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.12",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.2.1",
-        "ini": "^3.0.1",
-        "init-package-json": "^3.0.2",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.4",
-        "libnpmdiff": "^4.0.5",
-        "libnpmexec": "^4.0.14",
-        "libnpmfund": "^3.0.5",
-        "libnpmhook": "^8.0.4",
-        "libnpmorg": "^4.0.4",
-        "libnpmpack": "^4.1.3",
-        "libnpmpublish": "^6.0.5",
-        "libnpmsearch": "^5.0.4",
-        "libnpmteam": "^4.0.4",
-        "libnpmversion": "^3.0.7",
-        "make-fetch-happen": "^10.2.0",
-        "minimatch": "^5.1.0",
-        "minipass": "^3.1.6",
+        "fastest-levenshtein": "^1.0.16",
+        "fs-minipass": "^3.0.3",
+        "glob": "^10.4.5",
+        "graceful-fs": "^4.2.11",
+        "hosted-git-info": "^8.0.0",
+        "ini": "^5.0.0",
+        "init-package-json": "^7.0.1",
+        "is-cidr": "^5.1.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "libnpmaccess": "^9.0.0",
+        "libnpmdiff": "^7.0.0",
+        "libnpmexec": "^9.0.0",
+        "libnpmfund": "^6.0.0",
+        "libnpmhook": "^11.0.0",
+        "libnpmorg": "^7.0.0",
+        "libnpmpack": "^8.0.0",
+        "libnpmpublish": "^10.0.0",
+        "libnpmsearch": "^8.0.0",
+        "libnpmteam": "^7.0.0",
+        "libnpmversion": "^7.0.0",
+        "make-fetch-happen": "^14.0.1",
+        "minimatch": "^9.0.5",
+        "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.1.0",
-        "nopt": "^6.0.0",
-        "npm-audit-report": "^3.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.1.0",
-        "npm-pick-manifest": "^7.0.2",
-        "npm-profile": "^6.2.0",
-        "npm-registry-fetch": "^13.3.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.2",
-        "opener": "^1.5.2",
+        "node-gyp": "^10.2.0",
+        "nopt": "^8.0.0",
+        "normalize-package-data": "^7.0.0",
+        "npm-audit-report": "^6.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-profile": "^11.0.1",
+        "npm-registry-fetch": "^18.0.1",
+        "npm-user-validate": "^3.0.0",
         "p-map": "^4.0.0",
-        "pacote": "^13.6.2",
-        "parse-conflict-json": "^2.0.2",
-        "proc-log": "^2.0.1",
+        "pacote": "^19.0.0",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^5.0.2",
-        "read-package-json-fast": "^2.0.3",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.1",
-        "tar": "^6.1.11",
+        "read": "^4.0.0",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^12.0.0",
+        "supports-color": "^9.4.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "treeverse": "^2.0.0",
-        "validate-npm-package-name": "^4.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.1"
+        "treeverse": "^3.0.0",
+        "validate-npm-package-name": "^6.0.0",
+        "which": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-normalize-package-bin": {
@@ -6481,21 +6771,84 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
+    "node_modules/npm/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.3",
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
@@ -6503,306 +6856,516 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/metavuln-calculator": "^3.0.1",
-        "@npmcli/move-file": "^2.0.0",
-        "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/query": "^1.2.0",
-        "@npmcli/run-script": "^4.1.3",
-        "bin-links": "^3.0.3",
-        "cacache": "^16.1.3",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^5.2.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "json-stringify-nice": "^1.1.4",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^6.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.0",
-        "npm-pick-manifest": "^7.0.2",
-        "npm-registry-fetch": "^13.0.0",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.6.1",
-        "parse-conflict-json": "^2.0.1",
-        "proc-log": "^2.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.0",
-        "treeverse": "^2.0.0",
-        "walk-up-path": "^1.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "4.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/map-workspaces": "^2.0.2",
-        "ini": "^3.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^6.0.0",
-        "proc-log": "^2.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "semver": "^7.3.5",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^3.0.0",
-        "lru-cache": "^7.4.4",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^7.0.0",
-        "proc-log": "^2.0.0",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "installed-package-contents": "index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^8.0.1",
-        "minimatch": "^5.0.1",
-        "read-package-json-fast": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^16.0.0",
-        "json-parse-even-better-errors": "^2.3.1",
-        "pacote": "^13.0.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+    "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "infer-owner": "^1.0.4"
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/metavuln-calculator": "^8.0.0",
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/query": "^4.0.0",
+        "@npmcli/redact": "^3.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "bin-links": "^5.0.0",
+        "cacache": "^19.0.1",
+        "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^10.2.2",
+        "minimatch": "^9.0.4",
+        "nopt": "^8.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "pacote": "^19.0.0",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "proggy": "^3.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "read-package-json-fast": "^4.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^12.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^3.0.1"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/config": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/package-json": "^6.0.1",
+        "ci-info": "^4.0.0",
+        "ini": "^5.0.0",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "walk-up-path": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/git": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^8.0.0",
+        "ini": "^5.0.0",
+        "lru-cache": "^10.0.1",
+        "npm-pick-manifest": "^10.0.0",
+        "proc-log": "^5.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^19.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "pacote": "^19.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "normalize-package-data": "^7.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+      "version": "8.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "1.2.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^9.1.0",
-        "postcss-selector-parser": "^6.0.10",
-        "semver": "^7.3.7"
+        "postcss-selector-parser": "^6.1.2"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "4.2.1",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "which": "^2.0.2"
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "node-gyp": "^10.0.0",
+        "proc-log": "^5.0.0",
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/@tootallnate/once": {
+    "node_modules/npm/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "2.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.3.2"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "2.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
+      "version": "2.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/cacache": {
+      "version": "18.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
+      "version": "13.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/minipass-fetch": {
+      "version": "3.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/ssri": {
+      "version": "10.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-filename": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-slug": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "2.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "tuf-js": "^2.2.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.3.2"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "1.1.1",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/agent-base": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
+      "license": "ISC",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.2.1",
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/aggregate-error": {
@@ -6828,15 +7391,12 @@
       }
     },
     "node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -6854,25 +7414,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -6880,38 +7421,31 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "3.0.3",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^5.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-normalize-package-bin": "^2.0.0",
-        "read-cmd-shim": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "write-file-atomic": "^4.0.0"
+        "cmd-shim": "^7.0.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "read-cmd-shim": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
@@ -6923,55 +7457,111 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/builtins": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.1.3",
+      "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
+        "@npmcli/fs": "^4.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
+    "node_modules/npm/node_modules/cacache/node_modules/chownr": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/p-map": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/tar": {
+      "version": "7.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/chalk": {
+      "version": "5.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -6986,16 +7576,31 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "4.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "ip-regex": "^4.1.0"
+        "ip-regex": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/clean-stack": {
@@ -7020,40 +7625,13 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "5.0.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/color-convert": {
@@ -7074,45 +7652,40 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/columnify": {
-      "version": "1.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/concat-map": {
-      "version": "0.0.1",
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "7.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
-    "node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
+    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
@@ -7127,7 +7700,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.3.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7149,57 +7722,20 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/debuglog": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
-    "node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/npm/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7232,117 +7768,85 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
+    "node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "Apache-2.0"
     },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "2.1.0",
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 4.9.1"
       }
     },
-    "node_modules/npm/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/gauge": {
-      "version": "4.0.4",
+    "node_modules/npm/node_modules/foreground-child": {
+      "version": "3.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "8.0.3",
+      "version": "10.4.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": ">=12"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
+      "version": "4.2.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.2.1",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^7.5.1"
+        "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -7352,39 +7856,29 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
@@ -7401,15 +7895,15 @@
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "5.0.1",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^5.0.1"
+        "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -7430,92 +7924,68 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "3.0.2",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^9.0.1",
-        "promzard": "^0.3.0",
-        "read": "^1.0.7",
-        "read-package-json": "^5.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "npm-package-arg": "^12.0.0",
+        "promzard": "^2.0.0",
+        "read": "^4.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^4.0.0"
+        "validate-npm-package-name": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^3.1.1"
+        "cidr-regex": "^4.1.1"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
@@ -7539,11 +8009,35 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
+    "node_modules/npm/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -7564,223 +8058,213 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "5.1.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.4.1",
+      "version": "5.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "6.0.4",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^2.0.0",
-        "minipass": "^3.1.1",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-package-arg": "^12.0.0",
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "4.0.5",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/disparity-colors": "^2.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "binary-extensions": "^2.2.0",
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
-        "minimatch": "^5.0.1",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.6.1",
-        "tar": "^6.1.0"
+        "minimatch": "^9.0.4",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0",
+        "tar": "^6.2.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.14",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.6.3",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/fs": "^2.1.1",
-        "@npmcli/run-script": "^4.2.0",
-        "chalk": "^4.1.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.6.1",
-        "proc-log": "^2.0.0",
-        "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2",
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0",
+        "proc-log": "^5.0.0",
+        "read": "^4.0.0",
+        "read-package-json-fast": "^4.0.0",
         "semver": "^7.3.7",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.5",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.6.3"
+        "@npmcli/arborist": "^8.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "8.0.4",
+      "version": "11.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "4.0.4",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "4.1.3",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/run-script": "^4.1.3",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.6.1"
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.5",
+      "version": "10.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "normalize-package-data": "^4.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0",
+        "ci-info": "^4.0.0",
+        "normalize-package-data": "^7.0.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.7",
-        "ssri": "^9.0.0"
+        "sigstore": "^2.2.0",
+        "ssri": "^12.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "5.0.4",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "4.0.4",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.7",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/run-script": "^4.1.3",
-        "json-parse-even-better-errors": "^2.3.1",
-        "proc-log": "^2.0.0",
+        "@npmcli/git": "^6.0.1",
+        "@npmcli/run-script": "^9.0.1",
+        "json-parse-even-better-errors": "^4.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.13.2",
+      "version": "10.4.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.2.1",
+      "version": "14.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
+        "ssri": "^12.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "5.1.0",
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7788,48 +8272,61 @@
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.3.4",
+      "version": "7.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.1.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.1.6",
+        "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
@@ -7844,14 +8341,16 @@
         "node": ">= 8"
       }
     },
-    "node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
+    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -7866,6 +8365,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
       "dev": true,
@@ -7873,6 +8384,18 @@
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -7891,6 +8414,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
       "dev": true,
@@ -7903,20 +8438,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
       "dev": true,
@@ -7924,10 +8445,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "0.0.8",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
@@ -7939,151 +8463,274 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^10.3.10",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
+        "make-fetch-happen": "^13.0.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^4.1.0",
         "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
+        "tar": "^6.2.1",
+        "which": "^4.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
-      "version": "7.2.3",
+    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/agent": {
+      "version": "2.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
-      "version": "3.1.2",
+    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": "*"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^1.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+    "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
+      "version": "18.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/isexe": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
+      "version": "13.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
+      "version": "3.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
+      "version": "7.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
+      "version": "10.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/which": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt/node_modules/abbrev": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "5.0.0",
+      "version": "7.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8091,149 +8738,112 @@
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "9.1.0",
+      "version": "12.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "proc-log": "^2.0.1",
+        "hosted-git-info": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^4.0.0"
+        "validate-npm-package-name": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.1.3",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^8.0.1",
-        "ignore-walk": "^5.0.1",
-        "npm-bundled": "^2.0.0",
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
+        "ignore-walk": "^7.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "7.0.2",
+      "version": "10.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-install-checks": "^5.0.0",
-        "npm-normalize-package-bin": "^2.0.0",
-        "npm-package-arg": "^9.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "6.2.1",
+      "version": "11.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0"
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.3.1",
+      "version": "18.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "make-fetch-happen": "^10.0.6",
-        "minipass": "^3.1.6",
-        "minipass-fetch": "^2.0.3",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^9.0.1",
-        "proc-log": "^2.0.0"
+        "@npmcli/redact": "^3.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^14.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^12.0.0",
+        "proc-log": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "1.0.1",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/p-map": {
@@ -8251,66 +8861,84 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/npm/node_modules/pacote": {
-      "version": "13.6.2",
+      "version": "19.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "@npmcli/run-script": "^4.1.0",
-        "cacache": "^16.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.6",
-        "mkdirp": "^1.0.4",
-        "npm-package-arg": "^9.0.0",
-        "npm-packlist": "^5.1.0",
-        "npm-pick-manifest": "^7.0.0",
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0",
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^5.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
+        "sigstore": "^2.2.0",
+        "ssri": "^12.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
-        "pacote": "lib/bin.js"
+        "pacote": "bin/index.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "2.0.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1",
-        "just-diff": "^5.0.1",
+        "json-parse-even-better-errors": "^4.0.0",
+        "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/path-is-absolute": {
-      "version": "1.0.1",
+    "node_modules/npm/node_modules/path-key": {
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
+      "version": "6.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8323,12 +8951,21 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "2.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/proggy": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -8341,7 +8978,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8369,12 +9006,15 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "0.3.0",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "1"
+        "read": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -8386,87 +9026,37 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "1.0.7",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "3.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^8.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "normalize-package-data": "^4.0.0",
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.3",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
+        "json-parse-even-better-errors": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/retry": {
@@ -8479,81 +9069,19 @@
       }
     },
     "node_modules/npm/node_modules/rimraf": {
-      "version": "3.0.2",
+      "version": "5.0.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8563,13 +9091,10 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8577,29 +9102,55 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/set-blocking": {
+    "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.7",
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore": {
+      "version": "2.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "@sigstore/sign": "^2.3.2",
+        "@sigstore/tuf": "^2.3.4",
+        "@sigstore/verify": "^1.2.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -8612,35 +9163,35 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.7.0",
+      "version": "2.8.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
+        "agent-base": "^7.1.1",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -8649,13 +9200,7 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
+    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
@@ -8665,34 +9210,62 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.11",
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0"
+      "license": "CC-BY-3.0"
     },
-    "node_modules/npm/node_modules/ssri": {
-      "version": "9.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/spdx-license-ids": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/npm/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/npm/node_modules/ssri": {
+      "version": "12.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "dev": true,
       "inBundle": true,
@@ -8718,33 +9291,79 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
+    "node_modules/npm/node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "9.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.11",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -8760,28 +9379,154 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "2.0.1",
+    "node_modules/npm/node_modules/tuf-js": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "2.0.1",
+        "debug": "^4.3.4",
+        "make-fetch-happen": "^13.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/agent": {
+      "version": "2.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^3.0.0"
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/unique-slug": {
+    "node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/cacache": {
+      "version": "18.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/make-fetch-happen": {
+      "version": "13.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/minipass-fetch": {
+      "version": "3.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/proc-log": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/ssri": {
+      "version": "10.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/unique-filename": {
       "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/unique-slug": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8789,7 +9534,31 @@
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-filename": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/unique-slug": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -8808,74 +9577,166 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
+    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "defaults": "^1.0.3"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/which": {
-      "version": "2.0.2",
+    "node_modules/npm/node_modules/validate-npm-package-name": {
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/npm/node_modules/wrappy": {
-      "version": "1.0.2",
+    "node_modules/npm/node_modules/walk-up-path": {
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/which": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/which/node_modules/isexe": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "4.0.2",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -8883,6 +9744,16 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -8929,29 +9800,32 @@
       }
     },
     "node_modules/p-each-series": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+      "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+      "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-map": "^2.0.0"
+        "p-map": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-is-promise": {
@@ -9010,13 +9884,16 @@
       }
     },
     "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
+      "integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-reduce": {
@@ -9070,6 +9947,43 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -9338,6 +10252,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+      "integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9424,18 +10354,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -9462,16 +10380,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -9549,58 +10457,168 @@
         "npm-normalize-package-bin": "^1.0.0"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
+      "integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
+      "deprecated": "Renamed to read-package-up",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "index-to-position": "^0.1.2",
+        "type-fest": "^4.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/readable-stream": {
@@ -9645,30 +10663,6 @@
         "dezalgo": "^1.0.0",
         "graceful-fs": "^4.1.2",
         "once": "^1.3.0"
-      }
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/redeyed": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esprima": "~4.0.0"
       }
     },
     "node_modules/regexpp": {
@@ -9869,84 +10863,259 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
-      "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
+      "version": "23.1.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.1.1.tgz",
+      "integrity": "sha512-qqJDBhbtHsjUEMsojWKGuL5lQFCJuPtiXKEIlFKyTzDDGTAE/oyvznaP8GeOr5PvcqBJ6LQz4JCENWPLeehSpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@semantic-release/commit-analyzer": "^9.0.2",
-        "@semantic-release/error": "^3.0.0",
-        "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^9.0.0",
-        "@semantic-release/release-notes-generator": "^10.0.0",
-        "aggregate-error": "^3.0.0",
-        "cosmiconfig": "^7.0.0",
+        "@semantic-release/commit-analyzer": "^12.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "@semantic-release/github": "^10.0.0",
+        "@semantic-release/npm": "^12.0.0",
+        "@semantic-release/release-notes-generator": "^13.0.0",
+        "aggregate-error": "^5.0.0",
+        "cosmiconfig": "^9.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^5.0.0",
-        "execa": "^5.0.0",
-        "figures": "^3.0.0",
-        "find-versions": "^4.0.0",
+        "env-ci": "^11.0.0",
+        "execa": "^9.0.0",
+        "figures": "^6.0.0",
+        "find-versions": "^6.0.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
-        "hook-std": "^2.0.0",
-        "hosted-git-info": "^4.0.0",
-        "lodash": "^4.17.21",
-        "marked": "^4.0.10",
-        "marked-terminal": "^5.0.0",
+        "hook-std": "^3.0.0",
+        "hosted-git-info": "^7.0.0",
+        "import-from-esm": "^1.3.1",
+        "lodash-es": "^4.17.21",
+        "marked": "^12.0.0",
+        "marked-terminal": "^7.0.0",
         "micromatch": "^4.0.2",
-        "p-each-series": "^2.1.0",
-        "p-reduce": "^2.0.0",
-        "read-pkg-up": "^7.0.0",
+        "p-each-series": "^3.0.0",
+        "p-reduce": "^3.0.0",
+        "read-package-up": "^11.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^3.1.1",
+        "semver-diff": "^4.0.0",
         "signale": "^1.2.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.5.1"
       },
       "bin": {
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": ">=16 || ^14.17"
+        "node": ">=20.8.1"
       }
     },
-    "node_modules/semantic-release/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+    "node_modules/semantic-release/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/clean-stack": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+      "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/execa": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.1.tgz",
+      "integrity": "sha512-QY5PPtSonnGwhhHDNI7+3RvY285c7iuJFFB+lU+oEzMY/gEGJ808owqJsrr8Otd1E/x07po1LkUBmdAc5duPAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/human-signals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/p-reduce": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+      "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/resolve-from": {
@@ -9959,30 +11128,43 @@
         "node": ">=8"
       }
     },
-    "node_modules/semantic-release/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+    "node_modules/semantic-release/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
-    "node_modules/semantic-release/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+    "node_modules/semantic-release/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver": {
@@ -9998,36 +11180,29 @@
       }
     },
     "node_modules/semver-diff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+      "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^6.3.0"
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10176,6 +11351,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10278,27 +11466,14 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -10446,19 +11621,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10489,6 +11651,23 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/super-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
+      "integrity": "sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10503,9 +11682,9 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
+      "integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10513,7 +11692,10 @@
         "supports-color": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -10571,43 +11753,55 @@
       "license": "MIT"
     },
     "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tempy/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10629,13 +11823,16 @@
       }
     },
     "node_modules/text-extensions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/text-table": {
@@ -10645,6 +11842,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -10652,14 +11872,20 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "3"
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tmpl": {
@@ -10733,13 +11959,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/traverse": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
@@ -10751,16 +11970,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tsc-publish": {
@@ -10853,23 +12062,49 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "crypto-random-string": "^2.0.0"
+        "crypto-random-string": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -10925,11 +12160,14 @@
       }
     },
     "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -11008,24 +12246,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -11127,16 +12347,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -11184,6 +12394,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint:fix": "eslint . --fix",
     "eslint:check": "eslint . --cache",
     "lint": "npm run eslint:check",
-    "lint-fix": "npm run eslint:fix",
+    "lint-fix": "npm run eslint:fix && npm run tslint:fix",
     "build": "tsc && cp package.json dist/",
     "prepublishOnly": "npm run build",
     "postversion": "tsc-publish --no-checks --dry-run",
@@ -35,12 +35,12 @@
   "dependencies": {
     "@types/node": "^14.0.0",
     "extend": "^3.0.2",
-    "ibm-cloud-sdk-core": "^5.0.0",
+    "ibm-cloud-sdk-core": "^5.1.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@ibm-cloud/sdk-test-utilities": "^1.0.0",
-    "@semantic-release/changelog": "6.0.1",
+    "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "axios": "1.2.1",
     "dotenv": "^8.2.0",
@@ -53,7 +53,7 @@
     "jest": "^29.3.1",
     "nock": "^13.2.4",
     "prettier": "^2.3.0",
-    "semantic-release": "^19.0.3",
+    "semantic-release": "^23.1.1",
     "tsc-publish": "^0.5.2",
     "typescript": "~4.9.4"
   },

--- a/test/unit/vpc.v1.test.js
+++ b/test/unit/vpc.v1.test.js
@@ -2148,9 +2148,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/vpcs/testString/routes';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"routes":[{"action":"delegate","advertise":false,"created_at":"2019-01-01T12:00:00.000Z","creator":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpn:ddf51bec-3424-11e8-b467-0ed5f89f718b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpn_gateways/ddf51bec-3424-11e8-b467-0ed5f89f718b","id":"ddf51bec-3424-11e8-b467-0ed5f89f718b","name":"my-vpn-gateway","resource_type":"vpn_gateway"},"destination":"192.168.3.0/24","href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/8e454ead-0db7-48ac-9a8b-2698d8c470a7/routes/1a15dca5-7e33-45e1-b7c5-bc690e569531","id":"1a15dca5-7e33-45e1-b7c5-bc690e569531","lifecycle_state":"stable","name":"my-route-1","next_hop":{"address":"192.168.3.4"},"origin":"service","priority":1,"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"routes":[{"action":"delegate","advertise":false,"created_at":"2019-01-01T12:00:00.000Z","creator":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpn:ddf51bec-3424-11e8-b467-0ed5f89f718b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpn_gateways/ddf51bec-3424-11e8-b467-0ed5f89f718b","id":"ddf51bec-3424-11e8-b467-0ed5f89f718b","name":"my-vpn-gateway","resource_type":"vpn_gateway"},"destination":"192.168.3.0/24","href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/8e454ead-0db7-48ac-9a8b-2698d8c470a7/routing_tables/6885e83f-03b2-4603-8a86-db2a0f55c840/routes/1a15dca5-7e33-45e1-b7c5-bc690e569531","id":"1a15dca5-7e33-45e1-b7c5-bc690e569531","lifecycle_state":"stable","name":"my-route-1","next_hop":{"address":"192.168.3.4"},"origin":"service","priority":1,"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"routes":[{"action":"delegate","advertise":false,"created_at":"2019-01-01T12:00:00.000Z","creator":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpn:ddf51bec-3424-11e8-b467-0ed5f89f718b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpn_gateways/ddf51bec-3424-11e8-b467-0ed5f89f718b","id":"ddf51bec-3424-11e8-b467-0ed5f89f718b","name":"my-vpn-gateway","resource_type":"vpn_gateway"},"destination":"192.168.3.0/24","href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/8e454ead-0db7-48ac-9a8b-2698d8c470a7/routes/1a15dca5-7e33-45e1-b7c5-bc690e569531","id":"1a15dca5-7e33-45e1-b7c5-bc690e569531","lifecycle_state":"stable","name":"my-route-1","next_hop":{"address":"192.168.3.4"},"origin":"service","priority":1,"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"routes":[{"action":"delegate","advertise":false,"created_at":"2019-01-01T12:00:00.000Z","creator":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpn:ddf51bec-3424-11e8-b467-0ed5f89f718b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpn_gateways/ddf51bec-3424-11e8-b467-0ed5f89f718b","id":"ddf51bec-3424-11e8-b467-0ed5f89f718b","name":"my-vpn-gateway","resource_type":"vpn_gateway"},"destination":"192.168.3.0/24","href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/8e454ead-0db7-48ac-9a8b-2698d8c470a7/routing_tables/6885e83f-03b2-4603-8a86-db2a0f55c840/routes/1a15dca5-7e33-45e1-b7c5-bc690e569531","id":"1a15dca5-7e33-45e1-b7c5-bc690e569531","lifecycle_state":"stable","name":"my-route-1","next_hop":{"address":"192.168.3.4"},"origin":"service","priority":1,"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -5522,8 +5522,8 @@ describe('VpcV1', () => {
         // Construct the params object for operation updateSubnetReservedIp
         const subnetId = 'testString';
         const id = 'testString';
-        const autoDelete = false;
-        const name = 'my-reserved-ip';
+        const autoDelete = true;
+        const name = 'my-reserved-ip-updated';
         const updateSubnetReservedIpParams = {
           subnetId,
           id,
@@ -7002,9 +7002,11 @@ describe('VpcV1', () => {
         // Construct the params object for operation listKeys
         const start = 'testString';
         const limit = 50;
+        const resourceGroupId = 'testString';
         const listKeysParams = {
           start,
           limit,
+          resourceGroupId,
         };
 
         const listKeysResult = vpcService.listKeys(listKeysParams);
@@ -7025,6 +7027,7 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
         expect(mockRequestOptions.qs.start).toEqual(start);
         expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs['resource_group.id']).toEqual(resourceGroupId);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
@@ -7068,9 +7071,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/keys';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"keys":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::key:82679077-ac3b-4c10-be16-63e9c21f0f45","fingerprint":"SHA256:yxavE4CIOL2NlsqcurRO3xGjkP6m/0mp8ugojH5yxlY","href":"https://us-south.iaas.cloud.ibm.com/v1/keys/82679077-ac3b-4c10-be16-63e9c21f0f45","id":"82679077-ac3b-4c10-be16-63e9c21f0f45","length":2048,"name":"my-key-1","public_key":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"type":"ed25519"}],"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"keys":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::key:r006-82679077-ac3b-4c10-be16-63e9c21f0f45","fingerprint":"SHA256:yxavE4CIOL2NlsqcurRO3xGjkP6m/0mp8ugojH5yxlY","href":"https://us-south.iaas.cloud.ibm.com/v1/keys/r006-82679077-ac3b-4c10-be16-63e9c21f0f45","id":"r006-82679077-ac3b-4c10-be16-63e9c21f0f45","length":2048,"name":"my-key-1","public_key":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"type":"ed25519"}],"limit":1}';
       const mockPagerResponse2 =
-        '{"total_count":2,"keys":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::key:82679077-ac3b-4c10-be16-63e9c21f0f45","fingerprint":"SHA256:yxavE4CIOL2NlsqcurRO3xGjkP6m/0mp8ugojH5yxlY","href":"https://us-south.iaas.cloud.ibm.com/v1/keys/82679077-ac3b-4c10-be16-63e9c21f0f45","id":"82679077-ac3b-4c10-be16-63e9c21f0f45","length":2048,"name":"my-key-1","public_key":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"type":"ed25519"}],"limit":1}';
+        '{"total_count":2,"keys":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::key:r006-82679077-ac3b-4c10-be16-63e9c21f0f45","fingerprint":"SHA256:yxavE4CIOL2NlsqcurRO3xGjkP6m/0mp8ugojH5yxlY","href":"https://us-south.iaas.cloud.ibm.com/v1/keys/r006-82679077-ac3b-4c10-be16-63e9c21f0f45","id":"r006-82679077-ac3b-4c10-be16-63e9c21f0f45","length":2048,"name":"my-key-1","public_key":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDGe50Bxa5T5NDddrrtbx2Y4/VGbiCgXqnBsYToIUKoFSHTQl5IX3PasGnneKanhcLwWz5M5MoCRvhxTp66NKzIfAz7r+FX9rxgR+ZgcM253YAqOVeIpOU408simDZKriTlN8kYsXL7P34tsWuAJf4MgZtJAQxous/2byetpdCv8ddnT4X3ltOg9w+LqSCPYfNivqH00Eh7S1Ldz7I8aw5WOp5a+sQFP/RbwfpwHp+ny7DfeIOokcuI42tJkoBn7UsLTVpCSmXr2EDRlSWe/1M/iHNRBzaT3CK0+SwZWd2AEjePxSnWKNGIEUJDlUYp7hKhiQcgT5ZAnWU121oc5En","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"type":"ed25519"}],"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -7089,6 +7092,7 @@ describe('VpcV1', () => {
       test('getNext()', async () => {
         const params = {
           limit: 10,
+          resourceGroupId: 'testString',
         };
         const allResults = [];
         const pager = new VpcV1.KeysPager(vpcService, params);
@@ -7104,6 +7108,7 @@ describe('VpcV1', () => {
       test('getAll()', async () => {
         const params = {
           limit: 10,
+          resourceGroupId: 'testString',
         };
         const pager = new VpcV1.KeysPager(vpcService, params);
         const allResults = await pager.getAll();
@@ -7701,7 +7706,34 @@ describe('VpcV1', () => {
         host_failure: 'restart',
       };
 
-      // TrustedProfileIdentityTrustedProfileById
+      // ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPPrototypeClusterNetworkInterfacePrimaryIPContext
+      const clusterNetworkInterfacePrimaryIpPrototypeModel = {
+        address: '10.0.0.5',
+        auto_delete: false,
+        name: 'my-cluster-network-subnet-reserved-ip',
+      };
+
+      // ClusterNetworkSubnetIdentityById
+      const clusterNetworkSubnetIdentityModel = {
+        id: '0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930',
+      };
+
+      // InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceInstanceClusterNetworkInterfacePrototypeInstanceClusterNetworkAttachment
+      const instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel = {
+        auto_delete: false,
+        name: 'my-cluster-network-interface',
+        primary_ip: clusterNetworkInterfacePrimaryIpPrototypeModel,
+        subnet: clusterNetworkSubnetIdentityModel,
+      };
+
+      // InstanceClusterNetworkAttachmentPrototypeInstanceContext
+      const instanceClusterNetworkAttachmentPrototypeInstanceContextModel = {
+        cluster_network_interface:
+          instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel,
+        name: 'my-instance-network-attachment',
+      };
+
+      // TrustedProfileIdentityById
       const trustedProfileIdentityModel = {
         id: 'Profile-9fd84246-7df4-4667-94e4-8ecde51d5ac5',
       };
@@ -7736,7 +7768,7 @@ describe('VpcV1', () => {
 
       // ReservationIdentityById
       const reservationIdentityModel = {
-        id: '7187-ba49df72-37b8-43ac-98da-f8e029de0e63',
+        id: '0717-ba49df72-37b8-43ac-98da-f8e029de0e63',
       };
 
       // InstanceReservationAffinityPrototype
@@ -7832,7 +7864,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -7889,6 +7921,9 @@ describe('VpcV1', () => {
       // InstanceTemplatePrototypeInstanceTemplateBySourceTemplate
       const instanceTemplatePrototypeModel = {
         availability_policy: instanceAvailabilityPolicyPrototypeModel,
+        cluster_network_attachments: [
+          instanceClusterNetworkAttachmentPrototypeInstanceContextModel,
+        ],
         confidential_compute_mode: 'disabled',
         default_trusted_profile: instanceDefaultTrustedProfilePrototypeModel,
         enable_secure_boot: true,
@@ -8273,6 +8308,10 @@ describe('VpcV1', () => {
         const limit = 50;
         const resourceGroupId = 'testString';
         const name = 'my-name';
+        const clusterNetworkId = 'testString';
+        const clusterNetworkCrn =
+          'crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:r010-82b8c783-15d6-4a51-95bf-0b4649d3ef94';
+        const clusterNetworkName = 'my-cluster-network';
         const dedicatedHostId = 'testString';
         const dedicatedHostCrn =
           'crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:1e09281b-f177-46fb-baf1-bc152b2e391a';
@@ -8294,6 +8333,9 @@ describe('VpcV1', () => {
           limit,
           resourceGroupId,
           name,
+          clusterNetworkId,
+          clusterNetworkCrn,
+          clusterNetworkName,
           dedicatedHostId,
           dedicatedHostCrn,
           dedicatedHostName,
@@ -8328,6 +8370,9 @@ describe('VpcV1', () => {
         expect(mockRequestOptions.qs.limit).toEqual(limit);
         expect(mockRequestOptions.qs['resource_group.id']).toEqual(resourceGroupId);
         expect(mockRequestOptions.qs.name).toEqual(name);
+        expect(mockRequestOptions.qs['cluster_network.id']).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.qs['cluster_network.crn']).toEqual(clusterNetworkCrn);
+        expect(mockRequestOptions.qs['cluster_network.name']).toEqual(clusterNetworkName);
         expect(mockRequestOptions.qs['dedicated_host.id']).toEqual(dedicatedHostId);
         expect(mockRequestOptions.qs['dedicated_host.crn']).toEqual(dedicatedHostCrn);
         expect(mockRequestOptions.qs['dedicated_host.name']).toEqual(dedicatedHostName);
@@ -8383,9 +8428,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/instances';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"instances":[{"availability_policy":{"host_failure":"restart"},"bandwidth":1000,"boot_volume_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"80b3e36e-41f4-40e9-bd56-beae81792a68"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46f2-b1f1-bc152b2e391a/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}},"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"confidential_compute_mode":"disabled","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","dedicated_host":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"},"disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"nvme","name":"my-instance-disk","resource_type":"instance_disk","size":100}],"enable_secure_boot":true,"gpu":{"count":1,"manufacturer":"nvidia","memory":1,"model":"Tesla V100"},"health_reasons":[{"code":"reservation_expired","message":"The reservation cannot be used because it has expired.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-server-health-status-reasons"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":64,"metadata_service":{"enabled":false,"protocol":"http","response_hop_limit":1},"name":"my-instance","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/5dd61d72-acaa-47c2-a336-3d849660d010/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"numa_count":2,"placement_target":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-host-group","resource_type":"dedicated_host_group"},"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/5dd61d72-acaa-47c2-a336-3d849660d010/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"reservation":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:7187-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/7187-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"7187-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"},"reservation_affinity":{"policy":"disabled","pool":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:7187-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/7187-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"7187-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"}]},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"instance","startable":false,"status":"deleting","status_reasons":[{"code":"cannot_start_storage","message":"The virtual server instance is unusable because the encryption key for the boot volume\\nhas been deleted","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"total_network_bandwidth":500,"total_volume_bandwidth":500,"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"volume_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"80b3e36e-41f4-40e9-bd56-beae81792a68"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46f2-b1f1-bc152b2e391a/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"instances":[{"availability_policy":{"host_failure":"restart"},"bandwidth":1000,"boot_volume_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"id"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}},"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"cluster_network":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:0717-da0df18c-7598-4633-a648-fdaac28a5573","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573","id":"0717-da0df18c-7598-4633-a648-fdaac28a5573","name":"my-cluster-network","resource_type":"cluster_network"},"cluster_network_attachments":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"}],"confidential_compute_mode":"disabled","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","dedicated_host":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"},"disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"nvme","name":"my-instance-disk","resource_type":"instance_disk","size":100}],"enable_secure_boot":true,"gpu":{"count":1,"manufacturer":"nvidia","memory":1,"model":"Tesla V100"},"health_reasons":[{"code":"reservation_expired","message":"The reservation cannot be used because it has expired.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-server-health-status-reasons"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":64,"metadata_service":{"enabled":false,"protocol":"http","response_hop_limit":1},"name":"my-instance","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"numa_count":2,"placement_target":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-dedicated-host-group","resource_type":"dedicated_host_group"},"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"reservation":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:0717-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/0717-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"0717-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"},"reservation_affinity":{"policy":"disabled","pool":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:0717-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/0717-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"0717-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"}]},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"instance","startable":false,"status":"deleting","status_reasons":[{"code":"cannot_start_storage","message":"The virtual server instance is unusable because the encryption key for the boot volume\\nhas been deleted","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"total_network_bandwidth":500,"total_volume_bandwidth":500,"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"volume_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"id"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"instances":[{"availability_policy":{"host_failure":"restart"},"bandwidth":1000,"boot_volume_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"80b3e36e-41f4-40e9-bd56-beae81792a68"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46f2-b1f1-bc152b2e391a/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}},"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"confidential_compute_mode":"disabled","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","dedicated_host":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"},"disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"nvme","name":"my-instance-disk","resource_type":"instance_disk","size":100}],"enable_secure_boot":true,"gpu":{"count":1,"manufacturer":"nvidia","memory":1,"model":"Tesla V100"},"health_reasons":[{"code":"reservation_expired","message":"The reservation cannot be used because it has expired.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-server-health-status-reasons"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":64,"metadata_service":{"enabled":false,"protocol":"http","response_hop_limit":1},"name":"my-instance","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/5dd61d72-acaa-47c2-a336-3d849660d010/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"numa_count":2,"placement_target":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-host-group","resource_type":"dedicated_host_group"},"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/5dd61d72-acaa-47c2-a336-3d849660d010/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"reservation":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:7187-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/7187-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"7187-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"},"reservation_affinity":{"policy":"disabled","pool":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:7187-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/7187-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"7187-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"}]},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"instance","startable":false,"status":"deleting","status_reasons":[{"code":"cannot_start_storage","message":"The virtual server instance is unusable because the encryption key for the boot volume\\nhas been deleted","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"total_network_bandwidth":500,"total_volume_bandwidth":500,"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"volume_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"80b3e36e-41f4-40e9-bd56-beae81792a68"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46f2-b1f1-bc152b2e391a/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"instances":[{"availability_policy":{"host_failure":"restart"},"bandwidth":1000,"boot_volume_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"id"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}},"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"cluster_network":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:0717-da0df18c-7598-4633-a648-fdaac28a5573","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573","id":"0717-da0df18c-7598-4633-a648-fdaac28a5573","name":"my-cluster-network","resource_type":"cluster_network"},"cluster_network_attachments":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"}],"confidential_compute_mode":"disabled","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","dedicated_host":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"},"disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"nvme","name":"my-instance-disk","resource_type":"instance_disk","size":100}],"enable_secure_boot":true,"gpu":{"count":1,"manufacturer":"nvidia","memory":1,"model":"Tesla V100"},"health_reasons":[{"code":"reservation_expired","message":"The reservation cannot be used because it has expired.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-server-health-status-reasons"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":64,"metadata_service":{"enabled":false,"protocol":"http","response_hop_limit":1},"name":"my-instance","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"numa_count":2,"placement_target":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-dedicated-host-group","resource_type":"dedicated_host_group"},"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_attachments/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"instance_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"reservation":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:0717-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/0717-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"0717-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"},"reservation_affinity":{"policy":"disabled","pool":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:0717-ba49df72-37b8-43ac-98da-f8e029de0e63","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/0717-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"0717-ba49df72-37b8-43ac-98da-f8e029de0e63","name":"my-reservation","resource_type":"reservation"}]},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"instance","startable":false,"status":"deleting","status_reasons":[{"code":"cannot_start_storage","message":"The virtual server instance is unusable because the encryption key for the boot volume\\nhas been deleted","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"total_network_bandwidth":500,"total_volume_bandwidth":500,"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"volume_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"id"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","name":"my-volume-attachment","volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","resource_type":"volume"}}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -8406,6 +8451,10 @@ describe('VpcV1', () => {
           limit: 10,
           resourceGroupId: 'testString',
           name: 'my-name',
+          clusterNetworkId: 'testString',
+          clusterNetworkCrn:
+            'crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:r010-82b8c783-15d6-4a51-95bf-0b4649d3ef94',
+          clusterNetworkName: 'my-cluster-network',
           dedicatedHostId: 'testString',
           dedicatedHostCrn:
             'crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:1e09281b-f177-46fb-baf1-bc152b2e391a',
@@ -8439,6 +8488,10 @@ describe('VpcV1', () => {
           limit: 10,
           resourceGroupId: 'testString',
           name: 'my-name',
+          clusterNetworkId: 'testString',
+          clusterNetworkCrn:
+            'crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:r010-82b8c783-15d6-4a51-95bf-0b4649d3ef94',
+          clusterNetworkName: 'my-cluster-network',
           dedicatedHostId: 'testString',
           dedicatedHostCrn:
             'crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:1e09281b-f177-46fb-baf1-bc152b2e391a',
@@ -8473,7 +8526,34 @@ describe('VpcV1', () => {
         host_failure: 'restart',
       };
 
-      // TrustedProfileIdentityTrustedProfileById
+      // ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPPrototypeClusterNetworkInterfacePrimaryIPContext
+      const clusterNetworkInterfacePrimaryIpPrototypeModel = {
+        address: '10.0.0.5',
+        auto_delete: false,
+        name: 'my-cluster-network-subnet-reserved-ip',
+      };
+
+      // ClusterNetworkSubnetIdentityById
+      const clusterNetworkSubnetIdentityModel = {
+        id: '0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930',
+      };
+
+      // InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceInstanceClusterNetworkInterfacePrototypeInstanceClusterNetworkAttachment
+      const instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel = {
+        auto_delete: false,
+        name: 'my-cluster-network-interface',
+        primary_ip: clusterNetworkInterfacePrimaryIpPrototypeModel,
+        subnet: clusterNetworkSubnetIdentityModel,
+      };
+
+      // InstanceClusterNetworkAttachmentPrototypeInstanceContext
+      const instanceClusterNetworkAttachmentPrototypeInstanceContextModel = {
+        cluster_network_interface:
+          instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel,
+        name: 'my-instance-network-attachment',
+      };
+
+      // TrustedProfileIdentityById
       const trustedProfileIdentityModel = {
         id: 'Profile-9fd84246-7df4-4667-94e4-8ecde51d5ac5',
       };
@@ -8508,7 +8588,7 @@ describe('VpcV1', () => {
 
       // ReservationIdentityById
       const reservationIdentityModel = {
-        id: '7187-ba49df72-37b8-43ac-98da-f8e029de0e63',
+        id: '0717-ba49df72-37b8-43ac-98da-f8e029de0e63',
       };
 
       // InstanceReservationAffinityPrototype
@@ -8610,7 +8690,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -8667,6 +8747,9 @@ describe('VpcV1', () => {
       // InstancePrototypeInstanceBySourceTemplate
       const instancePrototypeModel = {
         availability_policy: instanceAvailabilityPolicyPrototypeModel,
+        cluster_network_attachments: [
+          instanceClusterNetworkAttachmentPrototypeInstanceContextModel,
+        ],
         confidential_compute_mode: 'disabled',
         default_trusted_profile: instanceDefaultTrustedProfilePrototypeModel,
         enable_secure_boot: true,
@@ -8979,7 +9062,7 @@ describe('VpcV1', () => {
 
       // ReservationIdentityById
       const reservationIdentityModel = {
-        id: '7187-ba49df72-37b8-43ac-98da-f8e029de0e63',
+        id: '0717-ba49df72-37b8-43ac-98da-f8e029de0e63',
       };
 
       // InstanceReservationAffinityPatch
@@ -9277,6 +9360,588 @@ describe('VpcV1', () => {
         let err;
         try {
           await vpcService.createInstanceAction();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('listInstanceClusterNetworkAttachments', () => {
+    describe('positive tests', () => {
+      function __listInstanceClusterNetworkAttachmentsTest() {
+        // Construct the params object for operation listInstanceClusterNetworkAttachments
+        const instanceId = 'testString';
+        const start = 'testString';
+        const limit = 50;
+        const listInstanceClusterNetworkAttachmentsParams = {
+          instanceId,
+          start,
+          limit,
+        };
+
+        const listInstanceClusterNetworkAttachmentsResult =
+          vpcService.listInstanceClusterNetworkAttachments(
+            listInstanceClusterNetworkAttachmentsParams
+          );
+
+        // all methods should return a Promise
+        expectToBePromise(listInstanceClusterNetworkAttachmentsResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/instances/{instance_id}/cluster_network_attachments',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.qs.start).toEqual(start);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listInstanceClusterNetworkAttachmentsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __listInstanceClusterNetworkAttachmentsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __listInstanceClusterNetworkAttachmentsTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listInstanceClusterNetworkAttachmentsParams = {
+          instanceId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.listInstanceClusterNetworkAttachments(
+          listInstanceClusterNetworkAttachmentsParams
+        );
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceClusterNetworkAttachments({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listInstanceClusterNetworkAttachments();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+
+    describe('InstanceClusterNetworkAttachmentsPager tests', () => {
+      const serviceUrl = vpcServiceOptions.url;
+      const path = '/instances/testString/cluster_network_attachments';
+      const mockPagerResponse1 =
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"cluster_network_attachments":[{"before":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"},"cluster_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/interfaces/0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","id":"0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","name":"my-cluster-network-interface","primary_ip":{"address":"10.1.0.6","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930/reserved_ips/6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-cluster-network-subnet-reserved-ip","resource_type":"cluster_network_subnet_reserved_ip"},"resource_type":"cluster_network_interface","subnet":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","id":"0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","name":"my-cluster-network-subnet","resource_type":"cluster_network_subnet"}},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"}],"limit":1}';
+      const mockPagerResponse2 =
+        '{"total_count":2,"cluster_network_attachments":[{"before":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"},"cluster_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/interfaces/0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","id":"0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","name":"my-cluster-network-interface","primary_ip":{"address":"10.1.0.6","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930/reserved_ips/6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-cluster-network-subnet-reserved-ip","resource_type":"cluster_network_subnet_reserved_ip"},"resource_type":"cluster_network_interface","subnet":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","id":"0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","name":"my-cluster-network-subnet","resource_type":"cluster_network_subnet"}},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"}],"limit":1}';
+
+      beforeEach(() => {
+        unmock_createRequest();
+        const scope = nock(serviceUrl)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse1)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse2);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        mock_createRequest();
+      });
+
+      test('getNext()', async () => {
+        const params = {
+          instanceId: 'testString',
+          limit: 10,
+        };
+        const allResults = [];
+        const pager = new VpcV1.InstanceClusterNetworkAttachmentsPager(vpcService, params);
+        while (pager.hasNext()) {
+          const nextPage = await pager.getNext();
+          expect(nextPage).not.toBeNull();
+          allResults.push(...nextPage);
+        }
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+
+      test('getAll()', async () => {
+        const params = {
+          instanceId: 'testString',
+          limit: 10,
+        };
+        const pager = new VpcV1.InstanceClusterNetworkAttachmentsPager(vpcService, params);
+        const allResults = await pager.getAll();
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('createClusterNetworkAttachment', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPPrototypeClusterNetworkInterfacePrimaryIPContext
+      const clusterNetworkInterfacePrimaryIpPrototypeModel = {
+        address: '10.0.0.5',
+        auto_delete: false,
+        name: 'my-cluster-network-subnet-reserved-ip',
+      };
+
+      // ClusterNetworkSubnetIdentityById
+      const clusterNetworkSubnetIdentityModel = {
+        id: '0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930',
+      };
+
+      // InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceInstanceClusterNetworkInterfacePrototypeInstanceClusterNetworkAttachment
+      const instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel = {
+        auto_delete: false,
+        name: 'my-cluster-network-interface',
+        primary_ip: clusterNetworkInterfacePrimaryIpPrototypeModel,
+        subnet: clusterNetworkSubnetIdentityModel,
+      };
+
+      // InstanceClusterNetworkAttachmentBeforePrototypeInstanceClusterNetworkAttachmentIdentityById
+      const instanceClusterNetworkAttachmentBeforePrototypeModel = {
+        id: '0717-fb880975-db45-4459-8548-64e3995ac213',
+      };
+
+      function __createClusterNetworkAttachmentTest() {
+        // Construct the params object for operation createClusterNetworkAttachment
+        const instanceId = 'testString';
+        const clusterNetworkInterface =
+          instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel;
+        const before = instanceClusterNetworkAttachmentBeforePrototypeModel;
+        const name = 'my-instance-network-attachment';
+        const createClusterNetworkAttachmentParams = {
+          instanceId,
+          clusterNetworkInterface,
+          before,
+          name,
+        };
+
+        const createClusterNetworkAttachmentResult = vpcService.createClusterNetworkAttachment(
+          createClusterNetworkAttachmentParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(createClusterNetworkAttachmentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/instances/{instance_id}/cluster_network_attachments',
+          'POST'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.cluster_network_interface).toEqual(clusterNetworkInterface);
+        expect(mockRequestOptions.body.before).toEqual(before);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createClusterNetworkAttachmentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __createClusterNetworkAttachmentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __createClusterNetworkAttachmentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const clusterNetworkInterface =
+          instanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createClusterNetworkAttachmentParams = {
+          instanceId,
+          clusterNetworkInterface,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.createClusterNetworkAttachment(createClusterNetworkAttachmentParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkAttachment({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkAttachment();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteInstanceClusterNetworkAttachment', () => {
+    describe('positive tests', () => {
+      function __deleteInstanceClusterNetworkAttachmentTest() {
+        // Construct the params object for operation deleteInstanceClusterNetworkAttachment
+        const instanceId = 'testString';
+        const id = 'testString';
+        const deleteInstanceClusterNetworkAttachmentParams = {
+          instanceId,
+          id,
+        };
+
+        const deleteInstanceClusterNetworkAttachmentResult =
+          vpcService.deleteInstanceClusterNetworkAttachment(
+            deleteInstanceClusterNetworkAttachmentParams
+          );
+
+        // all methods should return a Promise
+        expectToBePromise(deleteInstanceClusterNetworkAttachmentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/instances/{instance_id}/cluster_network_attachments/{id}',
+          'DELETE'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteInstanceClusterNetworkAttachmentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __deleteInstanceClusterNetworkAttachmentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __deleteInstanceClusterNetworkAttachmentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteInstanceClusterNetworkAttachmentParams = {
+          instanceId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.deleteInstanceClusterNetworkAttachment(
+          deleteInstanceClusterNetworkAttachmentParams
+        );
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceClusterNetworkAttachment({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteInstanceClusterNetworkAttachment();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getInstanceClusterNetworkAttachment', () => {
+    describe('positive tests', () => {
+      function __getInstanceClusterNetworkAttachmentTest() {
+        // Construct the params object for operation getInstanceClusterNetworkAttachment
+        const instanceId = 'testString';
+        const id = 'testString';
+        const getInstanceClusterNetworkAttachmentParams = {
+          instanceId,
+          id,
+        };
+
+        const getInstanceClusterNetworkAttachmentResult =
+          vpcService.getInstanceClusterNetworkAttachment(getInstanceClusterNetworkAttachmentParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getInstanceClusterNetworkAttachmentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/instances/{instance_id}/cluster_network_attachments/{id}',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getInstanceClusterNetworkAttachmentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __getInstanceClusterNetworkAttachmentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __getInstanceClusterNetworkAttachmentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getInstanceClusterNetworkAttachmentParams = {
+          instanceId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.getInstanceClusterNetworkAttachment(getInstanceClusterNetworkAttachmentParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceClusterNetworkAttachment({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getInstanceClusterNetworkAttachment();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('updateInstanceClusterNetworkAttachment', () => {
+    describe('positive tests', () => {
+      function __updateInstanceClusterNetworkAttachmentTest() {
+        // Construct the params object for operation updateInstanceClusterNetworkAttachment
+        const instanceId = 'testString';
+        const id = 'testString';
+        const name = 'my-instance-network-attachment-updated';
+        const updateInstanceClusterNetworkAttachmentParams = {
+          instanceId,
+          id,
+          name,
+        };
+
+        const updateInstanceClusterNetworkAttachmentResult =
+          vpcService.updateInstanceClusterNetworkAttachment(
+            updateInstanceClusterNetworkAttachmentParams
+          );
+
+        // all methods should return a Promise
+        expectToBePromise(updateInstanceClusterNetworkAttachmentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/instances/{instance_id}/cluster_network_attachments/{id}',
+          'PATCH'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/merge-patch+json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateInstanceClusterNetworkAttachmentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __updateInstanceClusterNetworkAttachmentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __updateInstanceClusterNetworkAttachmentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const updateInstanceClusterNetworkAttachmentParams = {
+          instanceId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.updateInstanceClusterNetworkAttachment(
+          updateInstanceClusterNetworkAttachmentParams
+        );
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceClusterNetworkAttachment({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateInstanceClusterNetworkAttachment();
         } catch (e) {
           err = e;
         }
@@ -9774,7 +10439,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -10296,7 +10961,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       function __createInstanceNetworkInterfaceTest() {
@@ -10607,7 +11272,7 @@ describe('VpcV1', () => {
         const instanceId = 'testString';
         const id = 'testString';
         const allowIpSpoofing = true;
-        const name = 'my-network-interface-1';
+        const name = 'my-network-interface-updated';
         const updateInstanceNetworkInterfaceParams = {
           instanceId,
           id,
@@ -14473,9 +15138,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/instance_groups/testString/memberships';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"memberships":[{"created_at":"2019-01-01T12:00:00.000Z","delete_instance_on_membership_delete":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/instance_groups/1e09281b-f177-46fb-baf1-bc152b2e391a/memberships/8b002d86-601f-11ea-898b-000c29475bed","id":"1e09281b-f177-46fb-baf1-bc152b2e391a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","name":"my-instance"},"instance_template":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance-template:1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/templates/1e09281b-f177-46fb-baf1-bc152b2e391a","id":"a6b1a881-2ce8-41a3-80fc-36316a73f803","name":"my-instance-template"},"name":"my-instance-group-membership","pool_member":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/load_balancers/dd754295-e9e0-4c9d-bf6c-58fbc59e5727/pools/70294e14-4e61-11e8-bcf4-0242ac110004/members/80294e14-4e61-11e8-bcf4-0242ac110004","id":"70294e14-4e61-11e8-bcf4-0242ac110004"},"status":"deleting","updated_at":"2019-01-01T12:00:00.000Z"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"memberships":[{"created_at":"2019-01-01T12:00:00.000Z","delete_instance_on_membership_delete":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/instance_groups/1e09281b-f177-46fb-baf1-bc152b2e391a/memberships/8b002d86-601f-11ea-898b-000c29475bed","id":"1e09281b-f177-46fb-baf1-bc152b2e391a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","name":"my-instance"},"instance_template":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance-template:1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/templates/1e09281b-f177-46fb-baf1-bc152b2e391a","id":"a6b1a881-2ce8-41a3-80fc-36316a73f803","name":"my-instance-template"},"name":"my-instance-group-membership","pool_member":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/load_balancers/dd754295-e9e0-4c9d-bf6c-58fbc59e5727/pools/70294e14-4e61-11e8-bcf4-0242ac110004/members/80294e14-4e61-11e8-bcf4-0242ac110004","id":"70294e14-4e61-11e8-bcf4-0242ac110004"},"status":"deleting","updated_at":"2019-01-01T12:00:00.000Z"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"memberships":[{"created_at":"2019-01-01T12:00:00.000Z","delete_instance_on_membership_delete":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/instance_groups/1e09281b-f177-46fb-baf1-bc152b2e391a/memberships/8b002d86-601f-11ea-898b-000c29475bed","id":"1e09281b-f177-46fb-baf1-bc152b2e391a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","name":"my-instance"},"instance_template":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance-template:1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/templates/1e09281b-f177-46fb-baf1-bc152b2e391a","id":"a6b1a881-2ce8-41a3-80fc-36316a73f803","name":"my-instance-template"},"name":"my-instance-group-membership","pool_member":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/load_balancers/dd754295-e9e0-4c9d-bf6c-58fbc59e5727/pools/70294e14-4e61-11e8-bcf4-0242ac110004/members/80294e14-4e61-11e8-bcf4-0242ac110004","id":"70294e14-4e61-11e8-bcf4-0242ac110004"},"status":"deleting","updated_at":"2019-01-01T12:00:00.000Z"}]}';
+        '{"total_count":2,"limit":1,"memberships":[{"created_at":"2019-01-01T12:00:00.000Z","delete_instance_on_membership_delete":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/instance_groups/1e09281b-f177-46fb-baf1-bc152b2e391a/memberships/8b002d86-601f-11ea-898b-000c29475bed","id":"1e09281b-f177-46fb-baf1-bc152b2e391a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","name":"my-instance"},"instance_template":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance-template:1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/templates/1e09281b-f177-46fb-baf1-bc152b2e391a","id":"a6b1a881-2ce8-41a3-80fc-36316a73f803","name":"my-instance-template"},"name":"my-instance-group-membership","pool_member":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/load_balancers/dd754295-e9e0-4c9d-bf6c-58fbc59e5727/pools/70294e14-4e61-11e8-bcf4-0242ac110004/members/80294e14-4e61-11e8-bcf4-0242ac110004","id":"70294e14-4e61-11e8-bcf4-0242ac110004"},"status":"deleting","updated_at":"2019-01-01T12:00:00.000Z"}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -14900,9 +15565,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/reservations';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"reservations":[{"affinity_policy":"restricted","capacity":{"allocated":10,"available":8,"status":"allocated","total":10,"used":2},"committed_use":{"expiration_at":"2019-01-01T12:00:00.000Z","expiration_policy":"release","term":"term"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:7187-ba49df72-37b8-43ac-98da-f8e029de0e63","href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/7187-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"7187-ba49df72-37b8-43ac-98da-f8e029de0e63","lifecycle_state":"stable","name":"my-reservation","profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"reservation","status":"activating","status_reasons":[{"code":"cannot_activate_no_capacity_available","message":"The reservation cannot be activated because capacity is unavailable","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-reserved-capacity-status-reasons"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"reservations":[{"affinity_policy":"restricted","capacity":{"allocated":10,"available":8,"status":"allocated","total":10,"used":2},"committed_use":{"expiration_at":"2019-01-01T12:00:00.000Z","expiration_policy":"release","term":"term"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:0717-ba49df72-37b8-43ac-98da-f8e029de0e63","href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/0717-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"0717-ba49df72-37b8-43ac-98da-f8e029de0e63","lifecycle_state":"stable","name":"my-reservation","profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"reservation","status":"activating","status_reasons":[{"code":"cannot_activate_no_capacity_available","message":"The reservation cannot be activated because capacity is unavailable","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-reserved-capacity-status-reasons"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"reservations":[{"affinity_policy":"restricted","capacity":{"allocated":10,"available":8,"status":"allocated","total":10,"used":2},"committed_use":{"expiration_at":"2019-01-01T12:00:00.000Z","expiration_policy":"release","term":"term"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:7187-ba49df72-37b8-43ac-98da-f8e029de0e63","href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/7187-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"7187-ba49df72-37b8-43ac-98da-f8e029de0e63","lifecycle_state":"stable","name":"my-reservation","profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"reservation","status":"activating","status_reasons":[{"code":"cannot_activate_no_capacity_available","message":"The reservation cannot be activated because capacity is unavailable","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-reserved-capacity-status-reasons"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"reservations":[{"affinity_policy":"restricted","capacity":{"allocated":10,"available":8,"status":"allocated","total":10,"used":2},"committed_use":{"expiration_at":"2019-01-01T12:00:00.000Z","expiration_policy":"release","term":"term"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::reservation:0717-ba49df72-37b8-43ac-98da-f8e029de0e63","href":"https://us-south.iaas.cloud.ibm.com/v1/reservations/0717-ba49df72-37b8-43ac-98da-f8e029de0e63","id":"0717-ba49df72-37b8-43ac-98da-f8e029de0e63","lifecycle_state":"stable","name":"my-reservation","profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"reservation","status":"activating","status_reasons":[{"code":"cannot_activate_no_capacity_available","message":"The reservation cannot be activated because capacity is unavailable","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-reserved-capacity-status-reasons"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -15548,9 +16213,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/dedicated_host/groups';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"groups":[{"class":"bx2","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","dedicated_hosts":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"}],"family":"balanced","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-host-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host_group","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"groups":[{"class":"bx2","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","dedicated_hosts":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"}],"family":"balanced","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-dedicated-host-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host_group","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"groups":[{"class":"bx2","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","dedicated_hosts":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"}],"family":"balanced","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-host-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host_group","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"total_count":2,"limit":1,"groups":[{"class":"bx2","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","dedicated_hosts":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"my-host","resource_type":"dedicated_host"}],"family":"balanced","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-dedicated-host-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host_group","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -15896,7 +16561,7 @@ describe('VpcV1', () => {
       function __updateDedicatedHostGroupTest() {
         // Construct the params object for operation updateDedicatedHostGroup
         const id = 'testString';
-        const name = 'my-host-group-updated';
+        const name = 'my-dedicated-host-group-updated';
         const updateDedicatedHostGroupParams = {
           id,
           name,
@@ -16273,9 +16938,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/dedicated_hosts';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"dedicated_hosts":[{"available_memory":128,"available_vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","disks":[{"available":9,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","instance_disks":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-disk","resource_type":"instance_disk"}],"interface_type":"nvme","lifecycle_state":"stable","name":"my-dedicated-host-disk","provisionable":false,"resource_type":"dedicated_host_disk","size":4,"supported_instance_interface_types":["nvme"]}],"group":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-host-group","resource_type":"dedicated_host_group"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","instance_placement_enabled":true,"instances":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","name":"my-instance"}],"lifecycle_state":"stable","memory":128,"name":"my-host","numa":{"count":2,"nodes":[{"available_vcpu":24,"vcpu":56}]},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"mx2-host-152x1216"},"provisionable":false,"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host","socket_count":4,"state":"available","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"dedicated_hosts":[{"available_memory":128,"available_vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","disks":[{"available":9,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a/disks/0717-bd091a9e-b036-4c65-a79b-56d164911f6e","id":"0717-bd091a9e-b036-4c65-a79b-56d164911f6e","instance_disks":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-disk","resource_type":"instance_disk"}],"interface_type":"nvme","lifecycle_state":"stable","name":"my-dedicated-host-disk","provisionable":false,"resource_type":"dedicated_host_disk","size":4,"supported_instance_interface_types":["nvme"]}],"group":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-dedicated-host-group","resource_type":"dedicated_host_group"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","instance_placement_enabled":true,"instances":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","name":"my-instance"}],"lifecycle_state":"stable","memory":128,"name":"my-host","numa":{"count":2,"nodes":[{"available_vcpu":24,"vcpu":56}]},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"mx2-host-152x1216"},"provisionable":false,"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host","socket_count":4,"state":"available","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"dedicated_hosts":[{"available_memory":128,"available_vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","disks":[{"available":9,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","instance_disks":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-disk","resource_type":"instance_disk"}],"interface_type":"nvme","lifecycle_state":"stable","name":"my-dedicated-host-disk","provisionable":false,"resource_type":"dedicated_host_disk","size":4,"supported_instance_interface_types":["nvme"]}],"group":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-host-group","resource_type":"dedicated_host_group"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","instance_placement_enabled":true,"instances":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","name":"my-instance"}],"lifecycle_state":"stable","memory":128,"name":"my-host","numa":{"count":2,"nodes":[{"available_vcpu":24,"vcpu":56}]},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"mx2-host-152x1216"},"provisionable":false,"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host","socket_count":4,"state":"available","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"dedicated_hosts":[{"available_memory":128,"available_vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host:0717-1e09281b-f177-46fb-baf1-bc152b2e391a","disks":[{"available":9,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a/disks/0717-bd091a9e-b036-4c65-a79b-56d164911f6e","id":"0717-bd091a9e-b036-4c65-a79b-56d164911f6e","instance_disks":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-disk","resource_type":"instance_disk"}],"interface_type":"nvme","lifecycle_state":"stable","name":"my-dedicated-host-disk","provisionable":false,"resource_type":"dedicated_host_disk","size":4,"supported_instance_interface_types":["nvme"]}],"group":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::dedicated-host-group:0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_host/groups/0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","id":"0717-bcc5b834-1258-4b9c-c3b4-43bc9cf5cde0","name":"my-dedicated-host-group","resource_type":"dedicated_host_group"},"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","id":"0717-1e09281b-f177-46fb-baf1-bc152b2e391a","instance_placement_enabled":true,"instances":[{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","name":"my-instance"}],"lifecycle_state":"stable","memory":128,"name":"my-host","numa":{"count":2,"nodes":[{"available_vcpu":24,"vcpu":56}]},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/dedicated_hosts/0717-1e09281b-f177-46fb-baf1-bc152b2e391a","name":"mx2-host-152x1216"},"provisionable":false,"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"dedicated_host","socket_count":4,"state":"available","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"vcpu":{"architecture":"amd64","count":4,"manufacturer":"intel"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -16629,7 +17294,7 @@ describe('VpcV1', () => {
         // Construct the params object for operation updateDedicatedHostDisk
         const dedicatedHostId = 'testString';
         const id = 'testString';
-        const name = 'my-disk-updated';
+        const name = 'my-dedicated-host-disk-updated';
         const updateDedicatedHostDiskParams = {
           dedicatedHostId,
           id,
@@ -16900,8 +17565,8 @@ describe('VpcV1', () => {
       function __updateDedicatedHostTest() {
         // Construct the params object for operation updateDedicatedHost
         const id = 'testString';
-        const instancePlacementEnabled = true;
-        const name = 'my-host';
+        const instancePlacementEnabled = false;
+        const name = 'testString';
         const updateDedicatedHostParams = {
           id,
           instancePlacementEnabled,
@@ -17061,9 +17726,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/placement_groups';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"placement_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::placement-group:r018-418fe842-a3e9-47b9-a938-1aa5bd632871","href":"https://us-south.iaas.cloud.ibm.com/v1/placement_groups/r018-418fe842-a3e9-47b9-a938-1aa5bd632871","id":"r018-418fe842-a3e9-47b9-a938-1aa5bd632871","lifecycle_state":"stable","name":"my-placement-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"placement_group","strategy":"host_spread"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"placement_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::placement-group:r006-418fe842-a3e9-47b9-a938-1aa5bd632871","href":"https://us-south.iaas.cloud.ibm.com/v1/placement_groups/r006-418fe842-a3e9-47b9-a938-1aa5bd632871","id":"r006-418fe842-a3e9-47b9-a938-1aa5bd632871","lifecycle_state":"stable","name":"my-placement-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"placement_group","strategy":"host_spread"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"placement_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::placement-group:r018-418fe842-a3e9-47b9-a938-1aa5bd632871","href":"https://us-south.iaas.cloud.ibm.com/v1/placement_groups/r018-418fe842-a3e9-47b9-a938-1aa5bd632871","id":"r018-418fe842-a3e9-47b9-a938-1aa5bd632871","lifecycle_state":"stable","name":"my-placement-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"placement_group","strategy":"host_spread"}]}';
+        '{"total_count":2,"limit":1,"placement_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::placement-group:r006-418fe842-a3e9-47b9-a938-1aa5bd632871","href":"https://us-south.iaas.cloud.ibm.com/v1/placement_groups/r006-418fe842-a3e9-47b9-a938-1aa5bd632871","id":"r006-418fe842-a3e9-47b9-a938-1aa5bd632871","lifecycle_state":"stable","name":"my-placement-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"placement_group","strategy":"host_spread"}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -17769,9 +18434,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/bare_metal_servers';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"bare_metal_servers":[{"bandwidth":20000,"boot_target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk"},"cpu":{"architecture":"amd64","core_count":80,"socket_count":4,"threads_per_core":2},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::bare-metal-server:1e09281b-f177-46fb-baf1-bc152b2e391a","disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"fcp","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk","size":100}],"enable_secure_boot":false,"firmware":{"update":"none"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a","id":"1e09281b-f177-46fb-baf1-bc152b2e391a","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":1536,"name":"my-bare-metal-server","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/2302-f7a2bf57-af7c-49d9-b599-b2c91293d30c/network_attachments/2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/2302-f7a2bf57-af7c-49d9-b599-b2c91293d30c/network_attachments/2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/profiles/bx2-metal-192x768","name":"bx2-metal-192x768","resource_type":"bare_metal_server_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"bare_metal_server","status":"deleting","status_reasons":[{"code":"cannot_start_capacity","message":"The bare metal server cannot start as there is no more capacity in this\\nzone for a bare metal server with the requested profile.","more_info":"https://console.bluemix.net/docs/iaas/bare_metal_server.html"}],"trusted_platform_module":{"enabled":true,"mode":"disabled","supported_modes":["disabled"]},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"bare_metal_servers":[{"bandwidth":20000,"boot_target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/disks/0717-3744f199-6ccc-4698-8772-bb3937348c96","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk"},"cpu":{"architecture":"amd64","core_count":80,"socket_count":4,"threads_per_core":2},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::bare-metal-server:0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304","disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/disks/0717-3744f199-6ccc-4698-8772-bb3937348c96","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"fcp","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk","size":100}],"enable_secure_boot":false,"firmware":{"update":"none"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304","id":"0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":1536,"name":"my-bare-metal-server","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_attachments/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_interfaces/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_attachments/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_interfaces/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/profiles/bx2-metal-192x768","name":"bx2-metal-192x768","resource_type":"bare_metal_server_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"bare_metal_server","status":"deleting","status_reasons":[{"code":"cannot_start_capacity","message":"The bare metal server cannot start as there is no more capacity in this\\nzone for a bare metal server with the requested profile.","more_info":"https://console.bluemix.net/docs/iaas/bare_metal_server.html"}],"trusted_platform_module":{"enabled":true,"mode":"disabled","supported_modes":["disabled"]},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"bare_metal_servers":[{"bandwidth":20000,"boot_target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk"},"cpu":{"architecture":"amd64","core_count":80,"socket_count":4,"threads_per_core":2},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::bare-metal-server:1e09281b-f177-46fb-baf1-bc152b2e391a","disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/disks/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"fcp","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk","size":100}],"enable_secure_boot":false,"firmware":{"update":"none"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a","id":"1e09281b-f177-46fb-baf1-bc152b2e391a","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":1536,"name":"my-bare-metal-server","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/2302-f7a2bf57-af7c-49d9-b599-b2c91293d30c/network_attachments/2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/2302-f7a2bf57-af7c-49d9-b599-b2c91293d30c/network_attachments/2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/profiles/bx2-metal-192x768","name":"bx2-metal-192x768","resource_type":"bare_metal_server_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"bare_metal_server","status":"deleting","status_reasons":[{"code":"cannot_start_capacity","message":"The bare metal server cannot start as there is no more capacity in this\\nzone for a bare metal server with the requested profile.","more_info":"https://console.bluemix.net/docs/iaas/bare_metal_server.html"}],"trusted_platform_module":{"enabled":true,"mode":"disabled","supported_modes":["disabled"]},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"total_count":2,"limit":1,"bare_metal_servers":[{"bandwidth":20000,"boot_target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/disks/0717-3744f199-6ccc-4698-8772-bb3937348c96","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk"},"cpu":{"architecture":"amd64","core_count":80,"socket_count":4,"threads_per_core":2},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::bare-metal-server:0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304","disks":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/disks/0717-3744f199-6ccc-4698-8772-bb3937348c96","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","interface_type":"fcp","name":"my-bare-metal-server-disk","resource_type":"bare_metal_server_disk","size":100}],"enable_secure_boot":false,"firmware":{"update":"none"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304","id":"0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","memory":1536,"name":"my-bare-metal-server","network_attachments":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_attachments/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}}],"network_interfaces":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_interfaces/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}}],"primary_network_attachment":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_attachments/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-attachment","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"}},"primary_network_interface":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_interfaces/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","name":"my-bare-metal-server-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"}},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/profiles/bx2-metal-192x768","name":"bx2-metal-192x768","resource_type":"bare_metal_server_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"bare_metal_server","status":"deleting","status_reasons":[{"code":"cannot_start_capacity","message":"The bare metal server cannot start as there is no more capacity in this\\nzone for a bare metal server with the requested profile.","more_info":"https://console.bluemix.net/docs/iaas/bare_metal_server.html"}],"trusted_platform_module":{"enabled":true,"mode":"disabled","supported_modes":["disabled"]},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -17888,7 +18553,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -18525,9 +19190,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/bare_metal_servers/testString/network_attachments';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"network_attachments":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/2302-f7a2bf57-af7c-49d9-b599-b2c91293d30c/network_attachments/2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","lifecycle_state":"stable","name":"my-bare-metal-server-network-attachment","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"allowed_vlans":[4],"interface_type":"pci"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"network_attachments":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_attachments/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","lifecycle_state":"stable","name":"my-bare-metal-server-network-attachment","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"allowed_vlans":[4],"interface_type":"pci"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"network_attachments":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/2302-f7a2bf57-af7c-49d9-b599-b2c91293d30c/network_attachments/2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"2302-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","lifecycle_state":"stable","name":"my-bare-metal-server-network-attachment","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"allowed_vlans":[4],"interface_type":"pci"}]}';
+        '{"total_count":2,"limit":1,"network_attachments":[{"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_attachments/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","lifecycle_state":"stable","name":"my-bare-metal-server-network-attachment","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"bare_metal_server_network_attachment","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"allowed_vlans":[4],"interface_type":"pci"}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -18597,7 +19262,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -19132,9 +19797,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/bare_metal_servers/testString/network_interfaces';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"network_interfaces":[{"allow_ip_spoofing":true,"created_at":"2019-01-01T12:00:00.000Z","enable_infrastructure_nat":true,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip"}],"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","mac_address":"02:00:04:00:C4:6A","name":"my-bare-metal-server-network-interface","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"status":"available","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","interface_type":"hipersocket"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"network_interfaces":[{"allow_ip_spoofing":true,"created_at":"2019-01-01T12:00:00.000Z","enable_infrastructure_nat":true,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip"}],"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_interfaces/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","mac_address":"02:00:04:00:C4:6A","name":"my-bare-metal-server-network-interface","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"status":"available","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","interface_type":"hipersocket"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"network_interfaces":[{"allow_ip_spoofing":true,"created_at":"2019-01-01T12:00:00.000Z","enable_infrastructure_nat":true,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip"}],"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/10c02d81-0ecb-4dc5-897d-28392913b81e","id":"10c02d81-0ecb-4dc5-897d-28392913b81e","mac_address":"02:00:04:00:C4:6A","name":"my-bare-metal-server-network-interface","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"status":"available","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","interface_type":"hipersocket"}]}';
+        '{"total_count":2,"limit":1,"network_interfaces":[{"allow_ip_spoofing":true,"created_at":"2019-01-01T12:00:00.000Z","enable_infrastructure_nat":true,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip"}],"href":"https://us-south.iaas.cloud.ibm.com/v1/bare_metal_servers/0717-aad10fd7-8a02-4f3e-97f3-b18bd82cf304/network_interfaces/0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","id":"0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6","mac_address":"02:00:04:00:C4:6A","name":"my-bare-metal-server-network-interface","port_speed":1000,"primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"status":"available","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"type":"primary","interface_type":"hipersocket"}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -19192,7 +19857,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -21376,9 +22041,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/volumes';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"volumes":[{"active":true,"adjustable_capacity_states":["attached"],"adjustable_iops_states":["attached"],"attachment_state":"attached","bandwidth":1000,"busy":true,"capacity":1000,"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"health_reasons":[{"code":"initializing_from_snapshot","message":"Performance will be degraded while this volume is being initialized from its snapshot","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-snapshots-vpc-troubleshooting&interface=ui#snapshot_ts_degraded_perf"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","iops":10000,"name":"my-volume","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/volume/profiles/general-purpose","name":"general-purpose"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"volume","source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"status":"available","status_reasons":[{"code":"encryption_key_deleted","message":"message","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"user_tags":["user_tags"],"volume_attachments":[{"delete_volume_on_instance_delete":true,"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"80b3e36e-41f4-40e9-bd56-beae81792a68"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46f2-b1f1-bc152b2e391a/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","name":"my-instance"},"name":"my-volume-attachment","type":"boot"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"volumes":[{"active":true,"adjustable_capacity_states":["attached"],"adjustable_iops_states":["attached"],"attachment_state":"attached","bandwidth":1000,"busy":true,"capacity":1000,"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"health_reasons":[{"code":"initializing_from_snapshot","message":"Performance will be degraded while this volume is being initialized from its snapshot","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-snapshots-vpc-troubleshooting&interface=ui#snapshot_ts_degraded_perf"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","iops":10000,"name":"my-volume","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/volume/profiles/general-purpose","name":"general-purpose"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"volume","source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"status":"available","status_reasons":[{"code":"encryption_key_deleted","message":"message","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"user_tags":["user_tags"],"volume_attachments":[{"delete_volume_on_instance_delete":true,"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"id"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","name":"my-instance"},"name":"my-volume-attachment","type":"boot"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"volumes":[{"active":true,"adjustable_capacity_states":["attached"],"adjustable_iops_states":["attached"],"attachment_state":"attached","bandwidth":1000,"busy":true,"capacity":1000,"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"health_reasons":[{"code":"initializing_from_snapshot","message":"Performance will be degraded while this volume is being initialized from its snapshot","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-snapshots-vpc-troubleshooting&interface=ui#snapshot_ts_degraded_perf"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","iops":10000,"name":"my-volume","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/volume/profiles/general-purpose","name":"general-purpose"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"volume","source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"status":"available","status_reasons":[{"code":"encryption_key_deleted","message":"message","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"user_tags":["user_tags"],"volume_attachments":[{"delete_volume_on_instance_delete":true,"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"80b3e36e-41f4-40e9-bd56-beae81792a68"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46f2-b1f1-bc152b2e391a/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_1e09281b-f177-46fb-b1f1-bc152b2e391a","id":"0717_1e09281b-f177-46f2-b1f1-bc152b2e391a","name":"my-instance"},"name":"my-volume-attachment","type":"boot"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"total_count":2,"limit":1,"volumes":[{"active":true,"adjustable_capacity_states":["attached"],"adjustable_iops_states":["attached"],"attachment_state":"attached","bandwidth":1000,"busy":true,"capacity":1000,"catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"health_reasons":[{"code":"initializing_from_snapshot","message":"Performance will be degraded while this volume is being initialized from its snapshot","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-snapshots-vpc-troubleshooting&interface=ui#snapshot_ts_degraded_perf"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","iops":10000,"name":"my-volume","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/volume/profiles/general-purpose","name":"general-purpose"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"volume","source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"status":"available","status_reasons":[{"code":"encryption_key_deleted","message":"message","more_info":"https://cloud.ibm.com/docs/key-protect?topic=key-protect-restore-keys"}],"user_tags":["user_tags"],"volume_attachments":[{"delete_volume_on_instance_delete":true,"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"device":{"id":"id"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/volume_attachments/0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","id":"0717-82cbf856-9cbb-45fb-b62f-d7bcef32399a","instance":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::instance:0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","id":"0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0","name":"my-instance"},"name":"my-volume-attachment","type":"boot"}],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -22601,9 +23266,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/snapshots';
       const mockPagerResponse1 =
-        '{"snapshots":[{"backup_policy_plan":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"},"bootable":true,"captured_at":"2019-01-01T12:00:00.000Z","catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"clones":[{"available":false,"created_at":"2019-01-01T12:00:00.000Z","zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"copies":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"}],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deletable":false,"encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","lifecycle_state":"stable","minimum_capacity":1,"name":"my-snapshot","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"snapshot","service_tags":["service_tags"],"size":1,"snapshot_consistency_group":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot-consistency-group:r134-fa329f6b-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshot_consistency_groups/r134-fa329f6b-0e36-433f-a3bb-0df632e79263","id":"r134-fa329f6b-0e36-433f-a3bb-0df632e79263","name":"my-snapshot-consistency-group","resource_type":"snapshot_consistency_group"},"source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"source_volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"volume"},"user_tags":["user_tags"]}],"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1}';
+        '{"snapshots":[{"backup_policy_plan":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"},"bootable":true,"captured_at":"2019-01-01T12:00:00.000Z","catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"clones":[{"available":false,"created_at":"2019-01-01T12:00:00.000Z","zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"copies":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"}],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deletable":false,"encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","lifecycle_state":"stable","minimum_capacity":1,"name":"my-snapshot","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"progress":55,"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"snapshot","service_tags":["service_tags"],"size":1,"snapshot_consistency_group":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot-consistency-group:r134-fa329f6b-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshot_consistency_groups/r134-fa329f6b-0e36-433f-a3bb-0df632e79263","id":"r134-fa329f6b-0e36-433f-a3bb-0df632e79263","name":"my-snapshot-consistency-group","resource_type":"snapshot_consistency_group"},"source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"source_volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"volume"},"user_tags":["user_tags"]}],"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"snapshots":[{"backup_policy_plan":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"},"bootable":true,"captured_at":"2019-01-01T12:00:00.000Z","catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"clones":[{"available":false,"created_at":"2019-01-01T12:00:00.000Z","zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"copies":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"}],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deletable":false,"encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","lifecycle_state":"stable","minimum_capacity":1,"name":"my-snapshot","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"snapshot","service_tags":["service_tags"],"size":1,"snapshot_consistency_group":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot-consistency-group:r134-fa329f6b-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshot_consistency_groups/r134-fa329f6b-0e36-433f-a3bb-0df632e79263","id":"r134-fa329f6b-0e36-433f-a3bb-0df632e79263","name":"my-snapshot-consistency-group","resource_type":"snapshot_consistency_group"},"source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"source_volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"volume"},"user_tags":["user_tags"]}],"total_count":2,"limit":1}';
+        '{"snapshots":[{"backup_policy_plan":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"},"bootable":true,"captured_at":"2019-01-01T12:00:00.000Z","catalog_offering":{"plan":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:51c9e0db-2911-45a6-adb0-ac5332d27cf2:plan:sw.51c9e0db-2911-45a6-adb0-ac5332d27cf2.772c0dbe-aa62-482e-adbe-a3fc20101e0e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"}},"version":{"crn":"crn:v1:bluemix:public:globalcatalog-collection:global:a/aa2432b1fa4d4ace891e9b80fc104e34:1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc:version:00111601-0ec5-41ac-b142-96d1e64e6442/ec66bec2-6a33-42d6-9323-26dd4dc8875d"}},"clones":[{"available":false,"created_at":"2019-01-01T12:00:00.000Z","zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"copies":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"}],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deletable":false,"encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","lifecycle_state":"stable","minimum_capacity":1,"name":"my-snapshot","operating_system":{"allow_user_image_creation":true,"architecture":"amd64","dedicated_host_only":false,"display_name":"Ubuntu Server 16.04 LTS amd64","family":"Ubuntu Server","href":"https://us-south.iaas.cloud.ibm.com/v1/operating_systems/ubuntu-24-04-amd64","name":"ubuntu-24-04-amd64","user_data_format":"cloud_init","vendor":"Canonical","version":"16.04 LTS"},"progress":55,"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"snapshot","service_tags":["service_tags"],"size":1,"snapshot_consistency_group":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot-consistency-group:r134-fa329f6b-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshot_consistency_groups/r134-fa329f6b-0e36-433f-a3bb-0df632e79263","id":"r134-fa329f6b-0e36-433f-a3bb-0df632e79263","name":"my-snapshot-consistency-group","resource_type":"snapshot_consistency_group"},"source_image":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::image:r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/images/r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","id":"r006-72b27b5c-f4b0-48bb-b954-5becc7c1dcb8","name":"my-image","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"image"},"source_snapshot":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::snapshot:r134-f6bfa329-0e36-433f-a3bb-0df632e79263","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/snapshots/r134-f6bfa329-0e36-433f-a3bb-0df632e79263","id":"r134-f6bfa329-0e36-433f-a3bb-0df632e79263","name":"my-snapshot","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"snapshot"},"source_volume":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::volume:r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/volumes/r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","id":"r006-1a6b7274-678d-4dfb-8981-c71dd9d4daa5","name":"my-volume","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"volume"},"user_tags":["user_tags"]}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -23730,9 +24395,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/shares';
       const mockPagerResponse1 =
-        '{"shares":[{"access_control_mode":"security_group","accessor_binding_role":"accessor","accessor_bindings":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","resource_type":"share_accessor_binding"}],"allowed_transit_encryption_modes":["none"],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","iops":100,"latest_job":{"status":"cancelled","status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"type":"replication_failover"},"latest_sync":{"completed_at":"2019-01-01T12:00:00.000Z","data_transferred":0,"started_at":"2019-01-01T12:00:00.000Z"},"lifecycle_reasons":[{"code":"origin_share_access_revoked","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","mount_targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"}],"name":"my-share","origin_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/share/profiles/tier-3iops","name":"tier-3iops","resource_type":"share_profile"},"replica_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"replication_cron_spec":"0 */5 * * *","replication_role":"none","replication_status":"active","replication_status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"share","size":200,"source_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"user_tags":["user_tags"],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1}';
+        '{"shares":[{"access_control_mode":"security_group","accessor_binding_role":"accessor","accessor_bindings":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","resource_type":"share_accessor_binding"}],"allowed_transit_encryption_modes":["none"],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","iops":100,"latest_job":{"status":"cancelled","status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"type":"replication_failover"},"latest_sync":{"completed_at":"2019-01-01T12:00:00.000Z","data_transferred":0,"started_at":"2019-01-01T12:00:00.000Z"},"lifecycle_reasons":[{"code":"origin_share_access_revoked","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","mount_targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"}],"name":"my-share","origin_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/share/profiles/tier-3iops","name":"tier-3iops","resource_type":"share_profile"},"replica_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"replication_cron_spec":"0 */5 * * *","replication_role":"none","replication_status":"active","replication_status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"share","size":200,"source_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"user_tags":["user_tags"],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"shares":[{"access_control_mode":"security_group","accessor_binding_role":"accessor","accessor_bindings":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","resource_type":"share_accessor_binding"}],"allowed_transit_encryption_modes":["none"],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","iops":100,"latest_job":{"status":"cancelled","status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"type":"replication_failover"},"latest_sync":{"completed_at":"2019-01-01T12:00:00.000Z","data_transferred":0,"started_at":"2019-01-01T12:00:00.000Z"},"lifecycle_reasons":[{"code":"origin_share_access_revoked","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","mount_targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"}],"name":"my-share","origin_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/share/profiles/tier-3iops","name":"tier-3iops","resource_type":"share_profile"},"replica_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"replication_cron_spec":"0 */5 * * *","replication_role":"none","replication_status":"active","replication_status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"share","size":200,"source_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"user_tags":["user_tags"],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"shares":[{"access_control_mode":"security_group","accessor_binding_role":"accessor","accessor_bindings":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","resource_type":"share_accessor_binding"}],"allowed_transit_encryption_modes":["none"],"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","encryption":"provider_managed","encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34:e4a29d1a-2ef0-42a6-8fd2-350deb1c647e:key:5437653b-c4b1-447f-9646-b2a2a4cd6179"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","iops":100,"latest_job":{"status":"cancelled","status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"type":"replication_failover"},"latest_sync":{"completed_at":"2019-01-01T12:00:00.000Z","data_transferred":0,"started_at":"2019-01-01T12:00:00.000Z"},"lifecycle_reasons":[{"code":"origin_share_access_revoked","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","mount_targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"}],"name":"my-share","origin_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/share/profiles/tier-3iops","name":"tier-3iops","resource_type":"share_profile"},"replica_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"replication_cron_spec":"0 */5 * * *","replication_role":"none","replication_status":"active","replication_status_reasons":[{"code":"cannot_reach_source_share","message":"The replication failover failed because the source share cannot be reached.","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-file-storage-planning"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"share","size":200,"source_share":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"user_tags":["user_tags"],"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -23808,7 +24473,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -24366,9 +25031,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/shares/testString/accessor_bindings';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"accessor_bindings":[{"accessor":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","lifecycle_state":"stable","resource_type":"share_accessor_binding"}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"accessor_bindings":[{"accessor":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","lifecycle_state":"stable","resource_type":"share_accessor_binding"}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"accessor_bindings":[{"accessor":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","lifecycle_state":"stable","resource_type":"share_accessor_binding"}],"total_count":2,"limit":1}';
+        '{"accessor_bindings":[{"accessor":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::share:r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58","id":"0fe9e5d8-0a4d-4818-96ec-e99708644a58","name":"my-share","remote":{"account":{"id":"bb1b52262f7441a586f49068482f1e60","resource_type":"account"},"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"share"},"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/accessor_bindings/r134-ae9bdc18-aed0-4392-841c-142d3300674f","id":"r134-ce9dac18-dea0-4392-841c-142d3300674f","lifecycle_state":"stable","resource_type":"share_accessor_binding"}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -24795,9 +25460,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/shares/testString/mount_targets';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"mount_targets":[{"access_control_mode":"security_group","created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","lifecycle_state":"stable","mount_path":"10.240.1.23:/nxg_s_voll_mz7121_58e7e963_8f4b_4a0c_b71a_8ba8d9cd1e2e","name":"my-share-mount-target","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"share_mount_target","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"transit_encryption":"none","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"mount_targets":[{"access_control_mode":"security_group","created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","lifecycle_state":"stable","mount_path":"10.240.1.23:/nxg_s_voll_mz7121_58e7e963_8f4b_4a0c_b71a_8ba8d9cd1e2e","name":"my-share-mount-target","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"share_mount_target","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"transit_encryption":"none","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"mount_targets":[{"access_control_mode":"security_group","created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","lifecycle_state":"stable","mount_path":"10.240.1.23:/nxg_s_voll_mz7121_58e7e963_8f4b_4a0c_b71a_8ba8d9cd1e2e","name":"my-share-mount-target","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"share_mount_target","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"transit_encryption":"none","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
+        '{"total_count":2,"limit":1,"mount_targets":[{"access_control_mode":"security_group","created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","lifecycle_state":"stable","mount_path":"10.240.1.23:/nxg_s_voll_mz7121_58e7e963_8f4b_4a0c_b71a_8ba8d9cd1e2e","name":"my-share-mount-target","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"share_mount_target","subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"transit_encryption":"none","virtual_network_interface":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","name":"my-virtual-network-interface","resource_type":"virtual_network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -24869,7 +25534,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       // SubnetIdentityById
@@ -25522,9 +26187,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/backup_policies';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"backup_policies":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::backup-policy:r134-076191ba-49c2-4763-94fd-c70de73ee2e6","health_reasons":[{"code":"missing_service_authorization_policies","message":"One or more accounts are missing service authorization policies","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-backup-service-about&interface=ui"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6","id":"r134-076191ba-49c2-4763-94fd-c70de73ee2e6","last_job_completed_at":"2019-01-01T12:00:00.000Z","lifecycle_state":"stable","match_user_tags":["match_user_tags"],"name":"my-backup-policy","plans":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"backup_policy","scope":{"crn":"crn:v1:bluemix:public:enterprise::a/aa2432b1fa4d4ace891e9b80fc104e34::enterprise:ebc2b430240943458b9e91e1432cfcce","id":"fee82deba12e4c0fb69c3b09d1f12345","resource_type":"enterprise"},"included_content":["data_volumes"],"match_resource_type":"instance"}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"backup_policies":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::backup-policy:r134-076191ba-49c2-4763-94fd-c70de73ee2e6","health_reasons":[{"code":"missing_service_authorization_policies","message":"One or more accounts are missing service authorization policies","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-backup-service-about&interface=ui"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6","id":"r134-076191ba-49c2-4763-94fd-c70de73ee2e6","last_job_completed_at":"2019-01-01T12:00:00.000Z","lifecycle_state":"stable","match_user_tags":["match_user_tags"],"name":"my-backup-policy","plans":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"backup_policy","scope":{"crn":"crn:v1:bluemix:public:enterprise::a/aa2432b1fa4d4ace891e9b80fc104e34::enterprise:ebc2b430240943458b9e91e1432cfcce","id":"ebc2b430240943458b9e91e1432cfcce","resource_type":"enterprise"},"included_content":["data_volumes"],"match_resource_type":"instance"}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"backup_policies":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::backup-policy:r134-076191ba-49c2-4763-94fd-c70de73ee2e6","health_reasons":[{"code":"missing_service_authorization_policies","message":"One or more accounts are missing service authorization policies","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-backup-service-about&interface=ui"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6","id":"r134-076191ba-49c2-4763-94fd-c70de73ee2e6","last_job_completed_at":"2019-01-01T12:00:00.000Z","lifecycle_state":"stable","match_user_tags":["match_user_tags"],"name":"my-backup-policy","plans":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"backup_policy","scope":{"crn":"crn:v1:bluemix:public:enterprise::a/aa2432b1fa4d4ace891e9b80fc104e34::enterprise:ebc2b430240943458b9e91e1432cfcce","id":"fee82deba12e4c0fb69c3b09d1f12345","resource_type":"enterprise"},"included_content":["data_volumes"],"match_resource_type":"instance"}],"total_count":2,"limit":1}';
+        '{"backup_policies":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::backup-policy:r134-076191ba-49c2-4763-94fd-c70de73ee2e6","health_reasons":[{"code":"missing_service_authorization_policies","message":"One or more accounts are missing service authorization policies","more_info":"https://cloud.ibm.com/docs/vpc?topic=vpc-backup-service-about&interface=ui"}],"health_state":"ok","href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6","id":"r134-076191ba-49c2-4763-94fd-c70de73ee2e6","last_job_completed_at":"2019-01-01T12:00:00.000Z","lifecycle_state":"stable","match_user_tags":["match_user_tags"],"name":"my-backup-policy","plans":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/backup_policies/r134-076191ba-49c2-4763-94fd-c70de73ee2e6/plans/r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","id":"r134-6da51cfe-6f7b-4638-a6ba-00e9c327b178","name":"my-policy-plan","remote":{"region":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south","name":"us-south"}},"resource_type":"backup_policy_plan"}],"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"backup_policy","scope":{"crn":"crn:v1:bluemix:public:enterprise::a/aa2432b1fa4d4ace891e9b80fc104e34::enterprise:ebc2b430240943458b9e91e1432cfcce","id":"ebc2b430240943458b9e91e1432cfcce","resource_type":"enterprise"},"included_content":["data_volumes"],"match_resource_type":"instance"}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -27270,9 +27935,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/virtual_network_interfaces';
       const mockPagerResponse1 =
-        '{"virtual_network_interfaces":[{"allow_ip_spoofing":true,"auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","enable_infrastructure_nat":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","ips":[{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"}],"lifecycle_state":"stable","mac_address":"02:00:4D:45:45:4D","name":"my-virtual-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"protocol_state_filtering_mode":"auto","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"virtual_network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1}';
+        '{"virtual_network_interfaces":[{"allow_ip_spoofing":true,"auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","enable_infrastructure_nat":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","ips":[{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"}],"lifecycle_state":"stable","mac_address":"02:00:4D:45:45:4D","name":"my-virtual-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"protocol_state_filtering_mode":"auto","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"virtual_network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"virtual_network_interfaces":[{"allow_ip_spoofing":true,"auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","enable_infrastructure_nat":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","id":"0767-fa41aecb-4f21-423d-8082-630bfba1e1d9","ips":[{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"}],"lifecycle_state":"stable","mac_address":"02:00:4D:45:45:4D","name":"my-virtual-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"protocol_state_filtering_mode":"auto","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"virtual_network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+        '{"virtual_network_interfaces":[{"allow_ip_spoofing":true,"auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::virtual-network-interface:0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","enable_infrastructure_nat":true,"href":"https://us-south.iaas.cloud.ibm.com/v1/virtual_network_interfaces/0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","id":"0717-54eb57ee-86f2-4796-90bb-d7874e0831ef","ips":[{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"}],"lifecycle_state":"stable","mac_address":"02:00:4D:45:45:4D","name":"my-virtual-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"protocol_state_filtering_mode":"auto","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"virtual_network_interface","security_groups":[{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group"}],"subnet":{"crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::subnet:0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","id":"0717-7ec86020-1c6e-4889-b3f0-a15f2e50f87e","name":"my-subnet","resource_type":"subnet"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/shares/r006-0fe9e5d8-0a4d-4818-96ec-e99708644a58/mount_targets/4cf9171a-0043-4434-8727-15b53dbc374c","id":"4cf9171a-0043-4434-8727-15b53dbc374c","name":"my-share-mount-target","resource_type":"share_mount_target"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -27828,9 +28493,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/virtual_network_interfaces/testString/floating_ips';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip"}]}';
+        '{"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip"}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -28626,6 +29291,2495 @@ describe('VpcV1', () => {
     });
   });
 
+  describe('listClusterNetworkProfiles', () => {
+    describe('positive tests', () => {
+      function __listClusterNetworkProfilesTest() {
+        // Construct the params object for operation listClusterNetworkProfiles
+        const start = 'testString';
+        const limit = 50;
+        const listClusterNetworkProfilesParams = {
+          start,
+          limit,
+        };
+
+        const listClusterNetworkProfilesResult = vpcService.listClusterNetworkProfiles(
+          listClusterNetworkProfilesParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(listClusterNetworkProfilesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_network/profiles', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.qs.start).toEqual(start);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listClusterNetworkProfilesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __listClusterNetworkProfilesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __listClusterNetworkProfilesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listClusterNetworkProfilesParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.listClusterNetworkProfiles(listClusterNetworkProfilesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        vpcService.listClusterNetworkProfiles({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+
+    describe('ClusterNetworkProfilesPager tests', () => {
+      const serviceUrl = vpcServiceOptions.url;
+      const path = '/cluster_network/profiles';
+      const mockPagerResponse1 =
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"profiles":[{"family":"vela","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_network/profiles/h100","name":"h100","resource_type":"cluster_network_profile","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"zones":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}]}]}';
+      const mockPagerResponse2 =
+        '{"total_count":2,"limit":1,"profiles":[{"family":"vela","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_network/profiles/h100","name":"h100","resource_type":"cluster_network_profile","supported_instance_profiles":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-4x16","name":"bx2-4x16","resource_type":"instance_profile"}],"zones":[{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}]}]}';
+
+      beforeEach(() => {
+        unmock_createRequest();
+        const scope = nock(serviceUrl)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse1)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse2);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        mock_createRequest();
+      });
+
+      test('getNext()', async () => {
+        const params = {
+          limit: 10,
+        };
+        const allResults = [];
+        const pager = new VpcV1.ClusterNetworkProfilesPager(vpcService, params);
+        while (pager.hasNext()) {
+          const nextPage = await pager.getNext();
+          expect(nextPage).not.toBeNull();
+          allResults.push(...nextPage);
+        }
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+
+      test('getAll()', async () => {
+        const params = {
+          limit: 10,
+        };
+        const pager = new VpcV1.ClusterNetworkProfilesPager(vpcService, params);
+        const allResults = await pager.getAll();
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('getClusterNetworkProfile', () => {
+    describe('positive tests', () => {
+      function __getClusterNetworkProfileTest() {
+        // Construct the params object for operation getClusterNetworkProfile
+        const name = 'h100';
+        const getClusterNetworkProfileParams = {
+          name,
+        };
+
+        const getClusterNetworkProfileResult = vpcService.getClusterNetworkProfile(
+          getClusterNetworkProfileParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(getClusterNetworkProfileResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_network/profiles/{name}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.name).toEqual(name);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getClusterNetworkProfileTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __getClusterNetworkProfileTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __getClusterNetworkProfileTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const name = 'h100';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getClusterNetworkProfileParams = {
+          name,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.getClusterNetworkProfile(getClusterNetworkProfileParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkProfile({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkProfile();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('listClusterNetworks', () => {
+    describe('positive tests', () => {
+      function __listClusterNetworksTest() {
+        // Construct the params object for operation listClusterNetworks
+        const start = 'testString';
+        const limit = 50;
+        const resourceGroupId = 'testString';
+        const name = 'my-name';
+        const sort = 'name';
+        const vpcId = 'testString';
+        const vpcCrn =
+          'crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b';
+        const vpcName = 'my-vpc';
+        const listClusterNetworksParams = {
+          start,
+          limit,
+          resourceGroupId,
+          name,
+          sort,
+          vpcId,
+          vpcCrn,
+          vpcName,
+        };
+
+        const listClusterNetworksResult = vpcService.listClusterNetworks(listClusterNetworksParams);
+
+        // all methods should return a Promise
+        expectToBePromise(listClusterNetworksResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_networks', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.qs.start).toEqual(start);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs['resource_group.id']).toEqual(resourceGroupId);
+        expect(mockRequestOptions.qs.name).toEqual(name);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.qs['vpc.id']).toEqual(vpcId);
+        expect(mockRequestOptions.qs['vpc.crn']).toEqual(vpcCrn);
+        expect(mockRequestOptions.qs['vpc.name']).toEqual(vpcName);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listClusterNetworksTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __listClusterNetworksTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __listClusterNetworksTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listClusterNetworksParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.listClusterNetworks(listClusterNetworksParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        vpcService.listClusterNetworks({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+
+    describe('ClusterNetworksPager tests', () => {
+      const serviceUrl = vpcServiceOptions.url;
+      const path = '/cluster_networks';
+      const mockPagerResponse1 =
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"cluster_networks":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:0717-da0df18c-7598-4633-a648-fdaac28a5573","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573","id":"0717-da0df18c-7598-4633-a648-fdaac28a5573","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-cluster-network","profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_network/profiles/h100","name":"h100","resource_type":"cluster_network_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"cluster_network","subnet_prefixes":[{"allocation_policy":"auto","cidr":"10.0.0.0/24"}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+      const mockPagerResponse2 =
+        '{"cluster_networks":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::cluster-network:0717-da0df18c-7598-4633-a648-fdaac28a5573","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573","id":"0717-da0df18c-7598-4633-a648-fdaac28a5573","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-cluster-network","profile":{"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_network/profiles/h100","name":"h100","resource_type":"cluster_network_profile"},"resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"cluster_network","subnet_prefixes":[{"allocation_policy":"auto","cidr":"10.0.0.0/24"}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+
+      beforeEach(() => {
+        unmock_createRequest();
+        const scope = nock(serviceUrl)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse1)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse2);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        mock_createRequest();
+      });
+
+      test('getNext()', async () => {
+        const params = {
+          limit: 10,
+          resourceGroupId: 'testString',
+          name: 'my-name',
+          sort: 'name',
+          vpcId: 'testString',
+          vpcCrn:
+            'crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b',
+          vpcName: 'my-vpc',
+        };
+        const allResults = [];
+        const pager = new VpcV1.ClusterNetworksPager(vpcService, params);
+        while (pager.hasNext()) {
+          const nextPage = await pager.getNext();
+          expect(nextPage).not.toBeNull();
+          allResults.push(...nextPage);
+        }
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+
+      test('getAll()', async () => {
+        const params = {
+          limit: 10,
+          resourceGroupId: 'testString',
+          name: 'my-name',
+          sort: 'name',
+          vpcId: 'testString',
+          vpcCrn:
+            'crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b',
+          vpcName: 'my-vpc',
+        };
+        const pager = new VpcV1.ClusterNetworksPager(vpcService, params);
+        const allResults = await pager.getAll();
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('createClusterNetwork', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // ClusterNetworkProfileIdentityByName
+      const clusterNetworkProfileIdentityModel = {
+        name: 'h100',
+      };
+
+      // VPCIdentityById
+      const vpcIdentityModel = {
+        id: 'r006-4727d842-f94f-4a2d-824a-9bc9b02c523b',
+      };
+
+      // ZoneIdentityByName
+      const zoneIdentityModel = {
+        name: 'us-south-1',
+      };
+
+      // ResourceGroupIdentityById
+      const resourceGroupIdentityModel = {
+        id: 'fee82deba12e4c0fb69c3b09d1f12345',
+      };
+
+      // ClusterNetworkSubnetPrefixPrototype
+      const clusterNetworkSubnetPrefixPrototypeModel = {
+        cidr: '10.0.0.0/24',
+      };
+
+      function __createClusterNetworkTest() {
+        // Construct the params object for operation createClusterNetwork
+        const profile = clusterNetworkProfileIdentityModel;
+        const vpc = vpcIdentityModel;
+        const zone = zoneIdentityModel;
+        const name = 'my-cluster-network';
+        const resourceGroup = resourceGroupIdentityModel;
+        const subnetPrefixes = [clusterNetworkSubnetPrefixPrototypeModel];
+        const createClusterNetworkParams = {
+          profile,
+          vpc,
+          zone,
+          name,
+          resourceGroup,
+          subnetPrefixes,
+        };
+
+        const createClusterNetworkResult = vpcService.createClusterNetwork(
+          createClusterNetworkParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(createClusterNetworkResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_networks', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.profile).toEqual(profile);
+        expect(mockRequestOptions.body.vpc).toEqual(vpc);
+        expect(mockRequestOptions.body.zone).toEqual(zone);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.subnet_prefixes).toEqual(subnetPrefixes);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createClusterNetworkTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __createClusterNetworkTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __createClusterNetworkTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const profile = clusterNetworkProfileIdentityModel;
+        const vpc = vpcIdentityModel;
+        const zone = zoneIdentityModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createClusterNetworkParams = {
+          profile,
+          vpc,
+          zone,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.createClusterNetwork(createClusterNetworkParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetwork({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetwork();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('listClusterNetworkInterfaces', () => {
+    describe('positive tests', () => {
+      function __listClusterNetworkInterfacesTest() {
+        // Construct the params object for operation listClusterNetworkInterfaces
+        const clusterNetworkId = 'testString';
+        const start = 'testString';
+        const limit = 50;
+        const name = 'my-name';
+        const sort = 'name';
+        const listClusterNetworkInterfacesParams = {
+          clusterNetworkId,
+          start,
+          limit,
+          name,
+          sort,
+        };
+
+        const listClusterNetworkInterfacesResult = vpcService.listClusterNetworkInterfaces(
+          listClusterNetworkInterfacesParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(listClusterNetworkInterfacesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/interfaces',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.qs.start).toEqual(start);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.name).toEqual(name);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listClusterNetworkInterfacesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __listClusterNetworkInterfacesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __listClusterNetworkInterfacesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listClusterNetworkInterfacesParams = {
+          clusterNetworkId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.listClusterNetworkInterfaces(listClusterNetworkInterfacesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.listClusterNetworkInterfaces({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listClusterNetworkInterfaces();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+
+    describe('ClusterNetworkInterfacesPager tests', () => {
+      const serviceUrl = vpcServiceOptions.url;
+      const path = '/cluster_networks/testString/interfaces';
+      const mockPagerResponse1 =
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"interfaces":[{"allow_ip_spoofing":true,"auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","enable_infrastructure_nat":false,"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/interfaces/0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","id":"0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","mac_address":"02:00:4D:45:45:4D","name":"my-cluster-network-interface","primary_ip":{"address":"10.1.0.6","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930/reserved_ips/6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-cluster-network-subnet-reserved-ip","resource_type":"cluster_network_subnet_reserved_ip"},"resource_type":"cluster_network_interface","subnet":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","id":"0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","name":"my-cluster-network-subnet","resource_type":"cluster_network_subnet"},"target":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+      const mockPagerResponse2 =
+        '{"interfaces":[{"allow_ip_spoofing":true,"auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","enable_infrastructure_nat":false,"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/interfaces/0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","id":"0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","mac_address":"02:00:4D:45:45:4D","name":"my-cluster-network-interface","primary_ip":{"address":"10.1.0.6","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930/reserved_ips/6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-cluster-network-subnet-reserved-ip","resource_type":"cluster_network_subnet_reserved_ip"},"resource_type":"cluster_network_interface","subnet":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","id":"0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","name":"my-cluster-network-subnet","resource_type":"cluster_network_subnet"},"target":{"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/cluster_network_attachments/0717-fb880975-db45-4459-8548-64e3995ac213","id":"0717-fb880975-db45-4459-8548-64e3995ac213","name":"my-instance-network-attachment","resource_type":"instance_cluster_network_attachment"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}],"total_count":2,"limit":1}';
+
+      beforeEach(() => {
+        unmock_createRequest();
+        const scope = nock(serviceUrl)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse1)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse2);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        mock_createRequest();
+      });
+
+      test('getNext()', async () => {
+        const params = {
+          clusterNetworkId: 'testString',
+          limit: 10,
+          name: 'my-name',
+          sort: 'name',
+        };
+        const allResults = [];
+        const pager = new VpcV1.ClusterNetworkInterfacesPager(vpcService, params);
+        while (pager.hasNext()) {
+          const nextPage = await pager.getNext();
+          expect(nextPage).not.toBeNull();
+          allResults.push(...nextPage);
+        }
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+
+      test('getAll()', async () => {
+        const params = {
+          clusterNetworkId: 'testString',
+          limit: 10,
+          name: 'my-name',
+          sort: 'name',
+        };
+        const pager = new VpcV1.ClusterNetworkInterfacesPager(vpcService, params);
+        const allResults = await pager.getAll();
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('createClusterNetworkInterface', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPPrototypeClusterNetworkInterfacePrimaryIPContext
+      const clusterNetworkInterfacePrimaryIpPrototypeModel = {
+        address: '10.0.0.5',
+        auto_delete: false,
+        name: 'my-cluster-network-subnet-reserved-ip',
+      };
+
+      // ClusterNetworkSubnetIdentityById
+      const clusterNetworkSubnetIdentityModel = {
+        id: '0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930',
+      };
+
+      function __createClusterNetworkInterfaceTest() {
+        // Construct the params object for operation createClusterNetworkInterface
+        const clusterNetworkId = 'testString';
+        const name = 'my-cluster-network-interface';
+        const primaryIp = clusterNetworkInterfacePrimaryIpPrototypeModel;
+        const subnet = clusterNetworkSubnetIdentityModel;
+        const createClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          name,
+          primaryIp,
+          subnet,
+        };
+
+        const createClusterNetworkInterfaceResult = vpcService.createClusterNetworkInterface(
+          createClusterNetworkInterfaceParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(createClusterNetworkInterfaceResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/interfaces',
+          'POST'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.primary_ip).toEqual(primaryIp);
+        expect(mockRequestOptions.body.subnet).toEqual(subnet);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createClusterNetworkInterfaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __createClusterNetworkInterfaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __createClusterNetworkInterfaceTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.createClusterNetworkInterface(createClusterNetworkInterfaceParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkInterface({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteClusterNetworkInterface', () => {
+    describe('positive tests', () => {
+      function __deleteClusterNetworkInterfaceTest() {
+        // Construct the params object for operation deleteClusterNetworkInterface
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const deleteClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          id,
+          ifMatch,
+        };
+
+        const deleteClusterNetworkInterfaceResult = vpcService.deleteClusterNetworkInterface(
+          deleteClusterNetworkInterfaceParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(deleteClusterNetworkInterfaceResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/interfaces/{id}',
+          'DELETE'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteClusterNetworkInterfaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __deleteClusterNetworkInterfaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __deleteClusterNetworkInterfaceTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.deleteClusterNetworkInterface(deleteClusterNetworkInterfaceParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetworkInterface({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getClusterNetworkInterface', () => {
+    describe('positive tests', () => {
+      function __getClusterNetworkInterfaceTest() {
+        // Construct the params object for operation getClusterNetworkInterface
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const getClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          id,
+        };
+
+        const getClusterNetworkInterfaceResult = vpcService.getClusterNetworkInterface(
+          getClusterNetworkInterfaceParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(getClusterNetworkInterfaceResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/interfaces/{id}',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getClusterNetworkInterfaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __getClusterNetworkInterfaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __getClusterNetworkInterfaceTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.getClusterNetworkInterface(getClusterNetworkInterfaceParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkInterface({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('updateClusterNetworkInterface', () => {
+    describe('positive tests', () => {
+      function __updateClusterNetworkInterfaceTest() {
+        // Construct the params object for operation updateClusterNetworkInterface
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const autoDelete = false;
+        const name = 'my-cluster-network-interface';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const updateClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          id,
+          autoDelete,
+          name,
+          ifMatch,
+        };
+
+        const updateClusterNetworkInterfaceResult = vpcService.updateClusterNetworkInterface(
+          updateClusterNetworkInterfaceParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(updateClusterNetworkInterfaceResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/interfaces/{id}',
+          'PATCH'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/merge-patch+json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.auto_delete).toEqual(autoDelete);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateClusterNetworkInterfaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __updateClusterNetworkInterfaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __updateClusterNetworkInterfaceTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const updateClusterNetworkInterfaceParams = {
+          clusterNetworkId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.updateClusterNetworkInterface(updateClusterNetworkInterfaceParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetworkInterface({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetworkInterface();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('listClusterNetworkSubnets', () => {
+    describe('positive tests', () => {
+      function __listClusterNetworkSubnetsTest() {
+        // Construct the params object for operation listClusterNetworkSubnets
+        const clusterNetworkId = 'testString';
+        const start = 'testString';
+        const limit = 50;
+        const name = 'my-name';
+        const sort = 'name';
+        const listClusterNetworkSubnetsParams = {
+          clusterNetworkId,
+          start,
+          limit,
+          name,
+          sort,
+        };
+
+        const listClusterNetworkSubnetsResult = vpcService.listClusterNetworkSubnets(
+          listClusterNetworkSubnetsParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(listClusterNetworkSubnetsResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.qs.start).toEqual(start);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.name).toEqual(name);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listClusterNetworkSubnetsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __listClusterNetworkSubnetsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __listClusterNetworkSubnetsTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listClusterNetworkSubnetsParams = {
+          clusterNetworkId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.listClusterNetworkSubnets(listClusterNetworkSubnetsParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.listClusterNetworkSubnets({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listClusterNetworkSubnets();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+
+    describe('ClusterNetworkSubnetsPager tests', () => {
+      const serviceUrl = vpcServiceOptions.url;
+      const path = '/cluster_networks/testString/subnets';
+      const mockPagerResponse1 =
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"subnets":[{"available_ipv4_address_count":15,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","id":"0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","ip_version":"ipv4","ipv4_cidr_block":"10.0.0.0/24","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-cluster-network-subnet","resource_type":"cluster_network_subnet","total_ipv4_address_count":256}]}';
+      const mockPagerResponse2 =
+        '{"total_count":2,"limit":1,"subnets":[{"available_ipv4_address_count":15,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","id":"0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930","ip_version":"ipv4","ipv4_cidr_block":"10.0.0.0/24","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-cluster-network-subnet","resource_type":"cluster_network_subnet","total_ipv4_address_count":256}]}';
+
+      beforeEach(() => {
+        unmock_createRequest();
+        const scope = nock(serviceUrl)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse1)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse2);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        mock_createRequest();
+      });
+
+      test('getNext()', async () => {
+        const params = {
+          clusterNetworkId: 'testString',
+          limit: 10,
+          name: 'my-name',
+          sort: 'name',
+        };
+        const allResults = [];
+        const pager = new VpcV1.ClusterNetworkSubnetsPager(vpcService, params);
+        while (pager.hasNext()) {
+          const nextPage = await pager.getNext();
+          expect(nextPage).not.toBeNull();
+          allResults.push(...nextPage);
+        }
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+
+      test('getAll()', async () => {
+        const params = {
+          clusterNetworkId: 'testString',
+          limit: 10,
+          name: 'my-name',
+          sort: 'name',
+        };
+        const pager = new VpcV1.ClusterNetworkSubnetsPager(vpcService, params);
+        const allResults = await pager.getAll();
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('createClusterNetworkSubnet', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // ClusterNetworkSubnetPrototypeClusterNetworkSubnetByTotalCountPrototype
+      const clusterNetworkSubnetPrototypeModel = {
+        ip_version: 'ipv4',
+        name: 'my-cluster-network-subnet',
+        total_ipv4_address_count: 256,
+      };
+
+      function __createClusterNetworkSubnetTest() {
+        // Construct the params object for operation createClusterNetworkSubnet
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetPrototype = clusterNetworkSubnetPrototypeModel;
+        const createClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetPrototype,
+        };
+
+        const createClusterNetworkSubnetResult = vpcService.createClusterNetworkSubnet(
+          createClusterNetworkSubnetParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(createClusterNetworkSubnetResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets',
+          'POST'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body).toEqual(clusterNetworkSubnetPrototype);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createClusterNetworkSubnetTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __createClusterNetworkSubnetTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __createClusterNetworkSubnetTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetPrototype = clusterNetworkSubnetPrototypeModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetPrototype,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.createClusterNetworkSubnet(createClusterNetworkSubnetParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkSubnet({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkSubnet();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('listClusterNetworkSubnetReservedIps', () => {
+    describe('positive tests', () => {
+      function __listClusterNetworkSubnetReservedIpsTest() {
+        // Construct the params object for operation listClusterNetworkSubnetReservedIps
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const start = 'testString';
+        const limit = 50;
+        const name = 'my-name';
+        const sort = 'name';
+        const listClusterNetworkSubnetReservedIpsParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          start,
+          limit,
+          name,
+          sort,
+        };
+
+        const listClusterNetworkSubnetReservedIpsResult =
+          vpcService.listClusterNetworkSubnetReservedIps(listClusterNetworkSubnetReservedIpsParams);
+
+        // all methods should return a Promise
+        expectToBePromise(listClusterNetworkSubnetReservedIpsResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.qs.start).toEqual(start);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.name).toEqual(name);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.cluster_network_subnet_id).toEqual(clusterNetworkSubnetId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listClusterNetworkSubnetReservedIpsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __listClusterNetworkSubnetReservedIpsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __listClusterNetworkSubnetReservedIpsTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listClusterNetworkSubnetReservedIpsParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.listClusterNetworkSubnetReservedIps(listClusterNetworkSubnetReservedIpsParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.listClusterNetworkSubnetReservedIps({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.listClusterNetworkSubnetReservedIps();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+
+    describe('ClusterNetworkSubnetReservedIpsPager tests', () => {
+      const serviceUrl = vpcServiceOptions.url;
+      const path = '/cluster_networks/testString/subnets/testString/reserved_ips';
+      const mockPagerResponse1 =
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"reserved_ips":[{"address":"10.1.0.6","auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930/reserved_ips/6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"6d353a0f-aeb1-4ae1-832e-1110d10981bb","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-cluster-network-subnet-reserved-ip","owner":"user","resource_type":"cluster_network_subnet_reserved_ip","target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/interfaces/0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","id":"0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","name":"my-cluster-network-interface","resource_type":"cluster_network_interface"}}],"total_count":2,"limit":1}';
+      const mockPagerResponse2 =
+        '{"reserved_ips":[{"address":"10.1.0.6","auto_delete":false,"created_at":"2019-01-01T12:00:00.000Z","href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/subnets/0717-7931845c-65c4-4b0a-80cd-7d9c1a6d7930/reserved_ips/6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"6d353a0f-aeb1-4ae1-832e-1110d10981bb","lifecycle_reasons":[{"code":"resource_suspended_by_provider","message":"The resource has been suspended. Contact IBM support with the CRN for next steps.","more_info":"https://cloud.ibm.com/apidocs/vpc#resource-suspension"}],"lifecycle_state":"stable","name":"my-cluster-network-subnet-reserved-ip","owner":"user","resource_type":"cluster_network_subnet_reserved_ip","target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/cluster_networks/0717-da0df18c-7598-4633-a648-fdaac28a5573/interfaces/0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","id":"0717-ffc092f7-5d02-4b93-ab69-26860529b9fb","name":"my-cluster-network-interface","resource_type":"cluster_network_interface"}}],"total_count":2,"limit":1}';
+
+      beforeEach(() => {
+        unmock_createRequest();
+        const scope = nock(serviceUrl)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse1)
+          .get((uri) => uri.includes(path))
+          .reply(200, mockPagerResponse2);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        mock_createRequest();
+      });
+
+      test('getNext()', async () => {
+        const params = {
+          clusterNetworkId: 'testString',
+          clusterNetworkSubnetId: 'testString',
+          limit: 10,
+          name: 'my-name',
+          sort: 'name',
+        };
+        const allResults = [];
+        const pager = new VpcV1.ClusterNetworkSubnetReservedIpsPager(vpcService, params);
+        while (pager.hasNext()) {
+          const nextPage = await pager.getNext();
+          expect(nextPage).not.toBeNull();
+          allResults.push(...nextPage);
+        }
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+
+      test('getAll()', async () => {
+        const params = {
+          clusterNetworkId: 'testString',
+          clusterNetworkSubnetId: 'testString',
+          limit: 10,
+          name: 'my-name',
+          sort: 'name',
+        };
+        const pager = new VpcV1.ClusterNetworkSubnetReservedIpsPager(vpcService, params);
+        const allResults = await pager.getAll();
+        expect(allResults).not.toBeNull();
+        expect(allResults).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('createClusterNetworkSubnetReservedIp', () => {
+    describe('positive tests', () => {
+      function __createClusterNetworkSubnetReservedIpTest() {
+        // Construct the params object for operation createClusterNetworkSubnetReservedIp
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const address = '192.168.3.4';
+        const name = 'my-cluster-network-subnet-reserved-ip';
+        const createClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          address,
+          name,
+        };
+
+        const createClusterNetworkSubnetReservedIpResult =
+          vpcService.createClusterNetworkSubnetReservedIp(
+            createClusterNetworkSubnetReservedIpParams
+          );
+
+        // all methods should return a Promise
+        expectToBePromise(createClusterNetworkSubnetReservedIpResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips',
+          'POST'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.address).toEqual(address);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.cluster_network_subnet_id).toEqual(clusterNetworkSubnetId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createClusterNetworkSubnetReservedIpTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __createClusterNetworkSubnetReservedIpTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __createClusterNetworkSubnetReservedIpTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.createClusterNetworkSubnetReservedIp(createClusterNetworkSubnetReservedIpParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkSubnetReservedIp({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.createClusterNetworkSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteClusterNetworkSubnetReservedIp', () => {
+    describe('positive tests', () => {
+      function __deleteClusterNetworkSubnetReservedIpTest() {
+        // Construct the params object for operation deleteClusterNetworkSubnetReservedIp
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const id = 'testString';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const deleteClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          id,
+          ifMatch,
+        };
+
+        const deleteClusterNetworkSubnetReservedIpResult =
+          vpcService.deleteClusterNetworkSubnetReservedIp(
+            deleteClusterNetworkSubnetReservedIpParams
+          );
+
+        // all methods should return a Promise
+        expectToBePromise(deleteClusterNetworkSubnetReservedIpResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips/{id}',
+          'DELETE'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.cluster_network_subnet_id).toEqual(clusterNetworkSubnetId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteClusterNetworkSubnetReservedIpTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __deleteClusterNetworkSubnetReservedIpTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __deleteClusterNetworkSubnetReservedIpTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.deleteClusterNetworkSubnetReservedIp(deleteClusterNetworkSubnetReservedIpParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetworkSubnetReservedIp({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetworkSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getClusterNetworkSubnetReservedIp', () => {
+    describe('positive tests', () => {
+      function __getClusterNetworkSubnetReservedIpTest() {
+        // Construct the params object for operation getClusterNetworkSubnetReservedIp
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const id = 'testString';
+        const getClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          id,
+        };
+
+        const getClusterNetworkSubnetReservedIpResult =
+          vpcService.getClusterNetworkSubnetReservedIp(getClusterNetworkSubnetReservedIpParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getClusterNetworkSubnetReservedIpResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips/{id}',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.cluster_network_subnet_id).toEqual(clusterNetworkSubnetId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getClusterNetworkSubnetReservedIpTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __getClusterNetworkSubnetReservedIpTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __getClusterNetworkSubnetReservedIpTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.getClusterNetworkSubnetReservedIp(getClusterNetworkSubnetReservedIpParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkSubnetReservedIp({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('updateClusterNetworkSubnetReservedIp', () => {
+    describe('positive tests', () => {
+      function __updateClusterNetworkSubnetReservedIpTest() {
+        // Construct the params object for operation updateClusterNetworkSubnetReservedIp
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const id = 'testString';
+        const autoDelete = false;
+        const name = 'my-cluster-network-subnet-reserved-ip';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const updateClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          id,
+          autoDelete,
+          name,
+          ifMatch,
+        };
+
+        const updateClusterNetworkSubnetReservedIpResult =
+          vpcService.updateClusterNetworkSubnetReservedIp(
+            updateClusterNetworkSubnetReservedIpParams
+          );
+
+        // all methods should return a Promise
+        expectToBePromise(updateClusterNetworkSubnetReservedIpResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips/{id}',
+          'PATCH'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/merge-patch+json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.auto_delete).toEqual(autoDelete);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.cluster_network_subnet_id).toEqual(clusterNetworkSubnetId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateClusterNetworkSubnetReservedIpTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __updateClusterNetworkSubnetReservedIpTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __updateClusterNetworkSubnetReservedIpTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const clusterNetworkSubnetId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const updateClusterNetworkSubnetReservedIpParams = {
+          clusterNetworkId,
+          clusterNetworkSubnetId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.updateClusterNetworkSubnetReservedIp(updateClusterNetworkSubnetReservedIpParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetworkSubnetReservedIp({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetworkSubnetReservedIp();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteClusterNetworkSubnet', () => {
+    describe('positive tests', () => {
+      function __deleteClusterNetworkSubnetTest() {
+        // Construct the params object for operation deleteClusterNetworkSubnet
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const deleteClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          id,
+          ifMatch,
+        };
+
+        const deleteClusterNetworkSubnetResult = vpcService.deleteClusterNetworkSubnet(
+          deleteClusterNetworkSubnetParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(deleteClusterNetworkSubnetResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{id}',
+          'DELETE'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteClusterNetworkSubnetTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __deleteClusterNetworkSubnetTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __deleteClusterNetworkSubnetTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.deleteClusterNetworkSubnet(deleteClusterNetworkSubnetParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetworkSubnet({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetworkSubnet();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getClusterNetworkSubnet', () => {
+    describe('positive tests', () => {
+      function __getClusterNetworkSubnetTest() {
+        // Construct the params object for operation getClusterNetworkSubnet
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const getClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          id,
+        };
+
+        const getClusterNetworkSubnetResult = vpcService.getClusterNetworkSubnet(
+          getClusterNetworkSubnetParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(getClusterNetworkSubnetResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{id}',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getClusterNetworkSubnetTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __getClusterNetworkSubnetTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __getClusterNetworkSubnetTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.getClusterNetworkSubnet(getClusterNetworkSubnetParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkSubnet({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetworkSubnet();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('updateClusterNetworkSubnet', () => {
+    describe('positive tests', () => {
+      function __updateClusterNetworkSubnetTest() {
+        // Construct the params object for operation updateClusterNetworkSubnet
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const name = 'my-cluster-network-subnet';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const updateClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          id,
+          name,
+          ifMatch,
+        };
+
+        const updateClusterNetworkSubnetResult = vpcService.updateClusterNetworkSubnet(
+          updateClusterNetworkSubnetParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(updateClusterNetworkSubnetResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/cluster_networks/{cluster_network_id}/subnets/{id}',
+          'PATCH'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/merge-patch+json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.cluster_network_id).toEqual(clusterNetworkId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateClusterNetworkSubnetTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __updateClusterNetworkSubnetTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __updateClusterNetworkSubnetTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const clusterNetworkId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const updateClusterNetworkSubnetParams = {
+          clusterNetworkId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.updateClusterNetworkSubnet(updateClusterNetworkSubnetParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetworkSubnet({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetworkSubnet();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteClusterNetwork', () => {
+    describe('positive tests', () => {
+      function __deleteClusterNetworkTest() {
+        // Construct the params object for operation deleteClusterNetwork
+        const id = 'testString';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const deleteClusterNetworkParams = {
+          id,
+          ifMatch,
+        };
+
+        const deleteClusterNetworkResult = vpcService.deleteClusterNetwork(
+          deleteClusterNetworkParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(deleteClusterNetworkResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_networks/{id}', 'DELETE');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteClusterNetworkTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __deleteClusterNetworkTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __deleteClusterNetworkTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteClusterNetworkParams = {
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.deleteClusterNetwork(deleteClusterNetworkParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetwork({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.deleteClusterNetwork();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getClusterNetwork', () => {
+    describe('positive tests', () => {
+      function __getClusterNetworkTest() {
+        // Construct the params object for operation getClusterNetwork
+        const id = 'testString';
+        const getClusterNetworkParams = {
+          id,
+        };
+
+        const getClusterNetworkResult = vpcService.getClusterNetwork(getClusterNetworkParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getClusterNetworkResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_networks/{id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getClusterNetworkTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __getClusterNetworkTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __getClusterNetworkTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getClusterNetworkParams = {
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.getClusterNetwork(getClusterNetworkParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetwork({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.getClusterNetwork();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('updateClusterNetwork', () => {
+    describe('positive tests', () => {
+      function __updateClusterNetworkTest() {
+        // Construct the params object for operation updateClusterNetwork
+        const id = 'testString';
+        const name = 'my-cluster-network';
+        const ifMatch = 'W/"96d225c4-56bd-43d9-98fc-d7148e5c5028"';
+        const updateClusterNetworkParams = {
+          id,
+          name,
+          ifMatch,
+        };
+
+        const updateClusterNetworkResult = vpcService.updateClusterNetwork(
+          updateClusterNetworkParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(updateClusterNetworkResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/cluster_networks/{id}', 'PATCH');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/merge-patch+json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.qs.version).toEqual(vpcServiceOptions.version);
+        expect(mockRequestOptions.qs.generation).toEqual(vpcServiceOptions.generation);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateClusterNetworkTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        vpcService.enableRetries();
+        __updateClusterNetworkTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        vpcService.disableRetries();
+        __updateClusterNetworkTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const updateClusterNetworkParams = {
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        vpcService.updateClusterNetwork(updateClusterNetworkParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetwork({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await vpcService.updateClusterNetwork();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
   describe('listPublicGateways', () => {
     describe('positive tests', () => {
       function __listPublicGatewaysTest() {
@@ -28701,9 +31855,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/public_gateways';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"public_gateways":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::public-gateway:dc5431ef-1fc6-4861-adc9-a59d077d1241","floating_ip":{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip"},"href":"https://us-south.iaas.cloud.ibm.com/v1/public_gateways/dc5431ef-1fc6-4861-adc9-a59d077d1241","id":"dc5431ef-1fc6-4861-adc9-a59d077d1241","name":"my-public-gateway","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"public_gateway","status":"available","vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"public_gateways":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::public-gateway:dc5431ef-1fc6-4861-adc9-a59d077d1241","floating_ip":{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip"},"href":"https://us-south.iaas.cloud.ibm.com/v1/public_gateways/dc5431ef-1fc6-4861-adc9-a59d077d1241","id":"dc5431ef-1fc6-4861-adc9-a59d077d1241","name":"my-public-gateway","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"public_gateway","status":"available","vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"public_gateways":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::public-gateway:dc5431ef-1fc6-4861-adc9-a59d077d1241","floating_ip":{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip"},"href":"https://us-south.iaas.cloud.ibm.com/v1/public_gateways/dc5431ef-1fc6-4861-adc9-a59d077d1241","id":"dc5431ef-1fc6-4861-adc9-a59d077d1241","name":"my-public-gateway","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"public_gateway","status":"available","vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"total_count":2,"limit":1,"public_gateways":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::public-gateway:dc5431ef-1fc6-4861-adc9-a59d077d1241","floating_ip":{"address":"203.0.113.1","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip"},"href":"https://us-south.iaas.cloud.ibm.com/v1/public_gateways/dc5431ef-1fc6-4861-adc9-a59d077d1241","id":"dc5431ef-1fc6-4861-adc9-a59d077d1241","name":"my-public-gateway","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"resource_type":"public_gateway","status":"available","vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -28764,7 +31918,7 @@ describe('VpcV1', () => {
 
       // PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityById
       const publicGatewayFloatingIpPrototypeModel = {
-        id: '39300233-9995-4806-89a5-3c1b6eb88689',
+        id: 'r006-f45e0d90-12a8-4460-8210-290ff2ab75cd',
       };
 
       // ResourceGroupIdentityById
@@ -29222,9 +32376,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/floating_ips';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"status":"available","target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"status":"available","target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:39300233-9995-4806-89a5-3c1b6eb88689","href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","name":"my-floating-ip","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"status":"available","target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
+        '{"total_count":2,"limit":1,"floating_ips":[{"address":"203.0.113.1","created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south-1:a/aa2432b1fa4d4ace891e9b80fc104e34::floating-ip:r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","href":"https://us-south.iaas.cloud.ibm.com/v1/floating_ips/r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","id":"r006-f45e0d90-12a8-4460-8210-290ff2ab75cd","name":"my-floating-ip","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"status":"available","target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","primary_ip":{"address":"192.168.3.4","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/subnets/0717-bea6a632-5e13-42a4-b4b8-31dc877abfe4/reserved_ips/0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","id":"0717-6d353a0f-aeb1-4ae1-832e-1110d10981bb","name":"my-reserved-ip","resource_type":"subnet_reserved_ip"},"resource_type":"network_interface"},"zone":{"href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/us-south-1","name":"us-south-1"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -29564,7 +32718,7 @@ describe('VpcV1', () => {
 
       // FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById
       const floatingIpTargetPatchModel = {
-        id: '10c02d81-0ecb-4dc5-897d-28392913b81e',
+        id: '0717-da8c43ec-b6ca-4bd2-871e-72e288c66ee6',
       };
 
       function __updateFloatingIpTest() {
@@ -30836,9 +33990,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/security_groups';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"security_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"rules":[{"direction":"inbound","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/be5df5ca-12a0-494b-907e-aa6ec2bfa271/rules/6f2a6efe-21e2-401c-b237-620aa26ba16a","id":"6f2a6efe-21e2-401c-b237-620aa26ba16a","ip_version":"ipv4","local":{"address":"192.168.3.4"},"remote":{"address":"192.168.3.4"},"protocol":"all"}],"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","resource_type":"network_interface"}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}],"total_count":2,"limit":1}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"security_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"rules":[{"direction":"inbound","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271/rules/r006-6f2a6efe-21e2-401c-b237-620aa26ba16a","id":"r006-6f2a6efe-21e2-401c-b237-620aa26ba16a","ip_version":"ipv4","local":{"address":"192.168.3.4"},"remote":{"address":"192.168.3.4"},"protocol":"all"}],"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","resource_type":"network_interface"}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}],"total_count":2,"limit":1}';
       const mockPagerResponse2 =
-        '{"security_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"rules":[{"direction":"inbound","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/be5df5ca-12a0-494b-907e-aa6ec2bfa271/rules/6f2a6efe-21e2-401c-b237-620aa26ba16a","id":"6f2a6efe-21e2-401c-b237-620aa26ba16a","ip_version":"ipv4","local":{"address":"192.168.3.4"},"remote":{"address":"192.168.3.4"},"protocol":"all"}],"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","resource_type":"network_interface"}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}],"total_count":2,"limit":1}';
+        '{"security_groups":[{"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::security-group:r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","id":"r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271","name":"my-security-group","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"rules":[{"direction":"inbound","href":"https://us-south.iaas.cloud.ibm.com/v1/security_groups/r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271/rules/r006-6f2a6efe-21e2-401c-b237-620aa26ba16a","id":"r006-6f2a6efe-21e2-401c-b237-620aa26ba16a","ip_version":"ipv4","local":{"address":"192.168.3.4"},"remote":{"address":"192.168.3.4"},"protocol":"all"}],"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","resource_type":"network_interface"}],"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}],"total_count":2,"limit":1}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -31683,9 +34837,9 @@ describe('VpcV1', () => {
         address: '192.168.3.4',
       };
 
-      // SecurityGroupRuleRemotePatchIP
+      // SecurityGroupRuleRemotePatchCIDR
       const securityGroupRuleRemotePatchModel = {
-        address: '192.168.3.4',
+        cidr_block: '10.0.0.0/8',
       };
 
       function __updateSecurityGroupRuleTest() {
@@ -31696,10 +34850,10 @@ describe('VpcV1', () => {
         const direction = 'inbound';
         const ipVersion = 'ipv4';
         const local = securityGroupRuleLocalPatchModel;
-        const portMax = 22;
-        const portMin = 22;
+        const portMax = 1;
+        const portMin = 1;
         const remote = securityGroupRuleRemotePatchModel;
-        const type = 8;
+        const type = 0;
         const updateSecurityGroupRuleParams = {
           securityGroupId,
           id,
@@ -31908,9 +35062,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/security_groups/testString/targets';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","resource_type":"network_interface"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","resource_type":"network_interface"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","resource_type":"network_interface"}]}';
+        '{"total_count":2,"limit":1,"targets":[{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","resource_type":"network_interface"}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -35650,7 +38804,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       function __createVpnServerTest() {
@@ -37551,7 +40705,7 @@ describe('VpcV1', () => {
 
       // LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById
       const loadBalancerPoolMemberTargetPrototypeModel = {
-        id: '0717_1e09281b-f177-46f2-b1f1-bc152b2e391a',
+        id: '0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0',
       };
 
       // LoadBalancerPoolMemberPrototype
@@ -37590,7 +40744,7 @@ describe('VpcV1', () => {
 
       // SecurityGroupIdentityById
       const securityGroupIdentityModel = {
-        id: 'be5df5ca-12a0-494b-907e-aa6ec2bfa271',
+        id: 'r006-be5df5ca-12a0-494b-907e-aa6ec2bfa271',
       };
 
       function __createLoadBalancerTest() {
@@ -39929,7 +43083,7 @@ describe('VpcV1', () => {
 
       // LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById
       const loadBalancerPoolMemberTargetPrototypeModel = {
-        id: '0717_1e09281b-f177-46f2-b1f1-bc152b2e391a',
+        id: '0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0',
       };
 
       // LoadBalancerPoolMemberPrototype
@@ -40486,7 +43640,7 @@ describe('VpcV1', () => {
 
       // LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById
       const loadBalancerPoolMemberTargetPrototypeModel = {
-        id: '0717_1e09281b-f177-46f2-b1f1-bc152b2e391a',
+        id: '0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0',
       };
 
       function __createLoadBalancerPoolMemberTest() {
@@ -40603,7 +43757,7 @@ describe('VpcV1', () => {
 
       // LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById
       const loadBalancerPoolMemberTargetPrototypeModel = {
-        id: '0717_1e09281b-f177-46f2-b1f1-bc152b2e391a',
+        id: '0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0',
       };
 
       // LoadBalancerPoolMemberPrototype
@@ -40923,7 +44077,7 @@ describe('VpcV1', () => {
 
       // LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById
       const loadBalancerPoolMemberTargetPrototypeModel = {
-        id: '0717_1e09281b-f177-46f2-b1f1-bc152b2e391a',
+        id: '0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0',
       };
 
       function __updateLoadBalancerPoolMemberTest() {
@@ -42142,9 +45296,9 @@ describe('VpcV1', () => {
       const serviceUrl = vpcServiceOptions.url;
       const path = '/flow_log_collectors';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"flow_log_collectors":[{"active":true,"auto_delete":true,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::flow-log-collector:39300233-9995-4806-89a5-3c1b6eb88689","href":"https://us-south.iaas.cloud.ibm.com/v1/flow_log_collectors/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","lifecycle_state":"stable","name":"my-flow-log-collector","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"storage_bucket":{"name":"bucket-27200-lwx4cfvcue"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","resource_type":"network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
+        '{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"flow_log_collectors":[{"active":true,"auto_delete":true,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::flow-log-collector:39300233-9995-4806-89a5-3c1b6eb88689","href":"https://us-south.iaas.cloud.ibm.com/v1/flow_log_collectors/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","lifecycle_state":"stable","name":"my-flow-log-collector","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"storage_bucket":{"name":"bucket-27200-lwx4cfvcue"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","resource_type":"network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"flow_log_collectors":[{"active":true,"auto_delete":true,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::flow-log-collector:39300233-9995-4806-89a5-3c1b6eb88689","href":"https://us-south.iaas.cloud.ibm.com/v1/flow_log_collectors/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","lifecycle_state":"stable","name":"my-flow-log-collector","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"storage_bucket":{"name":"bucket-27200-lwx4cfvcue"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/1e09281b-f177-46fb-baf1-bc152b2e391a/network_interfaces/0717-10c02d81-0ecb-4dc5-897d-28392913b81e","id":"0717-10c02d81-0ecb-4dc5-897d-28392913b81e","name":"my-instance-network-interface","resource_type":"network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
+        '{"total_count":2,"limit":1,"flow_log_collectors":[{"active":true,"auto_delete":true,"created_at":"2019-01-01T12:00:00.000Z","crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::flow-log-collector:39300233-9995-4806-89a5-3c1b6eb88689","href":"https://us-south.iaas.cloud.ibm.com/v1/flow_log_collectors/39300233-9995-4806-89a5-3c1b6eb88689","id":"39300233-9995-4806-89a5-3c1b6eb88689","lifecycle_state":"stable","name":"my-flow-log-collector","resource_group":{"href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/fee82deba12e4c0fb69c3b09d1f12345","id":"fee82deba12e4c0fb69c3b09d1f12345","name":"my-resource-group"},"storage_bucket":{"name":"bucket-27200-lwx4cfvcue"},"target":{"deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/instances/0717_e21b7391-2ca2-4ab5-84a8-b92157a633b0/network_interfaces/0717-d54eb633-98ea-459d-aa00-6a8e780175a7","id":"0717-d54eb633-98ea-459d-aa00-6a8e780175a7","name":"my-instance-network-interface","resource_type":"network_interface"},"vpc":{"crn":"crn:v1:bluemix:public:is:us-south:a/aa2432b1fa4d4ace891e9b80fc104e34::vpc:r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","deleted":{"more_info":"https://cloud.ibm.com/apidocs/vpc#deleted-resources"},"href":"https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","id":"r006-4727d842-f94f-4a2d-824a-9bc9b02c523b","name":"my-vpc","resource_type":"vpc"}}]}';
 
       beforeEach(() => {
         unmock_createRequest();
@@ -42214,7 +45368,7 @@ describe('VpcV1', () => {
 
       // FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById
       const flowLogCollectorTargetPrototypeModel = {
-        id: '0717-10c02d81-0ecb-4dc5-897d-28392913b81e',
+        id: '0717-d54eb633-98ea-459d-aa00-6a8e780175a7',
       };
 
       // ResourceGroupIdentityById

--- a/vpc/v1.ts
+++ b/vpc/v1.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.92.2-3f2a0533-20240712-183330
+ * IBM OpenAPI SDK Code Generator Version: 3.96.1-5136e54a-20241108-203028
  */
 
 /* eslint-disable max-classes-per-file */
@@ -39,7 +39,7 @@ import { getSdkHeaders } from '../lib/common';
  * The IBM Cloud Virtual Private Cloud (VPC) API can be used to programmatically provision and manage virtual server
  * instances, along with subnets, volumes, load balancers, and more.
  *
- * API Version: 2024-10-17
+ * API Version: 2024-11-13
  */
 
 class VpcV1 extends BaseService {
@@ -84,7 +84,7 @@ class VpcV1 extends BaseService {
   generation?: number;
 
   /** The API version, in format `YYYY-MM-DD`. For the API behavior documented here, specify any date between
-   *  `2024-04-30` and `2024-10-17`.
+   *  `2024-04-30` and `2024-11-14`.
    */
   version: string;
 
@@ -95,7 +95,7 @@ class VpcV1 extends BaseService {
    * @param {number} [options.generation] - The infrastructure generation. For the API behavior documented here, specify
    * `2`.
    * @param {string} options.version - The API version, in format `YYYY-MM-DD`. For the API behavior documented here,
-   * specify any date between `2024-04-30` and `2024-10-17`.
+   * specify any date between `2024-04-30` and `2024-11-14`.
    * @param {string} [options.serviceUrl] - The base URL for the service
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {Authenticator} options.authenticator - The Authenticator object used to authenticate requests to the service
@@ -120,7 +120,7 @@ class VpcV1 extends BaseService {
     if (!('generation' in options)) {
       this.generation = 2;
     }
-    this.version = options.version || '2024-10-15';
+    this.version = options.version || '2024-11-12';
   }
 
   /*************************
@@ -200,10 +200,14 @@ class VpcV1 extends BaseService {
    *
    * Since address prefixes are managed identically regardless of whether they were automatically created, the value is
    * not preserved as a VPC property.
-   * @param {boolean} [params.classicAccess] - Indicates whether this VPC will be connected to Classic Infrastructure.
-   * If true, this VPC's resources will have private network connectivity to the account's Classic Infrastructure
-   * resources. Only one VPC, per region, may be connected in this way. This value is set at creation and subsequently
-   * immutable.
+   * @param {boolean} [params.classicAccess] - Deprecated: Indicates whether this VPC will be connected to Classic
+   * Infrastructure. If true, this VPC's resources will have private network connectivity to the account's Classic
+   * Infrastructure resources. Only one VPC, per region, may be connected in this way. This value is set at creation and
+   * subsequently immutable.
+   *
+   * This property has been deprecated. Instead, use a [Transit Gateway](https://cloud.ibm.com/docs/transit-gateway) to
+   * connect this VPC to Classic Infrastructure. For more information, see [upcoming
+   * changes](https://cloud.ibm.com/docs/vpc?topic=vpc-api-change-log#upcoming-changes).
    * @param {VPCDNSPrototype} [params.dns] - The DNS configuration for this VPC.
    *
    * If unspecified, the system will assign DNS servers capable of resolving hosts and endpoint
@@ -1734,6 +1738,8 @@ class VpcV1 extends BaseService {
    * @param {string} params.vpcId - The VPC identifier.
    * @param {ResourceFilter[]} [params.acceptRoutesFrom] - The filters specifying the resources that may create routes
    * in this routing table.
+   *
+   * If specified, `resource_type` must be `vpn_gateway` or `vpn_server`.
    * @param {string[]} [params.advertiseRoutesTo] - The ingress sources to advertise routes to. Routes in the table with
    * `advertise` enabled will be advertised to these sources.
    * @param {string} [params.name] - The name for this routing table. The name must not be used by another routing table
@@ -1968,6 +1974,8 @@ class VpcV1 extends BaseService {
    * (replacing any existing filters). All routes created by resources that match a given filter will be removed when an
    * existing filter is removed. Therefore, if an empty array is specified, all filters will be removed, resulting in
    * all routes not directly created by the user being removed.
+   *
+   * If specified, `resource_type` must be `vpn_gateway` or `vpn_server`.
    * @param {string[]} [params.advertiseRoutesTo] - The ingress sources to advertise routes to, replacing any existing
    * sources to advertise to. Routes in the table with `advertise` enabled will be advertised to these sources.
    * @param {string} [params.name] - The name for this routing table. The name must not be used by another routing table
@@ -4402,6 +4410,8 @@ class VpcV1 extends BaseService {
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
    * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources with a `resource_group.id` property
+   * matching the specified identifier.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.KeyCollection>>}
    */
@@ -4410,7 +4420,7 @@ class VpcV1 extends BaseService {
   ): Promise<VpcV1.Response<VpcV1.KeyCollection>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['start', 'limit', 'headers'];
+    const _validParams = ['start', 'limit', 'resourceGroupId', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -4421,6 +4431,7 @@ class VpcV1 extends BaseService {
       'generation': this.generation,
       'start': _params.start,
       'limit': _params.limit,
+      'resource_group.id': _params.resourceGroupId,
     };
 
     const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listKeys');
@@ -5078,6 +5089,12 @@ class VpcV1 extends BaseService {
    * matching the specified identifier.
    * @param {string} [params.name] - Filters the collection to resources with a `name` property matching the exact
    * specified name.
+   * @param {string} [params.clusterNetworkId] - Filters the collection to instances with a `cluster_network.id`
+   * property matching the specified identifier.
+   * @param {string} [params.clusterNetworkCrn] - Filters the collection to instances with a `cluster_network.crn`
+   * property matching the specified CRN.
+   * @param {string} [params.clusterNetworkName] - Filters the collection to resources with a `cluster_network.name`
+   * property matching the exact specified name.
    * @param {string} [params.dedicatedHostId] - Filters the collection to resources with a `dedicated_host.id` property
    * matching the specified identifier.
    * @param {string} [params.dedicatedHostCrn] - Filters the collection to resources with a `dedicated_host.crn`
@@ -5110,7 +5127,7 @@ class VpcV1 extends BaseService {
   ): Promise<VpcV1.Response<VpcV1.InstanceCollection>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['start', 'limit', 'resourceGroupId', 'name', 'dedicatedHostId', 'dedicatedHostCrn', 'dedicatedHostName', 'placementGroupId', 'placementGroupCrn', 'placementGroupName', 'reservationId', 'reservationCrn', 'reservationName', 'vpcId', 'vpcCrn', 'vpcName', 'headers'];
+    const _validParams = ['start', 'limit', 'resourceGroupId', 'name', 'clusterNetworkId', 'clusterNetworkCrn', 'clusterNetworkName', 'dedicatedHostId', 'dedicatedHostCrn', 'dedicatedHostName', 'placementGroupId', 'placementGroupCrn', 'placementGroupName', 'reservationId', 'reservationCrn', 'reservationName', 'vpcId', 'vpcCrn', 'vpcName', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -5123,6 +5140,9 @@ class VpcV1 extends BaseService {
       'limit': _params.limit,
       'resource_group.id': _params.resourceGroupId,
       'name': _params.name,
+      'cluster_network.id': _params.clusterNetworkId,
+      'cluster_network.crn': _params.clusterNetworkCrn,
+      'cluster_network.name': _params.clusterNetworkName,
       'dedicated_host.id': _params.dedicatedHostId,
       'dedicated_host.crn': _params.dedicatedHostCrn,
       'dedicated_host.name': _params.dedicatedHostName,
@@ -5355,13 +5375,13 @@ class VpcV1 extends BaseService {
    * server instance. For the placement restrictions to be changed, the instance `status` must be `stopping` or
    * `stopped`.
    * If set, `reservation_affinity.policy` must be `disabled`.
-   * @param {InstancePatchProfile} [params.profile] - The profile to use for this virtual server instance. For the
-   * profile to be changed,
-   * the instance `status` must be `stopping` or `stopped`. In addition, the requested
-   * profile must:
-   * - Have matching instance disk support. Any disks associated with the current profile
-   *   will be deleted, and any disks associated with the requested profile will be
-   *   created.
+   * @param {InstancePatchProfile} [params.profile] - The profile to use for this virtual server instance. Any disks
+   * associated with the
+   * current profile will be deleted, and any disks associated with the requested profile
+   * will be created.
+   *
+   * For the profile to be changed, the instance `status` must be `stopping` or `stopped`.
+   * In addition, the requested profile must:
    * - Be compatible with any `placement_target` constraints. For example, if the
    *   instance is placed on a dedicated host, the requested profile `family` must be
    *   the same as the dedicated host `family`.
@@ -5547,6 +5567,330 @@ class VpcV1 extends BaseService {
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * List cluster network attachments on an instance.
+   *
+   * This request lists cluster network attachments on an instance. A cluster network attachment represents a device on
+   * the instance to which a cluster network interface is attached.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The virtual server instance identifier.
+   * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
+   * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachmentCollection>>}
+   */
+  public listInstanceClusterNetworkAttachments(
+    params: VpcV1.ListInstanceClusterNetworkAttachmentsParams
+  ): Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachmentCollection>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId'];
+    const _validParams = ['instanceId', 'start', 'limit', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+      'start': _params.start,
+      'limit': _params.limit,
+    };
+
+    const path = {
+      'instance_id': _params.instanceId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listInstanceClusterNetworkAttachments');
+
+    const parameters = {
+      options: {
+        url: '/instances/{instance_id}/cluster_network_attachments',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a cluster network attachment.
+   *
+   * This request creates a cluster network attachment from an instance cluster network attachment prototype object. A
+   * cluster network attachment will attach the instance to a cluster network. The cluster network attachment prototype
+   * must specify a cluster network interface identity or a cluster network interface prototype.
+   *
+   * The instance must be in a `stopped` or `stopping` state to create an instance cluster network attachment.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The virtual server instance identifier.
+   * @param {InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterface} params.clusterNetworkInterface - A
+   * cluster network interface for the instance cluster network attachment. This can be
+   * specified using an existing cluster network interface that does not already have a `target`,
+   * or a prototype object for a new cluster network interface.
+   *
+   * This instance must reside in the same VPC as the specified cluster network interface. The
+   * cluster network interface must reside in the same cluster network as the
+   * `cluster_network_interface` of any other `cluster_network_attachments` for this instance.
+   * @param {InstanceClusterNetworkAttachmentBeforePrototype} [params.before] - The instance cluster network attachment
+   * to insert this instance cluster network attachment
+   * immediately before.
+   *
+   * If unspecified, this instance cluster network attachment will be inserted after all
+   * existing instance cluster network attachments.
+   * @param {string} [params.name] - The name for this cluster network attachment. Names must be unique within the
+   * instance the cluster network attachment resides in. If unspecified, the name will be a hyphenated list of
+   * randomly-selected words. Names starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>>}
+   */
+  public createClusterNetworkAttachment(
+    params: VpcV1.CreateClusterNetworkAttachmentParams
+  ): Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId', 'clusterNetworkInterface'];
+    const _validParams = ['instanceId', 'clusterNetworkInterface', 'before', 'name', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'cluster_network_interface': _params.clusterNetworkInterface,
+      'before': _params.before,
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'instance_id': _params.instanceId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'createClusterNetworkAttachment');
+
+    const parameters = {
+      options: {
+        url: '/instances/{instance_id}/cluster_network_attachments',
+        method: 'POST',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete an instance cluster network attachment.
+   *
+   * This request deletes an instance cluster network attachment. The instance must be in a
+   * `stopped` or `stopping` state to delete an instance cluster network attachment.
+   *
+   * This operation cannot be reversed.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The virtual server instance identifier.
+   * @param {string} params.id - The instance cluster network attachment identifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>>}
+   */
+  public deleteInstanceClusterNetworkAttachment(
+    params: VpcV1.DeleteInstanceClusterNetworkAttachmentParams
+  ): Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId', 'id'];
+    const _validParams = ['instanceId', 'id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'instance_id': _params.instanceId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteInstanceClusterNetworkAttachment');
+
+    const parameters = {
+      options: {
+        url: '/instances/{instance_id}/cluster_network_attachments/{id}',
+        method: 'DELETE',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve an instance cluster network attachment.
+   *
+   * This request retrieves a single instance cluster network attachment specified by the identifier in the URL.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The virtual server instance identifier.
+   * @param {string} params.id - The instance cluster network attachment identifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>>}
+   */
+  public getInstanceClusterNetworkAttachment(
+    params: VpcV1.GetInstanceClusterNetworkAttachmentParams
+  ): Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId', 'id'];
+    const _validParams = ['instanceId', 'id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'instance_id': _params.instanceId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'getInstanceClusterNetworkAttachment');
+
+    const parameters = {
+      options: {
+        url: '/instances/{instance_id}/cluster_network_attachments/{id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update an instance cluster network attachment.
+   *
+   * This request updates an instance cluster network attachment with the information provided in an instance network
+   * interface patch object. The instance cluster network attachment patch object is structured in the same way as a
+   * retrieved instance cluster network attachment and needs to contain only the information to be updated.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - The virtual server instance identifier.
+   * @param {string} params.id - The instance cluster network attachment identifier.
+   * @param {string} [params.name] - The name for this network attachment. The name must not be used by another network
+   * attachment for the instance. Names starting with `ibm-` are reserved for provider-owned resources, and are not
+   * allowed.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>>}
+   */
+  public updateInstanceClusterNetworkAttachment(
+    params: VpcV1.UpdateInstanceClusterNetworkAttachmentParams
+  ): Promise<VpcV1.Response<VpcV1.InstanceClusterNetworkAttachment>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId', 'id'];
+    const _validParams = ['instanceId', 'id', 'name', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'instance_id': _params.instanceId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'updateInstanceClusterNetworkAttachment');
+
+    const parameters = {
+      options: {
+        url: '/instances/{instance_id}/cluster_network_attachments/{id}',
+        method: 'PATCH',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/merge-patch+json',
           },
           _params.headers
         ),
@@ -14091,7 +14435,7 @@ class VpcV1 extends BaseService {
    * The requested profile must be in the same `family`.
    * @param {string} [params.replicationCronSpec] - The cron specification for the file share replication schedule.
    *
-   * Replication of a share can be scheduled to occur at most once per hour.
+   * Replication of a share can be scheduled to occur at most once every 15 minutes.
    *
    * For this property to be changed, the share `replication_role` must be `replica`.
    * @param {number} [params.size] - The size of the file share rounded up to the next gigabyte. The value must not be
@@ -16172,17 +16516,21 @@ class VpcV1 extends BaseService {
    * @param {string} [params.name] - The name for this virtual network interface. The name must not be used by another
    * virtual network interface in the region. Names beginning with `ibm-` are reserved for provider-owned resources, and
    * are not allowed.
-   * @param {string} [params.protocolStateFilteringMode] - The protocol state filtering mode used for this virtual
-   * network interface. If `auto`, protocol state packet filtering is enabled or disabled based on the virtual network
-   * interface's `target` resource type:
+   * @param {string} [params.protocolStateFilteringMode] - The protocol state filtering mode to use for this virtual
+   * network interface. If
+   * `auto`, protocol state packet filtering is enabled or disabled based on the virtual network interface's `target`
+   * resource type:
    *
    * - `bare_metal_server_network_attachment`: disabled
    * - `instance_network_attachment`: enabled
    * - `share_mount_target`: enabled
    *
+   * Must not be `disabled` if the virtual network interface's `target` resource type is
+   * `share_mount_target`.
+   *
    * Protocol state filtering monitors each network connection flowing over this virtual network interface, and drops
    * any packets that are invalid based on the current connection state and protocol. See [Protocol state filtering
-   * mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering)) for more information.
+   * mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering) for more information.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.VirtualNetworkInterface>>}
    */
@@ -16714,6 +17062,1437 @@ class VpcV1 extends BaseService {
           sdkHeaders,
           {
             'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+  /*************************
+   * clusterNetworks
+   ************************/
+
+  /**
+   * List cluster network profiles.
+   *
+   * This request lists cluster network profiles available in the region. A cluster network profile specifies the
+   * performance characteristics and capabilities for a cluster network.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
+   * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkProfileCollection>>}
+   */
+  public listClusterNetworkProfiles(
+    params?: VpcV1.ListClusterNetworkProfilesParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkProfileCollection>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['start', 'limit', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+      'start': _params.start,
+      'limit': _params.limit,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listClusterNetworkProfiles');
+
+    const parameters = {
+      options: {
+        url: '/cluster_network/profiles',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a cluster network profile.
+   *
+   * This request retrieves a single cluster network profile specified by the name in the URL.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.name - The cluster network profile name.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkProfile>>}
+   */
+  public getClusterNetworkProfile(
+    params: VpcV1.GetClusterNetworkProfileParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkProfile>> {
+    const _params = { ...params };
+    const _requiredParams = ['name'];
+    const _validParams = ['name', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'name': _params.name,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'getClusterNetworkProfile');
+
+    const parameters = {
+      options: {
+        url: '/cluster_network/profiles/{name}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * List cluster networks.
+   *
+   * This request lists [cluster networks](https://cloud.ibm.com/docs/vpc?topic=vpc-about-cluster-network) in the
+   * region. A cluster network is a grouping of resources in a separate networking space for high performance computing
+   * and networking.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
+   * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {string} [params.resourceGroupId] - Filters the collection to resources with a `resource_group.id` property
+   * matching the specified identifier.
+   * @param {string} [params.name] - Filters the collection to resources with a `name` property matching the exact
+   * specified name.
+   * @param {string} [params.sort] - Sorts the returned collection by the specified property name in ascending order. A
+   * `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the
+   * collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property
+   * in ascending order.
+   * @param {string} [params.vpcId] - Filters the collection to cluster networks with a `vpc.id` property matching the
+   * specified id.
+   * @param {string} [params.vpcCrn] - Filters the collection to cluster networks with a `vpc.crn` property matching the
+   * specified CRN.
+   * @param {string} [params.vpcName] - Filters the collection to cluster networks with a `vpc.name` property matching
+   * the specified name.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkCollection>>}
+   */
+  public listClusterNetworks(
+    params?: VpcV1.ListClusterNetworksParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkCollection>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['start', 'limit', 'resourceGroupId', 'name', 'sort', 'vpcId', 'vpcCrn', 'vpcName', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+      'start': _params.start,
+      'limit': _params.limit,
+      'resource_group.id': _params.resourceGroupId,
+      'name': _params.name,
+      'sort': _params.sort,
+      'vpc.id': _params.vpcId,
+      'vpc.crn': _params.vpcCrn,
+      'vpc.name': _params.vpcName,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listClusterNetworks');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a cluster network.
+   *
+   * This request creates a new cluster network from a cluster network prototype object. The prototype object is
+   * structured in the same way as a retrieved cluster network, and contains the information necessary to create the new
+   * cluster network.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {ClusterNetworkProfileIdentity} params.profile - The profile to use for this cluster network.
+   * @param {VPCIdentity} params.vpc - The VPC this cluster network will reside in.
+   * @param {ZoneIdentity} params.zone - The zone this cluster network will reside in. The zone must be listed
+   * as supported on the specified cluster network profile.
+   * @param {string} [params.name] - The name for this cluster network. The name must not be used by another cluster
+   * network in the region. Names starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+   * If unspecified, the name will be a hyphenated list of randomly-selected words.
+   * @param {ResourceGroupIdentity} [params.resourceGroup] - The resource group to use. If unspecified, the account's
+   * [default resource
+   * group](https://cloud.ibm.com/apidocs/resource-manager#introduction) will be used.
+   * @param {ClusterNetworkSubnetPrefixPrototype[]} [params.subnetPrefixes] -
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetwork>>}
+   */
+  public createClusterNetwork(
+    params: VpcV1.CreateClusterNetworkParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetwork>> {
+    const _params = { ...params };
+    const _requiredParams = ['profile', 'vpc', 'zone'];
+    const _validParams = ['profile', 'vpc', 'zone', 'name', 'resourceGroup', 'subnetPrefixes', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'profile': _params.profile,
+      'vpc': _params.vpc,
+      'zone': _params.zone,
+      'name': _params.name,
+      'resource_group': _params.resourceGroup,
+      'subnet_prefixes': _params.subnetPrefixes,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'createClusterNetwork');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks',
+        method: 'POST',
+        body,
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * List cluster network interfaces.
+   *
+   * This request lists cluster network interfaces in the region. A cluster network interface is a logical abstraction
+   * of a cluster network interface in a subnet, and may be attached to a target resource.
+   *
+   * The cluster network interfaces will be sorted by their `created_at` property values, with newest cluster network
+   * interfaces first. Cluster network interfaces with identical
+   * `created_at` property values will in turn be sorted by ascending `name` property values.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
+   * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {string} [params.name] - Filters the collection to resources with a `name` property matching the exact
+   * specified name.
+   * @param {string} [params.sort] - Sorts the returned collection by the specified property name in ascending order. A
+   * `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the
+   * collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property
+   * in ascending order.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkInterfaceCollection>>}
+   */
+  public listClusterNetworkInterfaces(
+    params: VpcV1.ListClusterNetworkInterfacesParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkInterfaceCollection>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId'];
+    const _validParams = ['clusterNetworkId', 'start', 'limit', 'name', 'sort', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+      'start': _params.start,
+      'limit': _params.limit,
+      'name': _params.name,
+      'sort': _params.sort,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listClusterNetworkInterfaces');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/interfaces',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a cluster network interface.
+   *
+   * This request creates a new cluster network interface from a cluster network interface prototype object. The
+   * prototype object is structured in the same way as a retrieved cluster network interface, and contains the
+   * information necessary to create the new cluster network interface.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} [params.name] - The name for this cluster network interface. The name must not be used by another
+   * interface in the cluster network. Names beginning with `ibm-` are reserved for provider-owned resources, and are
+   * not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
+   * @param {ClusterNetworkInterfacePrimaryIPPrototype} [params.primaryIp] - The primary IP address to bind to the
+   * cluster network interface. May be either
+   * a cluster network subnet reserved IP identity, or a cluster network subnet reserved IP
+   * prototype object which will be used to create a new cluster network subnet reserved IP.
+   *
+   * If a cluster network subnet reserved IP identity is provided, the specified cluster
+   * network subnet reserved IP must be unbound.
+   *
+   * If a cluster network subnet reserved IP prototype object with an address is provided,
+   * the address must be available on the cluster network interface's cluster network
+   * subnet. If no address is specified, an available address on the cluster network subnet
+   * will be automatically selected and reserved.
+   * @param {ClusterNetworkSubnetIdentity} [params.subnet] - The associated cluster network subnet. Required if
+   * `primary_ip` does not specify a cluster
+   * network subnet reserved IP identity.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>>}
+   */
+  public createClusterNetworkInterface(
+    params: VpcV1.CreateClusterNetworkInterfaceParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId'];
+    const _validParams = ['clusterNetworkId', 'name', 'primaryIp', 'subnet', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+      'primary_ip': _params.primaryIp,
+      'subnet': _params.subnet,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'createClusterNetworkInterface');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/interfaces',
+        method: 'POST',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a cluster network interface.
+   *
+   * This request deletes a cluster network interface. This operation cannot be reversed. For this request to succeed,
+   * the cluster network interface must not be required by another resource, such as a cluster network attachment for a
+   * virtual server instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.id - The cluster network interface identifier.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>>}
+   */
+  public deleteClusterNetworkInterface(
+    params: VpcV1.DeleteClusterNetworkInterfaceParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'id'];
+    const _validParams = ['clusterNetworkId', 'id', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteClusterNetworkInterface');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/interfaces/{id}',
+        method: 'DELETE',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a cluster network interface.
+   *
+   * This request retrieves a single cluster network interface specified by the identifier in the URL.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.id - The cluster network interface identifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>>}
+   */
+  public getClusterNetworkInterface(
+    params: VpcV1.GetClusterNetworkInterfaceParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'id'];
+    const _validParams = ['clusterNetworkId', 'id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'getClusterNetworkInterface');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/interfaces/{id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a cluster network interface.
+   *
+   * This request updates a cluster network interface with the information provided in a cluster network interface patch
+   * object. The patch object is structured in the same way as a retrieved cluster network interface and needs to
+   * contain only the information to be updated.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.id - The cluster network interface identifier.
+   * @param {boolean} [params.autoDelete] - Indicates whether this cluster network interface will be automatically
+   * deleted when `target` is deleted. Must be `false` if the cluster network interface is unbound.
+   * @param {string} [params.name] - The name for this cluster network interface. The name must not be used by another
+   * interface in the cluster network. Names beginning with `ibm-` are reserved for provider-owned resources, and are
+   * not allowed.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value. Required if the request body includes an array.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>>}
+   */
+  public updateClusterNetworkInterface(
+    params: VpcV1.UpdateClusterNetworkInterfaceParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkInterface>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'id'];
+    const _validParams = ['clusterNetworkId', 'id', 'autoDelete', 'name', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'auto_delete': _params.autoDelete,
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'updateClusterNetworkInterface');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/interfaces/{id}',
+        method: 'PATCH',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/merge-patch+json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * List cluster network subnets.
+   *
+   * This request lists cluster network subnets in the cluster network. A cluster network subnet provides network
+   * routing between other cluster network subnets within a cluster network.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
+   * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {string} [params.name] - Filters the collection to resources with a `name` property matching the exact
+   * specified name.
+   * @param {string} [params.sort] - Sorts the returned collection by the specified property name in ascending order. A
+   * `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the
+   * collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property
+   * in ascending order.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetCollection>>}
+   */
+  public listClusterNetworkSubnets(
+    params: VpcV1.ListClusterNetworkSubnetsParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetCollection>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId'];
+    const _validParams = ['clusterNetworkId', 'start', 'limit', 'name', 'sort', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+      'start': _params.start,
+      'limit': _params.limit,
+      'name': _params.name,
+      'sort': _params.sort,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listClusterNetworkSubnets');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a cluster network subnet.
+   *
+   * This request creates a new cluster network subnet from a cluster network subnet prototype object. The prototype
+   * object is structured in the same way as a retrieved cluster network subnet, and contains the information necessary
+   * to create the new cluster network subnet.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {ClusterNetworkSubnetPrototype} params.clusterNetworkSubnetPrototype - The cluster network subnet prototype
+   * object.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>>}
+   */
+  public createClusterNetworkSubnet(
+    params: VpcV1.CreateClusterNetworkSubnetParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'clusterNetworkSubnetPrototype'];
+    const _validParams = ['clusterNetworkId', 'clusterNetworkSubnetPrototype', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = _params.clusterNetworkSubnetPrototype;
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'createClusterNetworkSubnet');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets',
+        method: 'POST',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * List cluster network subnet reserved IPs.
+   *
+   * This request lists cluster network subnet reserved IPs in the cluster network.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.clusterNetworkSubnetId - The cluster network subnet identifier.
+   * @param {string} [params.start] - A server-provided token determining what resource to start the page on.
+   * @param {number} [params.limit] - The number of resources to return on a page.
+   * @param {string} [params.name] - Filters the collection to resources with a `name` property matching the exact
+   * specified name.
+   * @param {string} [params.sort] - Sorts the returned collection by the specified property name in ascending order. A
+   * `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the
+   * collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property
+   * in ascending order.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIPCollection>>}
+   */
+  public listClusterNetworkSubnetReservedIps(
+    params: VpcV1.ListClusterNetworkSubnetReservedIpsParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIPCollection>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'clusterNetworkSubnetId'];
+    const _validParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'start', 'limit', 'name', 'sort', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+      'start': _params.start,
+      'limit': _params.limit,
+      'name': _params.name,
+      'sort': _params.sort,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'cluster_network_subnet_id': _params.clusterNetworkSubnetId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'listClusterNetworkSubnetReservedIps');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a cluster network subnet reserved IP.
+   *
+   * This request creates a new cluster network subnet reserved IP from a cluster network subnet reserved IP prototype
+   * object. The prototype object is structured in the same way as a retrieved cluster network subnet reserved IP, and
+   * contains the information necessary to create the new cluster network subnet reserved IP.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.clusterNetworkSubnetId - The cluster network subnet identifier.
+   * @param {string} [params.address] - The IP address to reserve, which must not already be reserved on the subnet.
+   *
+   * If unspecified, an available address on the subnet will automatically be selected.
+   * @param {string} [params.name] - The name for this cluster network subnet reserved IP. The name must not be used by
+   * another reserved IP in the cluster network subnet. Names starting with `ibm-` are reserved for provider-owned
+   * resources, and are not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>>}
+   */
+  public createClusterNetworkSubnetReservedIp(
+    params: VpcV1.CreateClusterNetworkSubnetReservedIpParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'clusterNetworkSubnetId'];
+    const _validParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'address', 'name', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'address': _params.address,
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'cluster_network_subnet_id': _params.clusterNetworkSubnetId,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'createClusterNetworkSubnetReservedIp');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips',
+        method: 'POST',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a cluster network subnet reserved IP.
+   *
+   * This request deletes a cluster network subnet reserved IP. This operation cannot be reversed.
+   *
+   * For this request to succeed, the reserved IP must be unbound. A provider-owned reserved IP is not allowed to be
+   * deleted.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.clusterNetworkSubnetId - The cluster network subnet identifier.
+   * @param {string} params.id - The cluster network subnet reserved IP identifier.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>>}
+   */
+  public deleteClusterNetworkSubnetReservedIp(
+    params: VpcV1.DeleteClusterNetworkSubnetReservedIpParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'id'];
+    const _validParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'id', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'cluster_network_subnet_id': _params.clusterNetworkSubnetId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteClusterNetworkSubnetReservedIp');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips/{id}',
+        method: 'DELETE',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a cluster network subnet reserved IP.
+   *
+   * This request retrieves a single cluster network subnet reserved IP specified by the identifier in the URL.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.clusterNetworkSubnetId - The cluster network subnet identifier.
+   * @param {string} params.id - The cluster network subnet reserved IP identifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>>}
+   */
+  public getClusterNetworkSubnetReservedIp(
+    params: VpcV1.GetClusterNetworkSubnetReservedIpParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'id'];
+    const _validParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'cluster_network_subnet_id': _params.clusterNetworkSubnetId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'getClusterNetworkSubnetReservedIp');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips/{id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a cluster network subnet reserved IP.
+   *
+   * This request updates a cluster network subnet reserved IP with the information provided in a cluster network subnet
+   * reserved IP patch object. The patch object is structured in the same way as a retrieved cluster network subnet
+   * reserved IP and needs to contain only the information to be updated.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.clusterNetworkSubnetId - The cluster network subnet identifier.
+   * @param {string} params.id - The cluster network subnet reserved IP identifier.
+   * @param {boolean} [params.autoDelete] - Indicates whether this cluster network subnet reserved IP member will be
+   * automatically deleted when either `target` is deleted, or the cluster network subnet reserved IP is unbound. Must
+   * be `false` if the cluster network subnet reserved IP is unbound.
+   * @param {string} [params.name] - The name for this cluster network subnet reserved IP. The name must not be used by
+   * another reserved IP in the cluster network subnet. Names starting with `ibm-` are reserved for provider-owned
+   * resources, and are not allowed.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value. Required if the request body includes an array.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>>}
+   */
+  public updateClusterNetworkSubnetReservedIp(
+    params: VpcV1.UpdateClusterNetworkSubnetReservedIpParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnetReservedIP>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'id'];
+    const _validParams = ['clusterNetworkId', 'clusterNetworkSubnetId', 'id', 'autoDelete', 'name', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'auto_delete': _params.autoDelete,
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'cluster_network_subnet_id': _params.clusterNetworkSubnetId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'updateClusterNetworkSubnetReservedIp');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{cluster_network_subnet_id}/reserved_ips/{id}',
+        method: 'PATCH',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/merge-patch+json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a cluster network subnet.
+   *
+   * This request deletes a cluster network subnet. This operation cannot be reversed.
+   *
+   * For this request to succeed, this cluster subnet must not be attached to a cluster network interface.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.id - The cluster network subnet identifier.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>>}
+   */
+  public deleteClusterNetworkSubnet(
+    params: VpcV1.DeleteClusterNetworkSubnetParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'id'];
+    const _validParams = ['clusterNetworkId', 'id', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteClusterNetworkSubnet');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{id}',
+        method: 'DELETE',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a cluster network subnet.
+   *
+   * This request retrieves a single cluster network subnet specified by the identifier in the URL.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.id - The cluster network subnet identifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>>}
+   */
+  public getClusterNetworkSubnet(
+    params: VpcV1.GetClusterNetworkSubnetParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'id'];
+    const _validParams = ['clusterNetworkId', 'id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'getClusterNetworkSubnet');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a cluster network subnet.
+   *
+   * This request updates a cluster network subnet with the information provided in a cluster network subnet patch
+   * object. The patch object is structured in the same way as a retrieved cluster network subnet and needs to contain
+   * only the information to be updated.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.clusterNetworkId - The cluster network identifier.
+   * @param {string} params.id - The cluster network subnet identifier.
+   * @param {string} [params.name] - The name for this cluster network subnet. The name must not be used by another
+   * cluster network subnet in the cluster network. Names starting with `ibm-` are reserved for provider-owned
+   * resources, and are not allowed.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value. Required if the request body includes an array.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>>}
+   */
+  public updateClusterNetworkSubnet(
+    params: VpcV1.UpdateClusterNetworkSubnetParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetworkSubnet>> {
+    const _params = { ...params };
+    const _requiredParams = ['clusterNetworkId', 'id'];
+    const _validParams = ['clusterNetworkId', 'id', 'name', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'cluster_network_id': _params.clusterNetworkId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'updateClusterNetworkSubnet');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{cluster_network_id}/subnets/{id}',
+        method: 'PATCH',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/merge-patch+json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a cluster network.
+   *
+   * This request deletes a cluster network. This operation cannot be reversed.
+   *
+   * For this request to succeed, virtual server instances must not reside in this cluster network.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.id - The cluster network identifier.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetwork>>}
+   */
+  public deleteClusterNetwork(
+    params: VpcV1.DeleteClusterNetworkParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetwork>> {
+    const _params = { ...params };
+    const _requiredParams = ['id'];
+    const _validParams = ['id', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteClusterNetwork');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{id}',
+        method: 'DELETE',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a cluster network.
+   *
+   * This request retrieves a single cluster network specified by the identifier in the URL.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.id - The cluster network identifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetwork>>}
+   */
+  public getClusterNetwork(
+    params: VpcV1.GetClusterNetworkParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetwork>> {
+    const _params = { ...params };
+    const _requiredParams = ['id'];
+    const _validParams = ['id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'getClusterNetwork');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a cluster.
+   *
+   * This request updates a cluster network with the information provided in a cluster network patch object. The patch
+   * object is structured in the same way as a retrieved cluster network and needs to contain only the information to be
+   * updated.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.id - The cluster network identifier.
+   * @param {string} [params.name] - The name for this cluster network. The name must not be used by another cluster
+   * network in the region. Names starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+   * @param {string} [params.ifMatch] - If present, the request will fail if the specified ETag value does not match the
+   * resource's current ETag value. Required if the request body includes an array.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<VpcV1.Response<VpcV1.ClusterNetwork>>}
+   */
+  public updateClusterNetwork(
+    params: VpcV1.UpdateClusterNetworkParams
+  ): Promise<VpcV1.Response<VpcV1.ClusterNetwork>> {
+    const _params = { ...params };
+    const _requiredParams = ['id'];
+    const _validParams = ['id', 'name', 'ifMatch', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+    };
+
+    const query = {
+      'version': this.version,
+      'generation': this.generation,
+    };
+
+    const path = {
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(VpcV1.DEFAULT_SERVICE_NAME, 'v1', 'updateClusterNetwork');
+
+    const parameters = {
+      options: {
+        url: '/cluster_networks/{id}',
+        method: 'PATCH',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/merge-patch+json',
+            'If-Match': _params.ifMatch,
           },
           _params.headers
         ),
@@ -22254,7 +24033,10 @@ class VpcV1 extends BaseService {
    * @param {CertificateInstanceIdentity} [params.certificateInstance] - The certificate instance to use for SSL
    * termination. The listener must have a
    * `protocol` of `https`.
-   * @param {number} [params.connectionLimit] - The connection limit of the listener.
+   * @param {number} [params.connectionLimit] - The concurrent connection limit for the listener. If reached, incoming
+   * connections may be queued or rejected.
+   *
+   * This property will be present for load balancers in the `application` family.
    * @param {LoadBalancerPoolIdentity} [params.defaultPool] - The default pool for this listener. If `https_redirect` is
    * specified, the
    * default pool will not be used.
@@ -22273,8 +24055,9 @@ class VpcV1 extends BaseService {
    *
    * If specified, this listener must have a `protocol` of `http`, and the target
    * listener must have a `protocol` of `https`.
-   * @param {number} [params.idleConnectionTimeout] - The idle connection timeout of the listener in seconds. Supported
-   * for load balancers in the `application` family.
+   * @param {number} [params.idleConnectionTimeout] - The idle connection timeout of the listener in seconds.
+   *
+   * Supported for load balancers in the `application` family.
    * @param {LoadBalancerListenerPolicyPrototype[]} [params.policies] - The policy prototype objects for this listener.
    * The load balancer must be in the
    * `application` family.
@@ -22493,7 +24276,10 @@ class VpcV1 extends BaseService {
    * @param {CertificateInstanceIdentity} [params.certificateInstance] - The certificate instance to use for SSL
    * termination. The listener must have a
    * `protocol` of `https`.
-   * @param {number} [params.connectionLimit] - The connection limit of the listener.
+   * @param {number} [params.connectionLimit] - The concurrent connection limit for the listener. If reached, incoming
+   * connections may be queued or rejected.
+   *
+   * Supported for load balancers in the `application` family.
    * @param {LoadBalancerListenerDefaultPoolPatch} [params.defaultPool] - The default pool for this listener. If
    * `https_redirect` is set, the default pool will not
    * be used. The specified pool must:
@@ -22512,8 +24298,9 @@ class VpcV1 extends BaseService {
    * must have a `protocol` of `https`.
    *
    * Specify `null` to remove any existing https redirect.
-   * @param {number} [params.idleConnectionTimeout] - The idle connection timeout of the listener in seconds. Supported
-   * for load balancers in the `application` family.
+   * @param {number} [params.idleConnectionTimeout] - The idle connection timeout of the listener in seconds.
+   *
+   * Supported for load balancers in the `application` family.
    * @param {number} [params.port] - The listener port number, or the inclusive lower bound of the port range. Each
    * listener in the load balancer must have a unique `port` and `protocol` combination.
    *
@@ -22680,9 +24467,9 @@ class VpcV1 extends BaseService {
    * @param {string} params.listenerId - The listener identifier.
    * @param {string} params.action - The policy action:
    * - `forward`: Requests will be forwarded to the specified `target` pool
-   * - `https_redirect`: Requests will be redirected to the specified target listener. The
-   *   listener must have a `protocol` of `http`, and the target listener must have a
-   *   `protocol` of `https`
+   * - `https_redirect`: Requests will be redirected to the specified `target.listener`.
+   *    This listener must have a `protocol` of `http`, and the target listener must
+   *    have a `protocol` of `https`.
    * - `redirect`: Requests will be redirected to the specified `target.url`
    * - `reject`: Requests will be rejected with a `403` status code.
    * @param {number} params.priority - Priority of the policy. The priority is unique across all policies for this load
@@ -22690,11 +24477,14 @@ class VpcV1 extends BaseService {
    * @param {string} [params.name] - The name for this policy. The name must not be used by another policy for the load
    * balancer listener. If unspecified, the name will be a hyphenated list of randomly-selected words.
    * @param {LoadBalancerListenerPolicyRulePrototype[]} [params.rules] - The rule prototype objects for this policy.
-   * @param {LoadBalancerListenerPolicyTargetPrototype} [params.target] - - If `action` is `forward`, specify a
-   * `LoadBalancerPoolIdentity`.
-   * - If `action` is `https_redirect`, specify a
-   * `LoadBalancerListenerPolicyHTTPSRedirectPrototype`.
-   * - If `action` is `redirect`, specify a `LoadBalancerListenerPolicyRedirectURLPrototype`.
+   * @param {LoadBalancerListenerPolicyTargetPrototype} [params.target] - - If `action` is `forward`, use
+   * `LoadBalancerPoolIdentity` to specify a pool in this
+   *   load balancer to forward to.
+   * - If `action` is `https_redirect`, use
+   *   `LoadBalancerListenerPolicyHTTPSRedirectPrototype` to specify a listener on this
+   *   load balancer to redirect to.
+   * - If `action` is `redirect`, use `LoadBalancerListenerPolicyRedirectURLPrototype`to
+   *   specify a URL to redirect to.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<VpcV1.Response<VpcV1.LoadBalancerListenerPolicy>>}
    */
@@ -23544,7 +25334,8 @@ class VpcV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.loadBalancerId - The load balancer identifier.
    * @param {string} params.id - The pool identifier.
-   * @param {string} [params.algorithm] - The load balancing algorithm.
+   * @param {string} [params.algorithm] - The load balancing algorithm. The `least_connections` algorithm is only
+   * supported for load balancers that have `availability` with value `subnet` in the profile.
    * @param {LoadBalancerPoolHealthMonitorPatch} [params.healthMonitor] - The health monitor of this pool.
    * @param {string} [params.name] - The name for this load balancer pool. The name must not be used by another pool for
    * the load balancer.
@@ -26051,7 +27842,7 @@ namespace VpcV1 {
     /** The infrastructure generation. For the API behavior documented here, specify `2`. */
     generation?: number;
     /** The API version, in format `YYYY-MM-DD`. For the API behavior documented here, specify any date between
-     *  `2024-04-30` and `2024-10-17`.
+     *  `2024-04-30` and `2024-11-14`.
      */
     version: string;
   }
@@ -26102,9 +27893,13 @@ namespace VpcV1 {
      *  is not preserved as a VPC property.
      */
     addressPrefixManagement?: CreateVpcConstants.AddressPrefixManagement | string;
-    /** Indicates whether this VPC will be connected to Classic Infrastructure. If true, this VPC's resources will
-     *  have private network connectivity to the account's Classic Infrastructure resources. Only one VPC, per region,
-     *  may be connected in this way. This value is set at creation and subsequently immutable.
+    /** Deprecated: Indicates whether this VPC will be connected to Classic Infrastructure. If true, this VPC's
+     *  resources will have private network connectivity to the account's Classic Infrastructure resources. Only one
+     *  VPC, per region, may be connected in this way. This value is set at creation and subsequently immutable.
+     *
+     *  This property has been deprecated. Instead, use a [Transit Gateway](https://cloud.ibm.com/docs/transit-gateway)
+     *  to connect this VPC to Classic Infrastructure. For more information, see [upcoming
+     *  changes](https://cloud.ibm.com/docs/vpc?topic=vpc-api-change-log#upcoming-changes).
      */
     classicAccess?: boolean;
     /** The DNS configuration for this VPC.
@@ -26499,7 +28294,10 @@ namespace VpcV1 {
   export interface CreateVpcRoutingTableParams {
     /** The VPC identifier. */
     vpcId: string;
-    /** The filters specifying the resources that may create routes in this routing table. */
+    /** The filters specifying the resources that may create routes in this routing table.
+     *
+     *  If specified, `resource_type` must be `vpn_gateway` or `vpn_server`.
+     */
     acceptRoutesFrom?: ResourceFilter[];
     /** The ingress sources to advertise routes to. Routes in the table with `advertise` enabled will be advertised
      *  to these sources.
@@ -26602,6 +28400,8 @@ namespace VpcV1 {
      *  (replacing any existing filters). All routes created by resources that match a given filter will be removed when
      *  an existing filter is removed. Therefore, if an empty array is specified, all filters will be removed, resulting
      *  in all routes not directly created by the user being removed.
+     *
+     *  If specified, `resource_type` must be `vpn_gateway` or `vpn_server`.
      */
     acceptRoutesFrom?: ResourceFilter[];
     /** The ingress sources to advertise routes to, replacing any existing sources to advertise to. Routes in the
@@ -27259,6 +29059,8 @@ namespace VpcV1 {
     start?: string;
     /** The number of resources to return on a page. */
     limit?: number;
+    /** Filters the collection to resources with a `resource_group.id` property matching the specified identifier. */
+    resourceGroupId?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -27374,6 +29176,14 @@ namespace VpcV1 {
     resourceGroupId?: string;
     /** Filters the collection to resources with a `name` property matching the exact specified name. */
     name?: string;
+    /** Filters the collection to instances with a `cluster_network.id` property matching the specified identifier. */
+    clusterNetworkId?: string;
+    /** Filters the collection to instances with a `cluster_network.crn` property matching the specified CRN. */
+    clusterNetworkCrn?: string;
+    /** Filters the collection to resources with a `cluster_network.name` property matching the exact specified
+     *  name.
+     */
+    clusterNetworkName?: string;
     /** Filters the collection to resources with a `dedicated_host.id` property matching the specified identifier. */
     dedicatedHostId?: string;
     /** Filters the collection to resources with a `dedicated_host.crn` property matching the specified CRN. */
@@ -27461,12 +29271,12 @@ namespace VpcV1 {
      *  If set, `reservation_affinity.policy` must be `disabled`.
      */
     placementTarget?: InstancePlacementTargetPatch;
-    /** The profile to use for this virtual server instance. For the profile to be changed,
-     *  the instance `status` must be `stopping` or `stopped`. In addition, the requested
-     *  profile must:
-     *  - Have matching instance disk support. Any disks associated with the current profile
-     *    will be deleted, and any disks associated with the requested profile will be
-     *    created.
+    /** The profile to use for this virtual server instance. Any disks associated with the
+     *  current profile will be deleted, and any disks associated with the requested profile
+     *  will be created.
+     *
+     *  For the profile to be changed, the instance `status` must be `stopping` or `stopped`.
+     *  In addition, the requested profile must:
      *  - Be compatible with any `placement_target` constraints. For example, if the
      *    instance is placed on a dedicated host, the requested profile `family` must be
      *    the same as the dedicated host `family`.
@@ -27525,6 +29335,76 @@ namespace VpcV1 {
       START = 'start',
       STOP = 'stop',
     }
+  }
+
+  /** Parameters for the `listInstanceClusterNetworkAttachments` operation. */
+  export interface ListInstanceClusterNetworkAttachmentsParams {
+    /** The virtual server instance identifier. */
+    instanceId: string;
+    /** A server-provided token determining what resource to start the page on. */
+    start?: string;
+    /** The number of resources to return on a page. */
+    limit?: number;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `createClusterNetworkAttachment` operation. */
+  export interface CreateClusterNetworkAttachmentParams {
+    /** The virtual server instance identifier. */
+    instanceId: string;
+    /** A cluster network interface for the instance cluster network attachment. This can be
+     *  specified using an existing cluster network interface that does not already have a `target`,
+     *  or a prototype object for a new cluster network interface.
+     *
+     *  This instance must reside in the same VPC as the specified cluster network interface. The
+     *  cluster network interface must reside in the same cluster network as the
+     *  `cluster_network_interface` of any other `cluster_network_attachments` for this instance.
+     */
+    clusterNetworkInterface: InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterface;
+    /** The instance cluster network attachment to insert this instance cluster network attachment
+     *  immediately before.
+     *
+     *  If unspecified, this instance cluster network attachment will be inserted after all
+     *  existing instance cluster network attachments.
+     */
+    before?: InstanceClusterNetworkAttachmentBeforePrototype;
+    /** The name for this cluster network attachment. Names must be unique within the instance the cluster network
+     *  attachment resides in. If unspecified, the name will be a hyphenated list of randomly-selected words. Names
+     *  starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+     */
+    name?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteInstanceClusterNetworkAttachment` operation. */
+  export interface DeleteInstanceClusterNetworkAttachmentParams {
+    /** The virtual server instance identifier. */
+    instanceId: string;
+    /** The instance cluster network attachment identifier. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getInstanceClusterNetworkAttachment` operation. */
+  export interface GetInstanceClusterNetworkAttachmentParams {
+    /** The virtual server instance identifier. */
+    instanceId: string;
+    /** The instance cluster network attachment identifier. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `updateInstanceClusterNetworkAttachment` operation. */
+  export interface UpdateInstanceClusterNetworkAttachmentParams {
+    /** The virtual server instance identifier. */
+    instanceId: string;
+    /** The instance cluster network attachment identifier. */
+    id: string;
+    /** The name for this network attachment. The name must not be used by another network attachment for the
+     *  instance. Names starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+     */
+    name?: string;
+    headers?: OutgoingHttpHeaders;
   }
 
   /** Parameters for the `createInstanceConsoleAccessToken` operation. */
@@ -29419,7 +31299,7 @@ namespace VpcV1 {
     profile?: ShareProfileIdentity;
     /** The cron specification for the file share replication schedule.
      *
-     *  Replication of a share can be scheduled to occur at most once per hour.
+     *  Replication of a share can be scheduled to occur at most once every 15 minutes.
      *
      *  For this property to be changed, the share `replication_role` must be `replica`.
      */
@@ -29969,16 +31849,20 @@ namespace VpcV1 {
      *  in the region. Names beginning with `ibm-` are reserved for provider-owned resources, and are not allowed.
      */
     name?: string;
-    /** The protocol state filtering mode used for this virtual network interface. If `auto`, protocol state packet
-     *  filtering is enabled or disabled based on the virtual network interface's `target` resource type:
+    /** The protocol state filtering mode to use for this virtual network interface. If
+     *  `auto`, protocol state packet filtering is enabled or disabled based on the virtual network interface's `target`
+     *  resource type:
      *
      *  - `bare_metal_server_network_attachment`: disabled
      *  - `instance_network_attachment`: enabled
      *  - `share_mount_target`: enabled
      *
+     *  Must not be `disabled` if the virtual network interface's `target` resource type is
+     *  `share_mount_target`.
+     *
      *  Protocol state filtering monitors each network connection flowing over this virtual network interface, and drops
      *  any packets that are invalid based on the current connection state and protocol. See [Protocol state filtering
-     *  mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering)) for more information.
+     *  mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering) for more information.
      */
     protocolStateFilteringMode?: UpdateVirtualNetworkInterfaceConstants.ProtocolStateFilteringMode | string;
     headers?: OutgoingHttpHeaders;
@@ -29986,7 +31870,7 @@ namespace VpcV1 {
 
   /** Constants for the `updateVirtualNetworkInterface` operation. */
   export namespace UpdateVirtualNetworkInterfaceConstants {
-    /** The protocol state filtering mode used for this virtual network interface. If `auto`, protocol state packet filtering is enabled or disabled based on the virtual network interface's `target` resource type: - `bare_metal_server_network_attachment`: disabled - `instance_network_attachment`: enabled - `share_mount_target`: enabled Protocol state filtering monitors each network connection flowing over this virtual network interface, and drops any packets that are invalid based on the current connection state and protocol. See [Protocol state filtering mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering)) for more information. */
+    /** The protocol state filtering mode to use for this virtual network interface. If `auto`, protocol state packet filtering is enabled or disabled based on the virtual network interface's `target` resource type: - `bare_metal_server_network_attachment`: disabled - `instance_network_attachment`: enabled - `share_mount_target`: enabled Must not be `disabled` if the virtual network interface's `target` resource type is `share_mount_target`. Protocol state filtering monitors each network connection flowing over this virtual network interface, and drops any packets that are invalid based on the current connection state and protocol. See [Protocol state filtering mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering) for more information. */
     export enum ProtocolStateFilteringMode {
       AUTO = 'auto',
       DISABLED = 'disabled',
@@ -30097,6 +31981,389 @@ namespace VpcV1 {
     virtualNetworkInterfaceId: string;
     /** The reserved IP identifier. */
     id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `listClusterNetworkProfiles` operation. */
+  export interface ListClusterNetworkProfilesParams {
+    /** A server-provided token determining what resource to start the page on. */
+    start?: string;
+    /** The number of resources to return on a page. */
+    limit?: number;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getClusterNetworkProfile` operation. */
+  export interface GetClusterNetworkProfileParams {
+    /** The cluster network profile name. */
+    name: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `listClusterNetworks` operation. */
+  export interface ListClusterNetworksParams {
+    /** A server-provided token determining what resource to start the page on. */
+    start?: string;
+    /** The number of resources to return on a page. */
+    limit?: number;
+    /** Filters the collection to resources with a `resource_group.id` property matching the specified identifier. */
+    resourceGroupId?: string;
+    /** Filters the collection to resources with a `name` property matching the exact specified name. */
+    name?: string;
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to
+     *  the name to sort in descending order. For example, the value `-created_at` sorts the collection by the
+     *  `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending
+     *  order.
+     */
+    sort?: ListClusterNetworksConstants.Sort | string;
+    /** Filters the collection to cluster networks with a `vpc.id` property matching the specified id. */
+    vpcId?: string;
+    /** Filters the collection to cluster networks with a `vpc.crn` property matching the specified CRN. */
+    vpcCrn?: string;
+    /** Filters the collection to cluster networks with a `vpc.name` property matching the specified name. */
+    vpcName?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `listClusterNetworks` operation. */
+  export namespace ListClusterNetworksConstants {
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending order. */
+    export enum Sort {
+      CREATED_AT = 'created_at',
+      NAME = 'name',
+    }
+  }
+
+  /** Parameters for the `createClusterNetwork` operation. */
+  export interface CreateClusterNetworkParams {
+    /** The profile to use for this cluster network. */
+    profile: ClusterNetworkProfileIdentity;
+    /** The VPC this cluster network will reside in. */
+    vpc: VPCIdentity;
+    /** The zone this cluster network will reside in. The zone must be listed
+     *  as supported on the specified cluster network profile.
+     */
+    zone: ZoneIdentity;
+    /** The name for this cluster network. The name must not be used by another cluster network in the region. Names
+     *  starting with `ibm-` are reserved for provider-owned resources, and are not allowed. If unspecified, the name
+     *  will be a hyphenated list of randomly-selected words.
+     */
+    name?: string;
+    /** The resource group to use. If unspecified, the account's [default resource
+     *  group](https://cloud.ibm.com/apidocs/resource-manager#introduction) will be used.
+     */
+    resourceGroup?: ResourceGroupIdentity;
+    subnetPrefixes?: ClusterNetworkSubnetPrefixPrototype[];
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `listClusterNetworkInterfaces` operation. */
+  export interface ListClusterNetworkInterfacesParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** A server-provided token determining what resource to start the page on. */
+    start?: string;
+    /** The number of resources to return on a page. */
+    limit?: number;
+    /** Filters the collection to resources with a `name` property matching the exact specified name. */
+    name?: string;
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to
+     *  the name to sort in descending order. For example, the value `-created_at` sorts the collection by the
+     *  `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending
+     *  order.
+     */
+    sort?: ListClusterNetworkInterfacesConstants.Sort | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `listClusterNetworkInterfaces` operation. */
+  export namespace ListClusterNetworkInterfacesConstants {
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending order. */
+    export enum Sort {
+      CREATED_AT = 'created_at',
+      NAME = 'name',
+    }
+  }
+
+  /** Parameters for the `createClusterNetworkInterface` operation. */
+  export interface CreateClusterNetworkInterfaceParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The name for this cluster network interface. The name must not be used by another interface in the cluster
+     *  network. Names beginning with `ibm-` are reserved for provider-owned resources, and are not allowed. If
+     *  unspecified, the name will be a hyphenated list of randomly-selected words.
+     */
+    name?: string;
+    /** The primary IP address to bind to the cluster network interface. May be either
+     *  a cluster network subnet reserved IP identity, or a cluster network subnet reserved IP
+     *  prototype object which will be used to create a new cluster network subnet reserved IP.
+     *
+     *  If a cluster network subnet reserved IP identity is provided, the specified cluster
+     *  network subnet reserved IP must be unbound.
+     *
+     *  If a cluster network subnet reserved IP prototype object with an address is provided,
+     *  the address must be available on the cluster network interface's cluster network
+     *  subnet. If no address is specified, an available address on the cluster network subnet
+     *  will be automatically selected and reserved.
+     */
+    primaryIp?: ClusterNetworkInterfacePrimaryIPPrototype;
+    /** The associated cluster network subnet. Required if `primary_ip` does not specify a cluster
+     *  network subnet reserved IP identity.
+     */
+    subnet?: ClusterNetworkSubnetIdentity;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteClusterNetworkInterface` operation. */
+  export interface DeleteClusterNetworkInterfaceParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network interface identifier. */
+    id: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getClusterNetworkInterface` operation. */
+  export interface GetClusterNetworkInterfaceParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network interface identifier. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `updateClusterNetworkInterface` operation. */
+  export interface UpdateClusterNetworkInterfaceParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network interface identifier. */
+    id: string;
+    /** Indicates whether this cluster network interface will be automatically deleted when `target` is deleted.
+     *  Must be `false` if the cluster network interface is unbound.
+     */
+    autoDelete?: boolean;
+    /** The name for this cluster network interface. The name must not be used by another interface in the cluster
+     *  network. Names beginning with `ibm-` are reserved for provider-owned resources, and are not allowed.
+     */
+    name?: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value. Required if the request body includes an array.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `listClusterNetworkSubnets` operation. */
+  export interface ListClusterNetworkSubnetsParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** A server-provided token determining what resource to start the page on. */
+    start?: string;
+    /** The number of resources to return on a page. */
+    limit?: number;
+    /** Filters the collection to resources with a `name` property matching the exact specified name. */
+    name?: string;
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to
+     *  the name to sort in descending order. For example, the value `-created_at` sorts the collection by the
+     *  `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending
+     *  order.
+     */
+    sort?: ListClusterNetworkSubnetsConstants.Sort | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `listClusterNetworkSubnets` operation. */
+  export namespace ListClusterNetworkSubnetsConstants {
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending order. */
+    export enum Sort {
+      CREATED_AT = 'created_at',
+      NAME = 'name',
+    }
+  }
+
+  /** Parameters for the `createClusterNetworkSubnet` operation. */
+  export interface CreateClusterNetworkSubnetParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet prototype object. */
+    clusterNetworkSubnetPrototype: ClusterNetworkSubnetPrototype;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `listClusterNetworkSubnetReservedIps` operation. */
+  export interface ListClusterNetworkSubnetReservedIpsParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    clusterNetworkSubnetId: string;
+    /** A server-provided token determining what resource to start the page on. */
+    start?: string;
+    /** The number of resources to return on a page. */
+    limit?: number;
+    /** Filters the collection to resources with a `name` property matching the exact specified name. */
+    name?: string;
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to
+     *  the name to sort in descending order. For example, the value `-created_at` sorts the collection by the
+     *  `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending
+     *  order.
+     */
+    sort?: ListClusterNetworkSubnetReservedIpsConstants.Sort | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `listClusterNetworkSubnetReservedIps` operation. */
+  export namespace ListClusterNetworkSubnetReservedIpsConstants {
+    /** Sorts the returned collection by the specified property name in ascending order. A `-` may be prepended to the name to sort in descending order. For example, the value `-created_at` sorts the collection by the `created_at` property in descending order, and the value `name` sorts it by the `name` property in ascending order. */
+    export enum Sort {
+      ADDRESS = 'address',
+      CREATED_AT = 'created_at',
+      NAME = 'name',
+    }
+  }
+
+  /** Parameters for the `createClusterNetworkSubnetReservedIp` operation. */
+  export interface CreateClusterNetworkSubnetReservedIpParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    clusterNetworkSubnetId: string;
+    /** The IP address to reserve, which must not already be reserved on the subnet.
+     *
+     *  If unspecified, an available address on the subnet will automatically be selected.
+     */
+    address?: string;
+    /** The name for this cluster network subnet reserved IP. The name must not be used by another reserved IP in
+     *  the cluster network subnet. Names starting with `ibm-` are reserved for provider-owned resources, and are not
+     *  allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
+     */
+    name?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteClusterNetworkSubnetReservedIp` operation. */
+  export interface DeleteClusterNetworkSubnetReservedIpParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    clusterNetworkSubnetId: string;
+    /** The cluster network subnet reserved IP identifier. */
+    id: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getClusterNetworkSubnetReservedIp` operation. */
+  export interface GetClusterNetworkSubnetReservedIpParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    clusterNetworkSubnetId: string;
+    /** The cluster network subnet reserved IP identifier. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `updateClusterNetworkSubnetReservedIp` operation. */
+  export interface UpdateClusterNetworkSubnetReservedIpParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    clusterNetworkSubnetId: string;
+    /** The cluster network subnet reserved IP identifier. */
+    id: string;
+    /** Indicates whether this cluster network subnet reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the cluster network subnet reserved IP is unbound. Must be `false` if the cluster
+     *  network subnet reserved IP is unbound.
+     */
+    autoDelete?: boolean;
+    /** The name for this cluster network subnet reserved IP. The name must not be used by another reserved IP in
+     *  the cluster network subnet. Names starting with `ibm-` are reserved for provider-owned resources, and are not
+     *  allowed.
+     */
+    name?: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value. Required if the request body includes an array.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteClusterNetworkSubnet` operation. */
+  export interface DeleteClusterNetworkSubnetParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    id: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getClusterNetworkSubnet` operation. */
+  export interface GetClusterNetworkSubnetParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `updateClusterNetworkSubnet` operation. */
+  export interface UpdateClusterNetworkSubnetParams {
+    /** The cluster network identifier. */
+    clusterNetworkId: string;
+    /** The cluster network subnet identifier. */
+    id: string;
+    /** The name for this cluster network subnet. The name must not be used by another cluster network subnet in the
+     *  cluster network. Names starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+     */
+    name?: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value. Required if the request body includes an array.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `deleteClusterNetwork` operation. */
+  export interface DeleteClusterNetworkParams {
+    /** The cluster network identifier. */
+    id: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value.
+     */
+    ifMatch?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getClusterNetwork` operation. */
+  export interface GetClusterNetworkParams {
+    /** The cluster network identifier. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `updateClusterNetwork` operation. */
+  export interface UpdateClusterNetworkParams {
+    /** The cluster network identifier. */
+    id: string;
+    /** The name for this cluster network. The name must not be used by another cluster network in the region. Names
+     *  starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+     */
+    name?: string;
+    /** If present, the request will fail if the specified ETag value does not match the resource's current ETag
+     *  value. Required if the request body includes an array.
+     */
+    ifMatch?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -31609,7 +33876,11 @@ namespace VpcV1 {
     acceptProxyProtocol?: boolean;
     /** The certificate instance to use for SSL termination. The listener must have a `protocol` of `https`. */
     certificateInstance?: CertificateInstanceIdentity;
-    /** The connection limit of the listener. */
+    /** The concurrent connection limit for the listener. If reached, incoming connections may be queued or
+     *  rejected.
+     *
+     *  This property will be present for load balancers in the `application` family.
+     */
     connectionLimit?: number;
     /** The default pool for this listener. If `https_redirect` is specified, the
      *  default pool will not be used.
@@ -31631,8 +33902,9 @@ namespace VpcV1 {
      *  listener must have a `protocol` of `https`.
      */
     httpsRedirect?: LoadBalancerListenerHTTPSRedirectPrototype;
-    /** The idle connection timeout of the listener in seconds. Supported for load balancers in the `application`
-     *  family.
+    /** The idle connection timeout of the listener in seconds.
+     *
+     *  Supported for load balancers in the `application` family.
      */
     idleConnectionTimeout?: number;
     /** The policy prototype objects for this listener. The load balancer must be in the `application` family. */
@@ -31711,7 +33983,11 @@ namespace VpcV1 {
     acceptProxyProtocol?: boolean;
     /** The certificate instance to use for SSL termination. The listener must have a `protocol` of `https`. */
     certificateInstance?: CertificateInstanceIdentity;
-    /** The connection limit of the listener. */
+    /** The concurrent connection limit for the listener. If reached, incoming connections may be queued or
+     *  rejected.
+     *
+     *  Supported for load balancers in the `application` family.
+     */
     connectionLimit?: number;
     /** The default pool for this listener. If `https_redirect` is set, the default pool will not
      *  be used. The specified pool must:
@@ -31733,8 +34009,9 @@ namespace VpcV1 {
      *  Specify `null` to remove any existing https redirect.
      */
     httpsRedirect?: LoadBalancerListenerHTTPSRedirectPatch;
-    /** The idle connection timeout of the listener in seconds. Supported for load balancers in the `application`
-     *  family.
+    /** The idle connection timeout of the listener in seconds.
+     *
+     *  Supported for load balancers in the `application` family.
      */
     idleConnectionTimeout?: number;
     /** The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer
@@ -31808,9 +34085,9 @@ namespace VpcV1 {
     listenerId: string;
     /** The policy action:
      *  - `forward`: Requests will be forwarded to the specified `target` pool
-     *  - `https_redirect`: Requests will be redirected to the specified target listener. The
-     *    listener must have a `protocol` of `http`, and the target listener must have a
-     *    `protocol` of `https`
+     *  - `https_redirect`: Requests will be redirected to the specified `target.listener`.
+     *     This listener must have a `protocol` of `http`, and the target listener must
+     *     have a `protocol` of `https`.
      *  - `redirect`: Requests will be redirected to the specified `target.url`
      *  - `reject`: Requests will be rejected with a `403` status code.
      */
@@ -31825,10 +34102,13 @@ namespace VpcV1 {
     name?: string;
     /** The rule prototype objects for this policy. */
     rules?: LoadBalancerListenerPolicyRulePrototype[];
-    /** - If `action` is `forward`, specify a `LoadBalancerPoolIdentity`.
-     *  - If `action` is `https_redirect`, specify a
-     *  `LoadBalancerListenerPolicyHTTPSRedirectPrototype`.
-     *  - If `action` is `redirect`, specify a `LoadBalancerListenerPolicyRedirectURLPrototype`.
+    /** - If `action` is `forward`, use `LoadBalancerPoolIdentity` to specify a pool in this
+     *    load balancer to forward to.
+     *  - If `action` is `https_redirect`, use
+     *    `LoadBalancerListenerPolicyHTTPSRedirectPrototype` to specify a listener on this
+     *    load balancer to redirect to.
+     *  - If `action` is `redirect`, use `LoadBalancerListenerPolicyRedirectURLPrototype`to
+     *    specify a URL to redirect to.
      */
     target?: LoadBalancerListenerPolicyTargetPrototype;
     headers?: OutgoingHttpHeaders;
@@ -31836,7 +34116,7 @@ namespace VpcV1 {
 
   /** Constants for the `createLoadBalancerListenerPolicy` operation. */
   export namespace CreateLoadBalancerListenerPolicyConstants {
-    /** The policy action: - `forward`: Requests will be forwarded to the specified `target` pool - `https_redirect`: Requests will be redirected to the specified target listener. The listener must have a `protocol` of `http`, and the target listener must have a `protocol` of `https` - `redirect`: Requests will be redirected to the specified `target.url` - `reject`: Requests will be rejected with a `403` status code. */
+    /** The policy action: - `forward`: Requests will be forwarded to the specified `target` pool - `https_redirect`: Requests will be redirected to the specified `target.listener`. This listener must have a `protocol` of `http`, and the target listener must have a `protocol` of `https`. - `redirect`: Requests will be redirected to the specified `target.url` - `reject`: Requests will be rejected with a `403` status code. */
     export enum Action {
       FORWARD = 'forward',
       HTTPS_REDIRECT = 'https_redirect',
@@ -32113,7 +34393,9 @@ namespace VpcV1 {
     loadBalancerId: string;
     /** The pool identifier. */
     id: string;
-    /** The load balancing algorithm. */
+    /** The load balancing algorithm. The `least_connections` algorithm is only supported for load balancers that
+     *  have `availability` with value `subnet` in the profile.
+     */
     algorithm?: UpdateLoadBalancerPoolConstants.Algorithm | string;
     /** The health monitor of this pool. */
     healthMonitor?: LoadBalancerPoolHealthMonitorPatch;
@@ -32144,7 +34426,7 @@ namespace VpcV1 {
 
   /** Constants for the `updateLoadBalancerPool` operation. */
   export namespace UpdateLoadBalancerPoolConstants {
-    /** The load balancing algorithm. */
+    /** The load balancing algorithm. The `least_connections` algorithm is only supported for load balancers that have `availability` with value `subnet` in the profile. */
     export enum Algorithm {
       LEAST_CONNECTIONS = 'least_connections',
       ROUND_ROBIN = 'round_robin',
@@ -32822,11 +35104,15 @@ namespace VpcV1 {
    * model interfaces
    ************************/
 
-  /** Identifies an account by a unique property. */
+  /**
+   * Identifies an account by a unique property.
+   */
   export interface AccountIdentity {
   }
 
-  /** AccountReference. */
+  /**
+   * AccountReference.
+   */
   export interface AccountReference {
     /** The unique identifier for this account. */
     id: string;
@@ -32842,7 +35128,9 @@ namespace VpcV1 {
     }
   }
 
-  /** AddressPrefix. */
+  /**
+   * AddressPrefix.
+   */
   export interface AddressPrefix {
     /** The CIDR block for this prefix. */
     cidr: string;
@@ -32865,33 +35153,25 @@ namespace VpcV1 {
     zone: ZoneReference;
   }
 
-  /** AddressPrefixCollection. */
+  /**
+   * AddressPrefixCollection.
+   */
   export interface AddressPrefixCollection {
     /** A page of address prefixes for the VPC. */
     address_prefixes: AddressPrefix[];
     /** A link to the first page of resources. */
-    first: AddressPrefixCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: AddressPrefixCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface AddressPrefixCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface AddressPrefixCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** BackupPolicy. */
+  /**
+   * BackupPolicy.
+   */
   export interface BackupPolicy {
     /** The date and time that the backup policy was created. */
     created_at: string;
@@ -32972,33 +35252,25 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyCollection. */
+  /**
+   * BackupPolicyCollection.
+   */
   export interface BackupPolicyCollection {
     /** A page of backup policies. */
     backup_policies: BackupPolicy[];
     /** A link to the first page of resources. */
-    first: BackupPolicyCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BackupPolicyCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BackupPolicyCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BackupPolicyCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** BackupPolicyHealthReason. */
+  /**
+   * BackupPolicyHealthReason.
+   */
   export interface BackupPolicyHealthReason {
     /** A reason code for this health state. */
     code: BackupPolicyHealthReason.Constants.Code | string;
@@ -33016,7 +35288,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyJob. */
+  /**
+   * BackupPolicyJob.
+   */
   export interface BackupPolicyJob {
     /** Indicates whether this backup policy job will be automatically deleted after it completes. At present, this
      *  is always `true`, but may be modifiable in the future.
@@ -33086,37 +35360,32 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyJobCollection. */
+  /**
+   * BackupPolicyJobCollection.
+   */
   export interface BackupPolicyJobCollection {
     /** A link to the first page of resources. */
-    first: BackupPolicyJobCollectionFirst;
+    first: PageLink;
     /** A page of jobs for the backup policy. */
     jobs: BackupPolicyJob[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BackupPolicyJobCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BackupPolicyJobCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BackupPolicyJobCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The source this backup was created from (may be [deleted](https://cloud.ibm.com/apidocs/vpc#deleted-resources)). */
+  /**
+   * The source this backup was created from (may be
+   * [deleted](https://cloud.ibm.com/apidocs/vpc#deleted-resources)).
+   */
   export interface BackupPolicyJobSource {
   }
 
-  /** BackupPolicyJobStatusReason. */
+  /**
+   * BackupPolicyJobStatusReason.
+   */
   export interface BackupPolicyJobStatusReason {
     /** A reason code for the status:
      *  - `internal_error`: Internal error (contact IBM support)
@@ -33152,7 +35421,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyPlan. */
+  /**
+   * BackupPolicyPlan.
+   */
   export interface BackupPolicyPlan {
     /** Indicates whether the plan is active. */
     active: boolean;
@@ -33203,7 +35474,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyPlanClonePolicy. */
+  /**
+   * BackupPolicyPlanClonePolicy.
+   */
   export interface BackupPolicyPlanClonePolicy {
     /** The maximum number of recent snapshots (per source) that will keep clones. */
     max_snapshots: number;
@@ -33211,7 +35484,9 @@ namespace VpcV1 {
     zones: ZoneReference[];
   }
 
-  /** BackupPolicyPlanClonePolicyPatch. */
+  /**
+   * BackupPolicyPlanClonePolicyPatch.
+   */
   export interface BackupPolicyPlanClonePolicyPatch {
     /** The maximum number of recent snapshots (per source) that will keep clones. */
     max_snapshots?: number;
@@ -33221,7 +35496,9 @@ namespace VpcV1 {
     zones?: ZoneIdentity[];
   }
 
-  /** BackupPolicyPlanClonePolicyPrototype. */
+  /**
+   * BackupPolicyPlanClonePolicyPrototype.
+   */
   export interface BackupPolicyPlanClonePolicyPrototype {
     /** The maximum number of recent snapshots (per source) that will keep clones. */
     max_snapshots?: number;
@@ -33229,33 +35506,25 @@ namespace VpcV1 {
     zones: ZoneIdentity[];
   }
 
-  /** BackupPolicyPlanCollection. */
+  /**
+   * BackupPolicyPlanCollection.
+   */
   export interface BackupPolicyPlanCollection {
     /** A link to the first page of resources. */
-    first: BackupPolicyPlanCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BackupPolicyPlanCollectionNext;
+    next?: PageLink;
     /** A page of plans for the backup policy. */
     plans: BackupPolicyPlan[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BackupPolicyPlanCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BackupPolicyPlanCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** BackupPolicyPlanDeletionTrigger. */
+  /**
+   * BackupPolicyPlanDeletionTrigger.
+   */
   export interface BackupPolicyPlanDeletionTrigger {
     /** The maximum number of days to keep each backup after creation. */
     delete_after: number;
@@ -33263,7 +35532,9 @@ namespace VpcV1 {
     delete_over_count?: number;
   }
 
-  /** BackupPolicyPlanDeletionTriggerPatch. */
+  /**
+   * BackupPolicyPlanDeletionTriggerPatch.
+   */
   export interface BackupPolicyPlanDeletionTriggerPatch {
     /** The maximum number of days to keep each backup after creation. */
     delete_after?: number;
@@ -33271,7 +35542,9 @@ namespace VpcV1 {
     delete_over_count?: number;
   }
 
-  /** BackupPolicyPlanDeletionTriggerPrototype. */
+  /**
+   * BackupPolicyPlanDeletionTriggerPrototype.
+   */
   export interface BackupPolicyPlanDeletionTriggerPrototype {
     /** The maximum number of days to keep each backup after creation. */
     delete_after?: number;
@@ -33279,7 +35552,9 @@ namespace VpcV1 {
     delete_over_count?: number;
   }
 
-  /** BackupPolicyPlanPrototype. */
+  /**
+   * BackupPolicyPlanPrototype.
+   */
   export interface BackupPolicyPlanPrototype {
     /** Indicates whether the plan is active. */
     active?: boolean;
@@ -33306,7 +35581,9 @@ namespace VpcV1 {
     remote_region_policies?: BackupPolicyPlanRemoteRegionPolicyPrototype[];
   }
 
-  /** BackupPolicyPlanReference. */
+  /**
+   * BackupPolicyPlanReference.
+   */
   export interface BackupPolicyPlanReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -33334,7 +35611,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface BackupPolicyPlanRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  region, and identifies the native region.
@@ -33342,7 +35622,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** BackupPolicyPlanRemoteRegionPolicy. */
+  /**
+   * BackupPolicyPlanRemoteRegionPolicy.
+   */
   export interface BackupPolicyPlanRemoteRegionPolicy {
     /** The region this backup policy plan will create backups in. */
     delete_over_count: number;
@@ -33352,7 +35634,9 @@ namespace VpcV1 {
     region: RegionReference;
   }
 
-  /** BackupPolicyPlanRemoteRegionPolicyPrototype. */
+  /**
+   * BackupPolicyPlanRemoteRegionPolicyPrototype.
+   */
   export interface BackupPolicyPlanRemoteRegionPolicyPrototype {
     /** The region this backup policy plan will create backups in. */
     delete_over_count?: number;
@@ -33366,7 +35650,9 @@ namespace VpcV1 {
     region: RegionIdentity;
   }
 
-  /** BackupPolicyPrototype. */
+  /**
+   * BackupPolicyPrototype.
+   */
   export interface BackupPolicyPrototype {
     /** The resource type this backup policy will apply to. Resources that have both a matching type and a matching
      *  user tag will be subject to the backup policy.
@@ -33402,15 +35688,23 @@ namespace VpcV1 {
     }
   }
 
-  /** The scope for this backup policy. */
+  /**
+   * The scope for this backup policy.
+   */
   export interface BackupPolicyScope {
   }
 
-  /** The scope to use for this backup policy. If unspecified, the policy will be scoped to the account. */
+  /**
+   * The scope to use for this backup policy.
+   *
+   * If unspecified, the policy will be scoped to the account.
+   */
   export interface BackupPolicyScopePrototype {
   }
 
-  /** BareMetalServer. */
+  /**
+   * BareMetalServer.
+   */
   export interface BareMetalServer {
     /** The total bandwidth (in megabits per second) shared across the bare metal server network attachments or bare
      *  metal server network interfaces.
@@ -33529,11 +35823,18 @@ namespace VpcV1 {
     }
   }
 
-  /** The resource from which this bare metal server is booted. The resources supported by this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+  /**
+   * The resource from which this bare metal server is booted.
+   *
+   * The resources supported by this property may
+   * [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+   */
   export interface BareMetalServerBootTarget {
   }
 
-  /** The bare metal server CPU configuration. */
+  /**
+   * The bare metal server CPU configuration.
+   */
   export interface BareMetalServerCPU {
     /** The CPU architecture. */
     architecture: string;
@@ -33545,33 +35846,25 @@ namespace VpcV1 {
     threads_per_core: number;
   }
 
-  /** BareMetalServerCollection. */
+  /**
+   * BareMetalServerCollection.
+   */
   export interface BareMetalServerCollection {
     /** A page of bare metal servers. */
     bare_metal_servers: BareMetalServer[];
     /** A link to the first page of resources. */
-    first: BareMetalServerCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BareMetalServerCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BareMetalServerCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BareMetalServerCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The bare metal server console access token information. */
+  /**
+   * The bare metal server console access token information.
+   */
   export interface BareMetalServerConsoleAccessToken {
     /** A URL safe single-use token used to access the console WebSocket. */
     access_token: string;
@@ -33598,7 +35891,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerDisk. */
+  /**
+   * BareMetalServerDisk.
+   */
   export interface BareMetalServerDisk {
     /** The date and time that the disk was created. */
     created_at: string;
@@ -33637,13 +35932,17 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerDiskCollection. */
+  /**
+   * BareMetalServerDiskCollection.
+   */
   export interface BareMetalServerDiskCollection {
     /** The disks for the bare metal server. */
     disks: BareMetalServerDisk[];
   }
 
-  /** Firmware information for the bare metal server. */
+  /**
+   * Firmware information for the bare metal server.
+   */
   export interface BareMetalServerFirmware {
     /** The type of update available.
      *
@@ -33663,7 +35962,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerInitialization. */
+  /**
+   * BareMetalServerInitialization.
+   */
   export interface BareMetalServerInitialization {
     /** The image the bare metal server was provisioned from. */
     image: ImageReference;
@@ -33675,7 +35976,9 @@ namespace VpcV1 {
     user_accounts: BareMetalServerInitializationUserAccount[];
   }
 
-  /** BareMetalServerInitializationPrototype. */
+  /**
+   * BareMetalServerInitializationPrototype.
+   */
   export interface BareMetalServerInitializationPrototype {
     /** The image to be used when provisioning the bare metal server. */
     image: ImageIdentity;
@@ -33695,11 +35998,15 @@ namespace VpcV1 {
     user_data?: string;
   }
 
-  /** BareMetalServerInitializationUserAccount. */
+  /**
+   * BareMetalServerInitializationUserAccount.
+   */
   export interface BareMetalServerInitializationUserAccount {
   }
 
-  /** BareMetalServerLifecycleReason. */
+  /**
+   * BareMetalServerLifecycleReason.
+   */
   export interface BareMetalServerLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `internal_error`: internal error (contact IBM support)
@@ -33725,7 +36032,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkAttachment. */
+  /**
+   * BareMetalServerNetworkAttachment.
+   */
   export interface BareMetalServerNetworkAttachment {
     /** The date and time that the bare metal server network attachment was created. */
     created_at: string;
@@ -33799,33 +36108,25 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkAttachmentCollection. */
+  /**
+   * BareMetalServerNetworkAttachmentCollection.
+   */
   export interface BareMetalServerNetworkAttachmentCollection {
     /** A link to the first page of resources. */
-    first: BareMetalServerNetworkAttachmentCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** The network attachments for the bare metal server. */
     network_attachments: BareMetalServerNetworkAttachment[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BareMetalServerNetworkAttachmentCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BareMetalServerNetworkAttachmentCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BareMetalServerNetworkAttachmentCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** BareMetalServerNetworkAttachmentPrototype. */
+  /**
+   * BareMetalServerNetworkAttachmentPrototype.
+   */
   export interface BareMetalServerNetworkAttachmentPrototype {
     /** The network attachment's interface type:
      *  - `pci`: a physical PCI device which can only be created or deleted when the bare metal
@@ -33864,11 +36165,18 @@ namespace VpcV1 {
     }
   }
 
-  /** A virtual network interface for the bare metal server network attachment. This can be specified using an existing virtual network interface, or a prototype object for a new virtual network interface. If an existing virtual network interface is specified, it must not be the target of a flow log collector. */
+  /**
+   * A virtual network interface for the bare metal server network attachment. This can be specified using an existing
+   * virtual network interface, or a prototype object for a new virtual network interface.
+   *
+   * If an existing virtual network interface is specified, it must not be the target of a flow log collector.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterface {
   }
 
-  /** BareMetalServerNetworkAttachmentReference. */
+  /**
+   * BareMetalServerNetworkAttachmentReference.
+   */
   export interface BareMetalServerNetworkAttachmentReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -33900,7 +36208,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterface. */
+  /**
+   * BareMetalServerNetworkInterface.
+   */
   export interface BareMetalServerNetworkInterface {
     /** Indicates whether source IP spoofing is allowed on this bare metal server network interface.
      *
@@ -34060,33 +36370,25 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfaceCollection. */
+  /**
+   * BareMetalServerNetworkInterfaceCollection.
+   */
   export interface BareMetalServerNetworkInterfaceCollection {
     /** A link to the first page of resources. */
-    first: BareMetalServerNetworkInterfaceCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** The network interfaces for the bare metal server. */
     network_interfaces: BareMetalServerNetworkInterface[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BareMetalServerNetworkInterfaceCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BareMetalServerNetworkInterfaceCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BareMetalServerNetworkInterfaceCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** BareMetalServerNetworkInterfacePrototype. */
+  /**
+   * BareMetalServerNetworkInterfacePrototype.
+   */
   export interface BareMetalServerNetworkInterfacePrototype {
     /** Indicates whether source IP spoofing is allowed on this bare metal server network interface.
      *
@@ -34161,7 +36463,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerPrimaryNetworkAttachmentPrototype. */
+  /**
+   * BareMetalServerPrimaryNetworkAttachmentPrototype.
+   */
   export interface BareMetalServerPrimaryNetworkAttachmentPrototype {
     /** The network attachment's interface type:
      *  - `pci`: a physical PCI device which can only be created or deleted when the bare metal
@@ -34195,7 +36499,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerPrimaryNetworkInterfacePrototype. */
+  /**
+   * BareMetalServerPrimaryNetworkInterfacePrototype.
+   */
   export interface BareMetalServerPrimaryNetworkInterfacePrototype {
     /** Indicates whether source IP spoofing is allowed on this bare metal server network interface.
      *
@@ -34271,7 +36577,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerProfile. */
+  /**
+   * BareMetalServerProfile.
+   */
   export interface BareMetalServerProfile {
     bandwidth: BareMetalServerProfileBandwidth;
     /** The console type configuration for a bare metal server with this profile. */
@@ -34307,11 +36615,15 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerProfileBandwidth. */
+  /**
+   * BareMetalServerProfileBandwidth.
+   */
   export interface BareMetalServerProfileBandwidth {
   }
 
-  /** BareMetalServerProfileCPUArchitecture. */
+  /**
+   * BareMetalServerProfileCPUArchitecture.
+   */
   export interface BareMetalServerProfileCPUArchitecture {
     /** The default CPU architecture for a bare metal server with this profile. */
     default?: string;
@@ -34329,41 +36641,37 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerProfileCPUCoreCount. */
+  /**
+   * BareMetalServerProfileCPUCoreCount.
+   */
   export interface BareMetalServerProfileCPUCoreCount {
   }
 
-  /** BareMetalServerProfileCPUSocketCount. */
+  /**
+   * BareMetalServerProfileCPUSocketCount.
+   */
   export interface BareMetalServerProfileCPUSocketCount {
   }
 
-  /** BareMetalServerProfileCollection. */
+  /**
+   * BareMetalServerProfileCollection.
+   */
   export interface BareMetalServerProfileCollection {
     /** A link to the first page of resources. */
-    first: BareMetalServerProfileCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: BareMetalServerProfileCollectionNext;
+    next?: PageLink;
     /** A page of bare metal server profiles. */
     profiles: BareMetalServerProfile[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface BareMetalServerProfileCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface BareMetalServerProfileCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The console type configuration for a bare metal server with this profile. */
+  /**
+   * The console type configuration for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileConsoleTypes {
     /** The type for this profile field. */
     type: BareMetalServerProfileConsoleTypes.Constants.Type | string;
@@ -34384,22 +36692,30 @@ namespace VpcV1 {
     }
   }
 
-  /** Disks provided by this profile. */
+  /**
+   * Disks provided by this profile.
+   */
   export interface BareMetalServerProfileDisk {
     quantity: BareMetalServerProfileDiskQuantity;
     size: BareMetalServerProfileDiskSize;
     supported_interface_types: BareMetalServerProfileDiskSupportedInterfaces;
   }
 
-  /** BareMetalServerProfileDiskQuantity. */
+  /**
+   * BareMetalServerProfileDiskQuantity.
+   */
   export interface BareMetalServerProfileDiskQuantity {
   }
 
-  /** BareMetalServerProfileDiskSize. */
+  /**
+   * BareMetalServerProfileDiskSize.
+   */
   export interface BareMetalServerProfileDiskSize {
   }
 
-  /** BareMetalServerProfileDiskSupportedInterfaces. */
+  /**
+   * BareMetalServerProfileDiskSupportedInterfaces.
+   */
   export interface BareMetalServerProfileDiskSupportedInterfaces {
     /** The default value for this profile field. */
     default: BareMetalServerProfileDiskSupportedInterfaces.Constants.Default | string;
@@ -34429,23 +36745,33 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a bare metal server profile by a unique property. */
+  /**
+   * Identifies a bare metal server profile by a unique property.
+   */
   export interface BareMetalServerProfileIdentity {
   }
 
-  /** BareMetalServerProfileMemory. */
+  /**
+   * BareMetalServerProfileMemory.
+   */
   export interface BareMetalServerProfileMemory {
   }
 
-  /** BareMetalServerProfileNetworkAttachmentCount. */
+  /**
+   * BareMetalServerProfileNetworkAttachmentCount.
+   */
   export interface BareMetalServerProfileNetworkAttachmentCount {
   }
 
-  /** BareMetalServerProfileNetworkInterfaceCount. */
+  /**
+   * BareMetalServerProfileNetworkInterfaceCount.
+   */
   export interface BareMetalServerProfileNetworkInterfaceCount {
   }
 
-  /** BareMetalServerProfileOSArchitecture. */
+  /**
+   * BareMetalServerProfileOSArchitecture.
+   */
   export interface BareMetalServerProfileOSArchitecture {
     /** The default OS architecture for a bare metal server with this profile. */
     default: string;
@@ -34463,7 +36789,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerProfileReference. */
+  /**
+   * BareMetalServerProfileReference.
+   */
   export interface BareMetalServerProfileReference {
     /** The URL for this bare metal server profile. */
     href: string;
@@ -34481,7 +36809,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The supported trusted platform module modes for this bare metal server profile. */
+  /**
+   * The supported trusted platform module modes for this bare metal server profile.
+   */
   export interface BareMetalServerProfileSupportedTrustedPlatformModuleModes {
     /** The default trusted platform module for a bare metal server with this profile. */
     default?: BareMetalServerProfileSupportedTrustedPlatformModuleModes.Constants.Default | string;
@@ -34509,7 +36839,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Indicates whether this profile supports virtual network interfaces. */
+  /**
+   * Indicates whether this profile supports virtual network interfaces.
+   */
   export interface BareMetalServerProfileVirtualNetworkInterfacesSupported {
     /** The type for this profile field. */
     type: BareMetalServerProfileVirtualNetworkInterfacesSupported.Constants.Type | string;
@@ -34525,7 +36857,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerPrototype. */
+  /**
+   * BareMetalServerPrototype.
+   */
   export interface BareMetalServerPrototype {
     /** The total bandwidth (in megabits per second) shared across the bare metal server's network interfaces. The
      *  specified value must match one of the bandwidth values in the bare metal server's profile. If unspecified, the
@@ -34562,7 +36896,9 @@ namespace VpcV1 {
     zone: ZoneIdentity;
   }
 
-  /** BareMetalServerStatusReason. */
+  /**
+   * BareMetalServerStatusReason.
+   */
   export interface BareMetalServerStatusReason {
     /** The status reason code:
      *  - `cannot_start`: Failed to start due to an internal error
@@ -34596,7 +36932,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerTrustedPlatformModule. */
+  /**
+   * BareMetalServerTrustedPlatformModule.
+   */
   export interface BareMetalServerTrustedPlatformModule {
     /** Indicates whether the trusted platform module is enabled. */
     enabled: boolean;
@@ -34626,7 +36964,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerTrustedPlatformModulePatch. */
+  /**
+   * BareMetalServerTrustedPlatformModulePatch.
+   */
   export interface BareMetalServerTrustedPlatformModulePatch {
     /** The trusted platform module mode to use. The specified value must be listed in the bare metal server's
      *  `supported_modes`.
@@ -34645,7 +36985,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerTrustedPlatformModulePrototype. */
+  /**
+   * BareMetalServerTrustedPlatformModulePrototype.
+   */
   export interface BareMetalServerTrustedPlatformModulePrototype {
     /** The trusted platform module mode to use. The specified value must be listed in the bare metal server
      *  profile's `supported_trusted_platform_module_modes`.
@@ -34664,19 +37006,29 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering by a unique property. */
+  /**
+   * Identifies a [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering by a unique
+   * property.
+   */
   export interface CatalogOfferingIdentity {
   }
 
-  /** Identifies a version of a [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering by a unique property. */
+  /**
+   * Identifies a version of a
+   * [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering by a unique property.
+   */
   export interface CatalogOfferingVersionIdentity {
   }
 
-  /** Identifies a catalog offering version's billing plan by a unique property. */
+  /**
+   * Identifies a catalog offering version's billing plan by a unique property.
+   */
   export interface CatalogOfferingVersionPlanIdentity {
   }
 
-  /** CatalogOfferingVersionPlanReference. */
+  /**
+   * CatalogOfferingVersionPlanReference.
+   */
   export interface CatalogOfferingVersionPlanReference {
     /** The CRN for this
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering version's billing plan.
@@ -34688,7 +37040,9 @@ namespace VpcV1 {
     deleted?: Deleted;
   }
 
-  /** CatalogOfferingVersionReference. */
+  /**
+   * CatalogOfferingVersionReference.
+   */
   export interface CatalogOfferingVersionReference {
     /** The CRN for this version of a
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering.
@@ -34696,21 +37050,29 @@ namespace VpcV1 {
     crn: string;
   }
 
-  /** Identifies a certificate instance by a unique property. */
+  /**
+   * Identifies a certificate instance by a unique property.
+   */
   export interface CertificateInstanceIdentity {
   }
 
-  /** CertificateInstanceReference. */
+  /**
+   * CertificateInstanceReference.
+   */
   export interface CertificateInstanceReference {
     /** The CRN for this certificate instance. */
     crn: string;
   }
 
-  /** Identifies a Cloud Object Storage bucket by a unique property. */
+  /**
+   * Identifies a Cloud Object Storage bucket by a unique property.
+   */
   export interface CloudObjectStorageBucketIdentity {
   }
 
-  /** CloudObjectStorageBucketReference. */
+  /**
+   * CloudObjectStorageBucketReference.
+   */
   export interface CloudObjectStorageBucketReference {
     /** The CRN of this Cloud Object Storage bucket. */
     crn: string;
@@ -34718,23 +37080,746 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** CloudObjectStorageObjectReference. */
+  /**
+   * CloudObjectStorageObjectReference.
+   */
   export interface CloudObjectStorageObjectReference {
     /** The name of this Cloud Object Storage object. Names are unique within a Cloud Object Storage bucket. */
     name: string;
   }
 
-  /** Identifies a DNS instance by a unique property. */
+  /**
+   * ClusterNetwork.
+   */
+  export interface ClusterNetwork {
+    /** The date and time that the cluster network was created. */
+    created_at: string;
+    /** The CRN for this cluster network. */
+    crn: string;
+    /** The URL for this cluster network. */
+    href: string;
+    /** The unique identifier for this cluster network. */
+    id: string;
+    /** The reasons for the current `lifecycle_state` (if any). */
+    lifecycle_reasons: ClusterNetworkLifecycleReason[];
+    /** The lifecycle state of the cluster network. */
+    lifecycle_state: ClusterNetwork.Constants.LifecycleState | string;
+    /** The name for this cluster network. The name must not be used by another cluster network in the region. */
+    name: string;
+    /** The profile for this cluster network. */
+    profile: ClusterNetworkProfileReference;
+    /** The resource group for this cluster network. */
+    resource_group: ResourceGroupReference;
+    /** The resource type. */
+    resource_type: ClusterNetwork.Constants.ResourceType | string;
+    /** The IP address ranges available for subnets for this cluster network. */
+    subnet_prefixes: ClusterNetworkSubnetPrefix[];
+    /** The VPC this cluster network resides in. */
+    vpc: VPCReference;
+    /** The zone this cluster network resides in. */
+    zone: ZoneReference;
+  }
+  export namespace ClusterNetwork {
+    export namespace Constants {
+      /** The lifecycle state of the cluster network. */
+      export enum LifecycleState {
+        DELETING = 'deleting',
+        FAILED = 'failed',
+        PENDING = 'pending',
+        STABLE = 'stable',
+        SUSPENDED = 'suspended',
+        UPDATING = 'updating',
+        WAITING = 'waiting',
+      }
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK = 'cluster_network',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkCollection.
+   */
+  export interface ClusterNetworkCollection {
+    /** A page of cluster networks. */
+    cluster_networks: ClusterNetwork[];
+    /** A link to the first page of resources. */
+    first: PageLink;
+    /** The maximum number of resources that can be returned by the request. */
+    limit: number;
+    /** A link to the next page of resources. This property is present for all pages except the last page. */
+    next?: PageLink;
+    /** The total number of resources across all pages. */
+    total_count: number;
+  }
+
+  /**
+   * The associated cluster network subnet.
+   */
+  export interface ClusterNetworkInterface {
+    /** Indicates whether source IP spoofing is allowed on this cluster network interface. If `false`, source IP
+     *  spoofing is prevented on this cluster network interface. If `true`, source IP spoofing is allowed on this
+     *  cluster network interface.
+     */
+    allow_ip_spoofing: boolean;
+    /** Indicates whether this cluster network interface will be automatically deleted when `target` is deleted. */
+    auto_delete: boolean;
+    /** The date and time that the cluster network interface was created. */
+    created_at: string;
+    /** If `true`:
+     *  - The VPC infrastructure performs any needed NAT operations.
+     *  - `floating_ips` must not have more than one floating IP.
+     *
+     *  If `false`:
+     *  - Packets are passed unchanged to/from the virtual network interface,
+     *    allowing the workload to perform any needed NAT operations.
+     */
+    enable_infrastructure_nat: boolean;
+    /** The URL for this cluster network interface. */
+    href: string;
+    /** The unique identifier for this cluster network interface. */
+    id: string;
+    /** The reasons for the current `lifecycle_state` (if any). */
+    lifecycle_reasons: ClusterNetworkInterfaceLifecycleReason[];
+    /** The lifecycle state of the cluster network interface. */
+    lifecycle_state: ClusterNetworkInterface.Constants.LifecycleState | string;
+    /** The MAC address of the cluster network interface. May be absent if `lifecycle_state` is `pending`. */
+    mac_address?: string;
+    /** The name for this cluster network interface. The name is unique across all interfaces in the cluster
+     *  network.
+     */
+    name: string;
+    /** The cluster network subnet reserved IP for this cluster network interface. */
+    primary_ip: ClusterNetworkSubnetReservedIPReference;
+    /** The resource type. */
+    resource_type: ClusterNetworkInterface.Constants.ResourceType | string;
+    subnet?: ClusterNetworkSubnetReference;
+    /** The target of this cluster network interface.
+     *
+     *  If absent, this cluster network interface is not attached to a target.
+     *
+     *  The resources supported by this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    target?: ClusterNetworkInterfaceTarget;
+    /** The VPC this cluster network interface resides in. */
+    vpc: VPCReference;
+    /** The zone this cluster network interface resides in. */
+    zone: ZoneReference;
+  }
+  export namespace ClusterNetworkInterface {
+    export namespace Constants {
+      /** The lifecycle state of the cluster network interface. */
+      export enum LifecycleState {
+        DELETING = 'deleting',
+        FAILED = 'failed',
+        PENDING = 'pending',
+        STABLE = 'stable',
+        SUSPENDED = 'suspended',
+        UPDATING = 'updating',
+        WAITING = 'waiting',
+      }
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_INTERFACE = 'cluster_network_interface',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkInterfaceCollection.
+   */
+  export interface ClusterNetworkInterfaceCollection {
+    /** A link to the first page of resources. */
+    first: PageLink;
+    /** A page of cluster network interfaces. */
+    interfaces: ClusterNetworkInterface[];
+    /** The maximum number of resources that can be returned by the request. */
+    limit: number;
+    /** A link to the next page of resources. This property is present for all pages except the last page. */
+    next?: PageLink;
+    /** The total number of resources across all pages. */
+    total_count: number;
+  }
+
+  /**
+   * ClusterNetworkInterfaceLifecycleReason.
+   */
+  export interface ClusterNetworkInterfaceLifecycleReason {
+    /** A reason code for this lifecycle state:
+     *  - `internal_error`: internal error (contact IBM support)
+     *  - `resource_suspended_by_provider`: The resource has been suspended (contact IBM
+     *    support)
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    code: ClusterNetworkInterfaceLifecycleReason.Constants.Code | string;
+    /** An explanation of the reason for this lifecycle state. */
+    message: string;
+    /** Link to documentation about the reason for this lifecycle state. */
+    more_info?: string;
+  }
+  export namespace ClusterNetworkInterfaceLifecycleReason {
+    export namespace Constants {
+      /** A reason code for this lifecycle state: - `internal_error`: internal error (contact IBM support) - `resource_suspended_by_provider`: The resource has been suspended (contact IBM support) The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Code {
+        INTERNAL_ERROR = 'internal_error',
+        RESOURCE_SUSPENDED_BY_PROVIDER = 'resource_suspended_by_provider',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkInterfacePrimaryIPPrototype.
+   */
+  export interface ClusterNetworkInterfacePrimaryIPPrototype {
+  }
+
+  /**
+   * The associated cluster network subnet.
+   */
+  export interface ClusterNetworkInterfaceReference {
+    /** If present, this property indicates the referenced resource has been deleted, and provides
+     *  some supplementary information.
+     */
+    deleted?: Deleted;
+    /** The URL for this cluster network interface. */
+    href: string;
+    /** The unique identifier for this cluster network interface. */
+    id: string;
+    /** The name for this cluster network interface. The name is unique across all interfaces in the cluster
+     *  network.
+     */
+    name: string;
+    /** The primary IP for this cluster network interface. */
+    primary_ip: ClusterNetworkSubnetReservedIPReference;
+    /** The resource type. */
+    resource_type: ClusterNetworkInterfaceReference.Constants.ResourceType | string;
+    subnet: ClusterNetworkSubnetReference;
+  }
+  export namespace ClusterNetworkInterfaceReference {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_INTERFACE = 'cluster_network_interface',
+      }
+    }
+  }
+
+  /**
+   * The target of this cluster network interface.
+   *
+   * If absent, this cluster network interface is not attached to a target.
+   *
+   * The resources supported by this property may
+   * [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+   */
+  export interface ClusterNetworkInterfaceTarget {
+  }
+
+  /**
+   * ClusterNetworkLifecycleReason.
+   */
+  export interface ClusterNetworkLifecycleReason {
+    /** A reason code for this lifecycle state:
+     *  - `internal_error`: internal error (contact IBM support)
+     *  - `resource_suspended_by_provider`: The resource has been suspended (contact IBM
+     *    support)
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    code: ClusterNetworkLifecycleReason.Constants.Code | string;
+    /** An explanation of the reason for this lifecycle state. */
+    message: string;
+    /** Link to documentation about the reason for this lifecycle state. */
+    more_info?: string;
+  }
+  export namespace ClusterNetworkLifecycleReason {
+    export namespace Constants {
+      /** A reason code for this lifecycle state: - `internal_error`: internal error (contact IBM support) - `resource_suspended_by_provider`: The resource has been suspended (contact IBM support) The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Code {
+        INTERNAL_ERROR = 'internal_error',
+        RESOURCE_SUSPENDED_BY_PROVIDER = 'resource_suspended_by_provider',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkProfile.
+   */
+  export interface ClusterNetworkProfile {
+    /** The product family this cluster network profile belongs to.
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    family: ClusterNetworkProfile.Constants.Family | string;
+    /** The URL for this cluster network profile. */
+    href: string;
+    /** The globally unique name for this cluster network profile. */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkProfile.Constants.ResourceType | string;
+    /** The instance profiles that support this cluster network profile. */
+    supported_instance_profiles: InstanceProfileReference[];
+    /** Zones in this region that support this cluster network profile. */
+    zones: ZoneReference[];
+  }
+  export namespace ClusterNetworkProfile {
+    export namespace Constants {
+      /** The product family this cluster network profile belongs to. The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Family {
+        VELA = 'vela',
+      }
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_PROFILE = 'cluster_network_profile',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkProfileCollection.
+   */
+  export interface ClusterNetworkProfileCollection {
+    /** A link to the first page of resources. */
+    first: PageLink;
+    /** The maximum number of resources that can be returned by the request. */
+    limit: number;
+    /** A link to the next page of resources. This property is present for all pages except the last page. */
+    next?: PageLink;
+    /** A page of cluster network profiles. */
+    profiles: ClusterNetworkProfile[];
+    /** The total number of resources across all pages. */
+    total_count: number;
+  }
+
+  /**
+   * Identifies an cluster network profile by a unique property.
+   */
+  export interface ClusterNetworkProfileIdentity {
+  }
+
+  /**
+   * ClusterNetworkProfileReference.
+   */
+  export interface ClusterNetworkProfileReference {
+    /** The URL for this cluster network profile. */
+    href: string;
+    /** The globally unique name for this cluster network profile. */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkProfileReference.Constants.ResourceType | string;
+  }
+  export namespace ClusterNetworkProfileReference {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_PROFILE = 'cluster_network_profile',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkReference.
+   */
+  export interface ClusterNetworkReference {
+    /** The CRN for this cluster network. */
+    crn: string;
+    /** If present, this property indicates the referenced resource has been deleted, and provides
+     *  some supplementary information.
+     */
+    deleted?: Deleted;
+    /** The URL for this cluster network. */
+    href: string;
+    /** The unique identifier for this cluster network. */
+    id: string;
+    /** The name for this cluster network. The name must not be used by another cluster network in the region. */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkReference.Constants.ResourceType | string;
+  }
+  export namespace ClusterNetworkReference {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK = 'cluster_network',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnet.
+   */
+  export interface ClusterNetworkSubnet {
+    /** The number of IPv4 addresses in this cluster network subnet that are not in use, and have not been reserved
+     *  by the user or the provider.
+     */
+    available_ipv4_address_count: number;
+    /** The date and time that the cluster network subnet was created. */
+    created_at: string;
+    /** The URL for this cluster network subnet. */
+    href: string;
+    /** The unique identifier for this cluster network subnet. */
+    id: string;
+    /** The IP version for this cluster network subnet.
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    ip_version: ClusterNetworkSubnet.Constants.IpVersion | string;
+    /** The IPv4 range of this cluster network subnet, expressed in CIDR format. */
+    ipv4_cidr_block: string;
+    /** The reasons for the current `lifecycle_state` (if any). */
+    lifecycle_reasons: ClusterNetworkSubnetLifecycleReason[];
+    /** The lifecycle state of the cluster network subnet. */
+    lifecycle_state: ClusterNetworkSubnet.Constants.LifecycleState | string;
+    /** The name for this cluster network subnet. The name is unique across all cluster network subnets in the
+     *  cluster network.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkSubnet.Constants.ResourceType | string;
+    /** The total number of IPv4 addresses in this cluster network subnet.
+     *
+     *  Note: This is calculated as 2<sup>(32 - prefix length)</sup>. For example, the prefix length `/24` gives:<br>
+     *  2<sup>(32 - 24)</sup> = 2<sup>8</sup> = 256 addresses.
+     */
+    total_ipv4_address_count: number;
+  }
+  export namespace ClusterNetworkSubnet {
+    export namespace Constants {
+      /** The IP version for this cluster network subnet. The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum IpVersion {
+        IPV4 = 'ipv4',
+      }
+      /** The lifecycle state of the cluster network subnet. */
+      export enum LifecycleState {
+        DELETING = 'deleting',
+        FAILED = 'failed',
+        PENDING = 'pending',
+        STABLE = 'stable',
+        SUSPENDED = 'suspended',
+        UPDATING = 'updating',
+        WAITING = 'waiting',
+      }
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_SUBNET = 'cluster_network_subnet',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetCollection.
+   */
+  export interface ClusterNetworkSubnetCollection {
+    /** A link to the first page of resources. */
+    first: PageLink;
+    /** The maximum number of resources that can be returned by the request. */
+    limit: number;
+    /** A link to the next page of resources. This property is present for all pages except the last page. */
+    next?: PageLink;
+    /** A page of subnets for the cluster network. */
+    subnets: ClusterNetworkSubnet[];
+    /** The total number of resources across all pages. */
+    total_count: number;
+  }
+
+  /**
+   * Identifies a cluster network subnet by a unique property.
+   */
+  export interface ClusterNetworkSubnetIdentity {
+  }
+
+  /**
+   * ClusterNetworkSubnetLifecycleReason.
+   */
+  export interface ClusterNetworkSubnetLifecycleReason {
+    /** A reason code for this lifecycle state:
+     *  - `internal_error`: internal error (contact IBM support)
+     *  - `resource_suspended_by_provider`: The resource has been suspended (contact IBM
+     *    support)
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    code: ClusterNetworkSubnetLifecycleReason.Constants.Code | string;
+    /** An explanation of the reason for this lifecycle state. */
+    message: string;
+    /** Link to documentation about the reason for this lifecycle state. */
+    more_info?: string;
+  }
+  export namespace ClusterNetworkSubnetLifecycleReason {
+    export namespace Constants {
+      /** A reason code for this lifecycle state: - `internal_error`: internal error (contact IBM support) - `resource_suspended_by_provider`: The resource has been suspended (contact IBM support) The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Code {
+        INTERNAL_ERROR = 'internal_error',
+        RESOURCE_SUSPENDED_BY_PROVIDER = 'resource_suspended_by_provider',
+      }
+    }
+  }
+
+  /**
+   * A range of addresses available for subnets for this cluster network.
+   */
+  export interface ClusterNetworkSubnetPrefix {
+    /** The allocation policy for this subnet prefix:
+     *  - `auto`: Subnets created by total count in this cluster network can use this prefix.
+     */
+    allocation_policy: ClusterNetworkSubnetPrefix.Constants.AllocationPolicy | string;
+    /** The CIDR block for this prefix. */
+    cidr: string;
+  }
+  export namespace ClusterNetworkSubnetPrefix {
+    export namespace Constants {
+      /** The allocation policy for this subnet prefix: - `auto`: Subnets created by total count in this cluster network can use this prefix. */
+      export enum AllocationPolicy {
+        AUTO = 'auto',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetPrefixPrototype.
+   */
+  export interface ClusterNetworkSubnetPrefixPrototype {
+    /** The IPv4 range of the cluster network's subnet prefix, expressed in CIDR format.
+     *
+     *  The CIDR prefix length must be less than `/29` (at least 8 addresses).
+     *
+     *  If a range is specified that overlaps with address prefixes in the cluster network's VPC, the operating systems
+     *  of any virtual server instances attaching to this cluster network must be [configured to avoid
+     *  conflicts](https://cloud.ibm.com/docs/vpc?topic=vpc-planning-cluster-network#advanced-consideration).
+     */
+    cidr?: string;
+  }
+
+  /**
+   * ClusterNetworkSubnetPrototype.
+   */
+  export interface ClusterNetworkSubnetPrototype {
+    /** The IP version(s) to support for this cluster network subnet. */
+    ip_version?: ClusterNetworkSubnetPrototype.Constants.IpVersion | string;
+    /** The name for this cluster network subnet. The name must not be used by another cluster network subnet in the
+     *  cluster network. Names starting with `ibm-` are reserved for provider-owned resources, and are not allowed. If
+     *  unspecified, the name will be a hyphenated list of randomly-selected words.
+     */
+    name?: string;
+  }
+  export namespace ClusterNetworkSubnetPrototype {
+    export namespace Constants {
+      /** The IP version(s) to support for this cluster network subnet. */
+      export enum IpVersion {
+        IPV4 = 'ipv4',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetReference.
+   */
+  export interface ClusterNetworkSubnetReference {
+    /** If present, this property indicates the referenced resource has been deleted, and provides
+     *  some supplementary information.
+     */
+    deleted?: Deleted;
+    /** The URL for this cluster network subnet. */
+    href: string;
+    /** The unique identifier for this cluster network subnet. */
+    id: string;
+    /** The name for this cluster network subnet. The name is unique across all cluster network subnets in the
+     *  cluster network.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkSubnetReference.Constants.ResourceType | string;
+  }
+  export namespace ClusterNetworkSubnetReference {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_SUBNET = 'cluster_network_subnet',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetReservedIP.
+   */
+  export interface ClusterNetworkSubnetReservedIP {
+    /** The IP address.
+     *
+     *  If the address is pending allocation, the value will be `0.0.0.0`.
+     *
+     *  This property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) to support IPv6 addresses
+     *  in the future.
+     */
+    address: string;
+    /** Indicates whether this cluster network subnet reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the cluster network subnet reserved IP is unbound.
+     */
+    auto_delete: boolean;
+    /** The date and time that the cluster network subnet reserved IP was created. */
+    created_at: string;
+    /** The URL for this cluster network subnet reserved IP. */
+    href: string;
+    /** The unique identifier for this cluster network subnet reserved IP. */
+    id: string;
+    /** The reasons for the current `lifecycle_state` (if any). */
+    lifecycle_reasons: ClusterNetworkSubnetReservedIPLifecycleReason[];
+    /** The lifecycle state of the cluster network subnet reserved IP. */
+    lifecycle_state: ClusterNetworkSubnetReservedIP.Constants.LifecycleState | string;
+    /** The name for this cluster network subnet reserved IP. The name is unique across all reserved IPs in a
+     *  cluster network subnet.
+     */
+    name: string;
+    /** The owner of the cluster network subnet reserved IP
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    owner: ClusterNetworkSubnetReservedIP.Constants.Owner | string;
+    /** The resource type. */
+    resource_type: ClusterNetworkSubnetReservedIP.Constants.ResourceType | string;
+    /** The target this cluster network subnet reserved IP is bound to.
+     *
+     *  If absent, this cluster network subnet reserved IP is provider-owned or unbound.
+     */
+    target?: ClusterNetworkSubnetReservedIPTarget;
+  }
+  export namespace ClusterNetworkSubnetReservedIP {
+    export namespace Constants {
+      /** The lifecycle state of the cluster network subnet reserved IP. */
+      export enum LifecycleState {
+        DELETING = 'deleting',
+        FAILED = 'failed',
+        PENDING = 'pending',
+        STABLE = 'stable',
+        SUSPENDED = 'suspended',
+        UPDATING = 'updating',
+        WAITING = 'waiting',
+      }
+      /** The owner of the cluster network subnet reserved IP The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Owner {
+        PROVIDER = 'provider',
+        USER = 'user',
+      }
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_SUBNET_RESERVED_IP = 'cluster_network_subnet_reserved_ip',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetReservedIPCollection.
+   */
+  export interface ClusterNetworkSubnetReservedIPCollection {
+    /** A link to the first page of resources. */
+    first: PageLink;
+    /** The maximum number of resources that can be returned by the request. */
+    limit: number;
+    /** A link to the next page of resources. This property is present for all pages except the last page. */
+    next?: PageLink;
+    /** A page of reserved IPs for the cluster network subnet. */
+    reserved_ips: ClusterNetworkSubnetReservedIP[];
+    /** The total number of resources across all pages. */
+    total_count: number;
+  }
+
+  /**
+   * ClusterNetworkSubnetReservedIPLifecycleReason.
+   */
+  export interface ClusterNetworkSubnetReservedIPLifecycleReason {
+    /** A reason code for this lifecycle state:
+     *  - `internal_error`: internal error (contact IBM support)
+     *  - `resource_suspended_by_provider`: The resource has been suspended (contact IBM
+     *    support)
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    code: ClusterNetworkSubnetReservedIPLifecycleReason.Constants.Code | string;
+    /** An explanation of the reason for this lifecycle state. */
+    message: string;
+    /** Link to documentation about the reason for this lifecycle state. */
+    more_info?: string;
+  }
+  export namespace ClusterNetworkSubnetReservedIPLifecycleReason {
+    export namespace Constants {
+      /** A reason code for this lifecycle state: - `internal_error`: internal error (contact IBM support) - `resource_suspended_by_provider`: The resource has been suspended (contact IBM support) The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Code {
+        INTERNAL_ERROR = 'internal_error',
+        RESOURCE_SUSPENDED_BY_PROVIDER = 'resource_suspended_by_provider',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetReservedIPReference.
+   */
+  export interface ClusterNetworkSubnetReservedIPReference {
+    /** The IP address.
+     *
+     *  If the address is pending allocation, the value will be `0.0.0.0`.
+     *
+     *  This property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) to support IPv6 addresses
+     *  in the future.
+     */
+    address: string;
+    /** If present, this property indicates the referenced resource has been deleted, and provides
+     *  some supplementary information.
+     */
+    deleted?: Deleted;
+    /** The URL for this cluster network subnet reserved IP. */
+    href: string;
+    /** The unique identifier for this cluster network subnet reserved IP. */
+    id: string;
+    /** The name for this cluster network subnet reserved IP. The name is unique across all reserved IPs in a
+     *  cluster network subnet.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkSubnetReservedIPReference.Constants.ResourceType | string;
+  }
+  export namespace ClusterNetworkSubnetReservedIPReference {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_SUBNET_RESERVED_IP = 'cluster_network_subnet_reserved_ip',
+      }
+    }
+  }
+
+  /**
+   * The target this cluster network subnet reserved IP is bound to.
+   *
+   * If absent, this cluster network subnet reserved IP is provider-owned or unbound.
+   */
+  export interface ClusterNetworkSubnetReservedIPTarget {
+  }
+
+  /**
+   * Identifies a DNS instance by a unique property.
+   */
   export interface DNSInstanceIdentity {
   }
 
-  /** DNSInstanceReferenceLoadBalancerDNSContext. */
+  /**
+   * DNSInstanceReferenceLoadBalancerDNSContext.
+   */
   export interface DNSInstanceReferenceLoadBalancerDNSContext {
     /** The CRN for this DNS instance. */
     crn: string;
   }
 
-  /** A DNS server. */
+  /**
+   * A DNS server.
+   */
   export interface DNSServer {
     /** The IP address.
      *
@@ -34746,7 +37831,9 @@ namespace VpcV1 {
     zone_affinity?: ZoneReference;
   }
 
-  /** DNSServerPrototype. */
+  /**
+   * DNSServerPrototype.
+   */
   export interface DNSServerPrototype {
     /** The DNS server IPv4 address. */
     address?: string;
@@ -34754,16 +37841,22 @@ namespace VpcV1 {
     zone_affinity?: ZoneIdentity;
   }
 
-  /** Identifies a DNS zone by a unique property. */
+  /**
+   * Identifies a DNS zone by a unique property.
+   */
   export interface DNSZoneIdentity {
   }
 
-  /** DNSZoneReference. */
+  /**
+   * DNSZoneReference.
+   */
   export interface DNSZoneReference {
     id: string;
   }
 
-  /** DedicatedHost. */
+  /**
+   * DedicatedHost.
+   */
   export interface DedicatedHost {
     /** The amount of memory in gibibytes that is currently available for instances. */
     available_memory: number;
@@ -34842,33 +37935,25 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostCollection. */
+  /**
+   * DedicatedHostCollection.
+   */
   export interface DedicatedHostCollection {
     /** A page of dedicated hosts. */
     dedicated_hosts: DedicatedHost[];
     /** A link to the first page of resources. */
-    first: DedicatedHostCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: DedicatedHostCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface DedicatedHostCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface DedicatedHostCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** DedicatedHostDisk. */
+  /**
+   * DedicatedHostDisk.
+   */
   export interface DedicatedHostDisk {
     /** The remaining space left for instance placement in GB (gigabytes). */
     available: number;
@@ -34927,13 +38012,17 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostDiskCollection. */
+  /**
+   * DedicatedHostDiskCollection.
+   */
   export interface DedicatedHostDiskCollection {
     /** The disks for the dedicated host. */
     disks: DedicatedHostDisk[];
   }
 
-  /** DedicatedHostGroup. */
+  /**
+   * DedicatedHostGroup.
+   */
   export interface DedicatedHostGroup {
     /** The dedicated host profile class for hosts in this group. */
     class: string;
@@ -34975,37 +38064,31 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostGroupCollection. */
+  /**
+   * DedicatedHostGroupCollection.
+   */
   export interface DedicatedHostGroupCollection {
     /** A link to the first page of resources. */
-    first: DedicatedHostGroupCollectionFirst;
+    first: PageLink;
     /** A page of dedicated host groups. */
     groups: DedicatedHostGroup[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: DedicatedHostGroupCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface DedicatedHostGroupCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface DedicatedHostGroupCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a dedicated host group by a unique property. */
+  /**
+   * Identifies a dedicated host group by a unique property.
+   */
   export interface DedicatedHostGroupIdentity {
   }
 
-  /** DedicatedHostGroupPrototypeDedicatedHostByZoneContext. */
+  /**
+   * DedicatedHostGroupPrototypeDedicatedHostByZoneContext.
+   */
   export interface DedicatedHostGroupPrototypeDedicatedHostByZoneContext {
     /** The name for this dedicated host group. The name must not be used by another dedicated host group in the
      *  region. If unspecified, the name will be a hyphenated list of randomly-selected words.
@@ -35015,7 +38098,9 @@ namespace VpcV1 {
     resource_group?: ResourceGroupIdentity;
   }
 
-  /** DedicatedHostGroupReference. */
+  /**
+   * DedicatedHostGroupReference.
+   */
   export interface DedicatedHostGroupReference {
     /** The CRN for this dedicated host group. */
     crn: string;
@@ -35041,7 +38126,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The dedicated host NUMA configuration. */
+  /**
+   * The dedicated host NUMA configuration.
+   */
   export interface DedicatedHostNUMA {
     /** The total number of NUMA nodes for this dedicated host. */
     count: number;
@@ -35049,7 +38136,9 @@ namespace VpcV1 {
     nodes: DedicatedHostNUMANode[];
   }
 
-  /** The dedicated host NUMA node configuration. */
+  /**
+   * The dedicated host NUMA node configuration.
+   */
   export interface DedicatedHostNUMANode {
     /** The available VCPU for this NUMA node. */
     available_vcpu: number;
@@ -35057,7 +38146,9 @@ namespace VpcV1 {
     vcpu: number;
   }
 
-  /** DedicatedHostProfile. */
+  /**
+   * DedicatedHostProfile.
+   */
   export interface DedicatedHostProfile {
     /** The product class this dedicated host profile belongs to. */
     class: string;
@@ -35110,33 +38201,25 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostProfileCollection. */
+  /**
+   * DedicatedHostProfileCollection.
+   */
   export interface DedicatedHostProfileCollection {
     /** A link to the first page of resources. */
-    first: DedicatedHostProfileCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: DedicatedHostProfileCollectionNext;
+    next?: PageLink;
     /** A page of dedicated host profiles. */
     profiles: DedicatedHostProfile[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface DedicatedHostProfileCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface DedicatedHostProfileCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Disks provided by this profile. */
+  /**
+   * Disks provided by this profile.
+   */
   export interface DedicatedHostProfileDisk {
     interface_type: DedicatedHostProfileDiskInterface;
     /** The number of disks of this type for a dedicated host with this profile. */
@@ -35146,7 +38229,9 @@ namespace VpcV1 {
     supported_instance_interface_types: DedicatedHostProfileDiskSupportedInterfaces;
   }
 
-  /** DedicatedHostProfileDiskInterface. */
+  /**
+   * DedicatedHostProfileDiskInterface.
+   */
   export interface DedicatedHostProfileDiskInterface {
     /** The type for this profile field. */
     type: DedicatedHostProfileDiskInterface.Constants.Type | string;
@@ -35170,7 +38255,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of disks of this type for a dedicated host with this profile. */
+  /**
+   * The number of disks of this type for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileDiskQuantity {
     /** The type for this profile field. */
     type: DedicatedHostProfileDiskQuantity.Constants.Type | string;
@@ -35186,7 +38273,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The size of the disk in GB (gigabytes). */
+  /**
+   * The size of the disk in GB (gigabytes).
+   */
   export interface DedicatedHostProfileDiskSize {
     /** The type for this profile field. */
     type: DedicatedHostProfileDiskSize.Constants.Type | string;
@@ -35202,7 +38291,9 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostProfileDiskSupportedInterfaces. */
+  /**
+   * DedicatedHostProfileDiskSupportedInterfaces.
+   */
   export interface DedicatedHostProfileDiskSupportedInterfaces {
     /** The type for this profile field. */
     type: DedicatedHostProfileDiskSupportedInterfaces.Constants.Type | string;
@@ -35223,15 +38314,21 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a dedicated host profile by a unique property. */
+  /**
+   * Identifies a dedicated host profile by a unique property.
+   */
   export interface DedicatedHostProfileIdentity {
   }
 
-  /** DedicatedHostProfileMemory. */
+  /**
+   * DedicatedHostProfileMemory.
+   */
   export interface DedicatedHostProfileMemory {
   }
 
-  /** DedicatedHostProfileReference. */
+  /**
+   * DedicatedHostProfileReference.
+   */
   export interface DedicatedHostProfileReference {
     /** The URL for this dedicated host. */
     href: string;
@@ -35239,15 +38336,21 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** DedicatedHostProfileSocket. */
+  /**
+   * DedicatedHostProfileSocket.
+   */
   export interface DedicatedHostProfileSocket {
   }
 
-  /** DedicatedHostProfileVCPU. */
+  /**
+   * DedicatedHostProfileVCPU.
+   */
   export interface DedicatedHostProfileVCPU {
   }
 
-  /** DedicatedHostProfileVCPUArchitecture. */
+  /**
+   * DedicatedHostProfileVCPUArchitecture.
+   */
   export interface DedicatedHostProfileVCPUArchitecture {
     /** The type for this profile field. */
     type: DedicatedHostProfileVCPUArchitecture.Constants.Type | string;
@@ -35263,7 +38366,9 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostProfileVCPUManufacturer. */
+  /**
+   * DedicatedHostProfileVCPUManufacturer.
+   */
   export interface DedicatedHostProfileVCPUManufacturer {
     /** The type for this profile field. */
     type: DedicatedHostProfileVCPUManufacturer.Constants.Type | string;
@@ -35279,7 +38384,9 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostPrototype. */
+  /**
+   * DedicatedHostPrototype.
+   */
   export interface DedicatedHostPrototype {
     /** If set to true, instances can be placed on this dedicated host. */
     instance_placement_enabled?: boolean;
@@ -35295,7 +38402,9 @@ namespace VpcV1 {
     resource_group?: ResourceGroupIdentity;
   }
 
-  /** DedicatedHostReference. */
+  /**
+   * DedicatedHostReference.
+   */
   export interface DedicatedHostReference {
     /** The CRN for this dedicated host. */
     crn: string;
@@ -35321,7 +38430,9 @@ namespace VpcV1 {
     }
   }
 
-  /** DefaultNetworkACL. */
+  /**
+   * DefaultNetworkACL.
+   */
   export interface DefaultNetworkACL {
     /** The date and time that the network ACL was created. */
     created_at: string;
@@ -35347,12 +38458,14 @@ namespace VpcV1 {
     vpc: VPCReference;
   }
 
-  /** DefaultRoutingTable. */
+  /**
+   * DefaultRoutingTable.
+   */
   export interface DefaultRoutingTable {
     /** The filters specifying the resources that may create routes in this routing table.
      *
-     *  At present, only the `resource_type` filter is permitted, and only the values
-     *  `vpn_gateway` and `vpn_server` are supported, but filter support is expected to expand in the future.
+     *  The resources and types of filters supported by this property is expected to
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
      */
     accept_routes_from: ResourceFilter[];
     /** The ingress sources to advertise routes to. Routes in the table with `advertise` enabled will be advertised
@@ -35451,7 +38564,9 @@ namespace VpcV1 {
     }
   }
 
-  /** DefaultSecurityGroup. */
+  /**
+   * DefaultSecurityGroup.
+   */
   export interface DefaultSecurityGroup {
     /** The date and time that this security group was created. */
     created_at: string;
@@ -35478,17 +38593,24 @@ namespace VpcV1 {
     vpc: VPCReference;
   }
 
-  /** If present, this property indicates the referenced resource has been deleted, and provides some supplementary information. */
+  /**
+   * If present, this property indicates the referenced resource has been deleted, and provides some supplementary
+   * information.
+   */
   export interface Deleted {
     /** Link to documentation about deleted resources. */
     more_info: string;
   }
 
-  /** Identifies an encryption key by a unique property. */
+  /**
+   * Identifies an encryption key by a unique property.
+   */
   export interface EncryptionKeyIdentity {
   }
 
-  /** EncryptionKeyReference. */
+  /**
+   * EncryptionKeyReference.
+   */
   export interface EncryptionKeyReference {
     /** The CRN of the [Key Protect Root
      *  Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto
@@ -35497,7 +38619,9 @@ namespace VpcV1 {
     crn: string;
   }
 
-  /** EndpointGateway. */
+  /**
+   * EndpointGateway.
+   */
   export interface EndpointGateway {
     /** Indicates whether to allow DNS resolution for this endpoint gateway when the VPC this endpoint gateway
      *  resides in has a DNS resolution binding to a VPC with `dns.enable_hub` set to `true`.
@@ -35569,33 +38693,25 @@ namespace VpcV1 {
     }
   }
 
-  /** EndpointGatewayCollection. */
+  /**
+   * EndpointGatewayCollection.
+   */
   export interface EndpointGatewayCollection {
     /** A page of endpoint gateways. */
     endpoint_gateways: EndpointGateway[];
     /** A link to the first page of resources. */
-    first: EndpointGatewayCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: EndpointGatewayCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface EndpointGatewayCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface EndpointGatewayCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** EndpointGatewayLifecycleReason. */
+  /**
+   * EndpointGatewayLifecycleReason.
+   */
   export interface EndpointGatewayLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `access_denied`: endpoint gateway access was denied
@@ -35629,7 +38745,9 @@ namespace VpcV1 {
     }
   }
 
-  /** EndpointGatewayReferenceRemote. */
+  /**
+   * EndpointGatewayReferenceRemote.
+   */
   export interface EndpointGatewayReferenceRemote {
     /** The CRN for this endpoint gateway. */
     crn: string;
@@ -35655,7 +38773,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface EndpointGatewayRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  account, and identifies the owning account.
@@ -35667,22 +38788,24 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** A reserved IP to bind to the endpoint gateway. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP. The reserved IP will be bound to the endpoint gateway to function as a virtual private endpoint for the service. */
+  /**
+   * A reserved IP to bind to the endpoint gateway. This can be specified using an existing reserved IP, or a prototype
+   * object for a new reserved IP. The reserved IP will be bound to the endpoint gateway to function as a virtual
+   * private endpoint for the service.
+   */
   export interface EndpointGatewayReservedIP {
   }
 
-  /** The target for this endpoint gateway. */
+  /**
+   * The target for this endpoint gateway.
+   */
   export interface EndpointGatewayTarget {
+    /** The target resource type for this endpoint gateway. */
+    resource_type: EndpointGatewayTarget.Constants.ResourceType | string;
   }
-
-  /** The target to use for this endpoint gateway. The target: - Must not already be the target of another endpoint gateway in the VPC - Must not have a service endpoint that duplicates or overlaps with any `service_endpoints` of another endpoint gateway in the VPC. */
-  export interface EndpointGatewayTargetPrototype {
-    /** The type of target for this endpoint gateway. */
-    resource_type: EndpointGatewayTargetPrototype.Constants.ResourceType | string;
-  }
-  export namespace EndpointGatewayTargetPrototype {
+  export namespace EndpointGatewayTarget {
     export namespace Constants {
-      /** The type of target for this endpoint gateway. */
+      /** The target resource type for this endpoint gateway. */
       export enum ResourceType {
         PRIVATE_PATH_SERVICE_GATEWAY = 'private_path_service_gateway',
         PROVIDER_CLOUD_SERVICE = 'provider_cloud_service',
@@ -35691,7 +38814,30 @@ namespace VpcV1 {
     }
   }
 
-  /** FloatingIP. */
+  /**
+   * The target to use for this endpoint gateway. The target:
+   * - Must not already be the target of another endpoint gateway in the VPC
+   * - Must not have a service endpoint that duplicates or overlaps with any `service_endpoints`
+   *   of another endpoint gateway in the VPC.
+   */
+  export interface EndpointGatewayTargetPrototype {
+    /** The target resource type for this endpoint gateway. */
+    resource_type?: EndpointGatewayTargetPrototype.Constants.ResourceType | string;
+  }
+  export namespace EndpointGatewayTargetPrototype {
+    export namespace Constants {
+      /** The target resource type for this endpoint gateway. */
+      export enum ResourceType {
+        PRIVATE_PATH_SERVICE_GATEWAY = 'private_path_service_gateway',
+        PROVIDER_CLOUD_SERVICE = 'provider_cloud_service',
+        PROVIDER_INFRASTRUCTURE_SERVICE = 'provider_infrastructure_service',
+      }
+    }
+  }
+
+  /**
+   * FloatingIP.
+   */
   export interface FloatingIP {
     /** The globally unique IP address. */
     address: string;
@@ -35730,59 +38876,41 @@ namespace VpcV1 {
     }
   }
 
-  /** FloatingIPCollection. */
+  /**
+   * FloatingIPCollection.
+   */
   export interface FloatingIPCollection {
     /** A link to the first page of resources. */
-    first: FloatingIPCollectionFirst;
+    first: PageLink;
     /** A page of floating IPs. */
     floating_ips: FloatingIP[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: FloatingIPCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface FloatingIPCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface FloatingIPCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** FloatingIPCollectionVirtualNetworkInterfaceContext. */
+  /**
+   * FloatingIPCollectionVirtualNetworkInterfaceContext.
+   */
   export interface FloatingIPCollectionVirtualNetworkInterfaceContext {
     /** A link to the first page of resources. */
-    first: FloatingIPCollectionVirtualNetworkInterfaceContextFirst;
+    first: PageLink;
     /** A page of floating IPs bound to the virtual network interface specified by the identifier in the URL. */
     floating_ips: FloatingIPReference[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: FloatingIPCollectionVirtualNetworkInterfaceContextNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface FloatingIPCollectionVirtualNetworkInterfaceContextFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface FloatingIPCollectionVirtualNetworkInterfaceContextNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** FloatingIPPrototype. */
+  /**
+   * FloatingIPPrototype.
+   */
   export interface FloatingIPPrototype {
     /** The name for this floating IP. The name must not be used by another floating IP in the region. If
      *  unspecified, the name will be a hyphenated list of randomly-selected words.
@@ -35794,7 +38922,9 @@ namespace VpcV1 {
     resource_group?: ResourceGroupIdentity;
   }
 
-  /** FloatingIPReference. */
+  /**
+   * FloatingIPReference.
+   */
   export interface FloatingIPReference {
     /** The globally unique IP address. */
     address: string;
@@ -35812,25 +38942,50 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** The target of this floating IP. */
+  /**
+   * The target of this floating IP.
+   */
   export interface FloatingIPTarget {
   }
 
-  /** The target resource to bind this floating IP to, replacing any existing binding. The floating IP must not be required by another resource, such as a public gateway. The target resource must not already have a floating IP bound to it if the target resource is: - an instance network interface - a bare metal server network interface with `enable_infrastructure_nat` set to `true` - a virtual network interface with `enable_infrastructure_nat` set to `true` Specify `null` to remove an existing binding. */
+  /**
+   * The target resource to bind this floating IP to, replacing any existing binding. The floating IP must not be
+   * required by another resource, such as a public gateway.
+   *
+   * The target resource must not already have a floating IP bound to it if the target resource is:
+   *
+   * - an instance network interface
+   * - a bare metal server network interface with `enable_infrastructure_nat` set to `true`
+   * - a virtual network interface with `enable_infrastructure_nat` set to `true`
+   *
+   * Specify `null` to remove an existing binding.
+   */
   export interface FloatingIPTargetPatch {
   }
 
-  /** The target resource to bind this floating IP to. The target resource must not already have a floating IP bound to it if the target resource is: - an instance network interface - a bare metal server network interface with `enable_infrastructure_nat` set to `true` - a virtual network interface with `enable_infrastructure_nat` set to `true`. */
+  /**
+   * The target resource to bind this floating IP to.
+   *
+   * The target resource must not already have a floating IP bound to it if the target resource is:
+   *
+   * - an instance network interface
+   * - a bare metal server network interface with `enable_infrastructure_nat` set to `true`
+   * - a virtual network interface with `enable_infrastructure_nat` set to `true`.
+   */
   export interface FloatingIPTargetPrototype {
   }
 
-  /** FloatingIPUnpaginatedCollection. */
+  /**
+   * FloatingIPUnpaginatedCollection.
+   */
   export interface FloatingIPUnpaginatedCollection {
     /** The floating IPs. */
     floating_ips: FloatingIP[];
   }
 
-  /** FlowLogCollector. */
+  /**
+   * FlowLogCollector.
+   */
   export interface FlowLogCollector {
     /** Indicates whether this collector is active. */
     active: boolean;
@@ -35897,41 +39052,63 @@ namespace VpcV1 {
     }
   }
 
-  /** FlowLogCollectorCollection. */
+  /**
+   * FlowLogCollectorCollection.
+   */
   export interface FlowLogCollectorCollection {
     /** A link to the first page of resources. */
-    first: FlowLogCollectorCollectionFirst;
+    first: PageLink;
     /** A page of flow log collectors. */
     flow_log_collectors: FlowLogCollector[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: FlowLogCollectorCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface FlowLogCollectorCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface FlowLogCollectorCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The target this collector is collecting flow logs for. - If the target is an instance network attachment, flow logs will be collected for that instance network attachment. - If the target is an instance network interface, flow logs will be collected for that instance network interface. - If the target is a virtual network interface, flow logs will be collected for the virtual network interface's `target` resource if the resource is an instance network attachment, unless the target resource is itself the target of a flow log collector. - If the target is a virtual server instance, flow logs will be collected for all network attachments or network interfaces on that instance. - If the target is a subnet, flow logs will be collected for all instance network interfaces and virtual network interfaces attached to that subnet. - If the target is a VPC, flow logs will be collected for all instance network interfaces and virtual network interfaces  attached to all subnets within that VPC. If the target is an instance, subnet, or VPC, flow logs will not be collected for any instance network attachments or instance network interfaces within the target that are themselves the target of a more specific flow log collector. */
+  /**
+   * The target this collector is collecting flow logs for.
+   *
+   * - If the target is an instance network attachment, flow logs will be collected
+   *   for that instance network attachment.
+   * - If the target is an instance network interface, flow logs will be collected
+   *   for that instance network interface.
+   * - If the target is a virtual network interface, flow logs will be collected for the
+   *   virtual network interface's `target` resource if the resource is an instance network
+   *   attachment, unless the target resource is itself the target of a flow log collector.
+   * - If the target is a virtual server instance, flow logs will be collected
+   *   for all network attachments or network interfaces on that instance.
+   * - If the target is a subnet, flow logs will be collected
+   *   for all instance network interfaces and virtual network interfaces
+   *   attached to that subnet.
+   * - If the target is a VPC, flow logs will be collected for all instance network
+   *   interfaces and virtual network interfaces  attached to all subnets within that VPC.
+   *
+   * If the target is an instance, subnet, or VPC, flow logs will not be collected for any instance network attachments
+   * or instance network interfaces within the target that are themselves the target of a more specific flow log
+   * collector.
+   */
   export interface FlowLogCollectorTarget {
   }
 
-  /** The target this collector will collect flow logs for. If the target is an instance, subnet, or VPC, flow logs will not be collected for any instance network attachments, virtual network interfaces or instance network interfaces within the target that are themselves the target of a more specific flow log collector. The target must not be a virtual network interface that is attached to a bare metal server network attachment or to a file share mount target. */
+  /**
+   * The target this collector will collect flow logs for.
+   *
+   * If the target is an instance, subnet, or VPC, flow logs will not be collected for any instance network attachments,
+   * virtual network interfaces or instance network interfaces within the target that are themselves the target of a
+   * more specific flow log collector.
+   *
+   * The target must not be a virtual network interface that is attached to a bare metal server network attachment or to
+   * a file share mount target.
+   */
   export interface FlowLogCollectorTargetPrototype {
   }
 
-  /** IKEPolicy. */
+  /**
+   * IKEPolicy.
+   */
   export interface IKEPolicy {
     /** The authentication algorithm.
      *
@@ -36007,59 +39184,41 @@ namespace VpcV1 {
     }
   }
 
-  /** IKEPolicyCollection. */
+  /**
+   * IKEPolicyCollection.
+   */
   export interface IKEPolicyCollection {
     /** A link to the first page of resources. */
-    first: IKEPolicyCollectionFirst;
+    first: PageLink;
     /** A page of IKE policies. */
     ike_policies: IKEPolicy[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: IKEPolicyCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface IKEPolicyCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface IKEPolicyCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** IKEPolicyConnectionCollection. */
+  /**
+   * IKEPolicyConnectionCollection.
+   */
   export interface IKEPolicyConnectionCollection {
     /** A page of VPN gateway connections that use the IKE policy specified by the identifier in the URL. */
     connections: VPNGatewayConnection[];
     /** A link to the first page of resources. */
-    first: IKEPolicyConnectionCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: IKEPolicyConnectionCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface IKEPolicyConnectionCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface IKEPolicyConnectionCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** IKEPolicyReference. */
+  /**
+   * IKEPolicyReference.
+   */
   export interface IKEPolicyReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -36083,7 +39242,9 @@ namespace VpcV1 {
     }
   }
 
-  /** IP. */
+  /**
+   * IP.
+   */
   export interface IP {
     /** The IP address.
      *
@@ -36093,7 +39254,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** IPsecPolicy. */
+  /**
+   * IPsecPolicy.
+   */
   export interface IPsecPolicy {
     /** The authentication algorithm
      *
@@ -36202,59 +39365,41 @@ namespace VpcV1 {
     }
   }
 
-  /** IPsecPolicyCollection. */
+  /**
+   * IPsecPolicyCollection.
+   */
   export interface IPsecPolicyCollection {
     /** A link to the first page of resources. */
-    first: IPsecPolicyCollectionFirst;
+    first: PageLink;
     /** A page of IPsec policies. */
     ipsec_policies: IPsecPolicy[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: IPsecPolicyCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface IPsecPolicyCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface IPsecPolicyCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** IPsecPolicyConnectionCollection. */
+  /**
+   * IPsecPolicyConnectionCollection.
+   */
   export interface IPsecPolicyConnectionCollection {
     /** A page of VPN gateway connections that use the IPsec policy specified by the identifier in the URL. */
     connections: VPNGatewayConnection[];
     /** A link to the first page of resources. */
-    first: IPsecPolicyConnectionCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: IPsecPolicyConnectionCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface IPsecPolicyConnectionCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface IPsecPolicyConnectionCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** IPsecPolicyReference. */
+  /**
+   * IPsecPolicyReference.
+   */
   export interface IPsecPolicyReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -36278,7 +39423,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Image. */
+  /**
+   * Image.
+   */
   export interface Image {
     catalog_offering: ImageCatalogOffering;
     /** The date and time that the image was created. */
@@ -36389,7 +39536,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ImageCatalogOffering. */
+  /**
+   * ImageCatalogOffering.
+   */
   export interface ImageCatalogOffering {
     /** Indicates whether this image is managed as part of a
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering. If an image is managed,
@@ -36405,33 +39554,25 @@ namespace VpcV1 {
     version?: CatalogOfferingVersionReference;
   }
 
-  /** ImageCollection. */
+  /**
+   * ImageCollection.
+   */
   export interface ImageCollection {
     /** A link to the first page of resources. */
-    first: ImageCollectionFirst;
+    first: PageLink;
     /** A page of images. */
     images: Image[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ImageCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ImageCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ImageCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ImageExportJob. */
+  /**
+   * ImageExportJob.
+   */
   export interface ImageExportJob {
     /** The date and time that the image export job was completed.
      *
@@ -36517,7 +39658,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ImageExportJobStatusReason. */
+  /**
+   * ImageExportJobStatusReason.
+   */
   export interface ImageExportJobStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -36540,13 +39683,17 @@ namespace VpcV1 {
     }
   }
 
-  /** ImageExportJobUnpaginatedCollection. */
+  /**
+   * ImageExportJobUnpaginatedCollection.
+   */
   export interface ImageExportJobUnpaginatedCollection {
     /** The export jobs for the image. */
     export_jobs: ImageExportJob[];
   }
 
-  /** ImageFile. */
+  /**
+   * ImageFile.
+   */
   export interface ImageFile {
     /** Checksums for this image file.
      *
@@ -36562,13 +39709,17 @@ namespace VpcV1 {
     size?: number;
   }
 
-  /** ImageFileChecksums. */
+  /**
+   * ImageFileChecksums.
+   */
   export interface ImageFileChecksums {
     /** The SHA256 fingerprint of the image file, in hexadecimal. */
     sha256?: string;
   }
 
-  /** ImageFilePrototype. */
+  /**
+   * ImageFilePrototype.
+   */
   export interface ImageFilePrototype {
     /** The Cloud Object Storage location of the image file.
      *
@@ -36578,11 +39729,15 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** Identifies an image by a unique property. */
+  /**
+   * Identifies an image by a unique property.
+   */
   export interface ImageIdentity {
   }
 
-  /** ImagePrototype. */
+  /**
+   * ImagePrototype.
+   */
   export interface ImagePrototype {
     /** The deprecation date and time to set for this image.
      *
@@ -36618,7 +39773,9 @@ namespace VpcV1 {
     resource_group?: ResourceGroupIdentity;
   }
 
-  /** ImageReference. */
+  /**
+   * ImageReference.
+   */
   export interface ImageReference {
     /** The CRN for this image. */
     crn: string;
@@ -36648,7 +39805,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface ImageRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  account, and identifies the owning account.
@@ -36660,7 +39820,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** ImageStatusReason. */
+  /**
+   * ImageStatusReason.
+   */
   export interface ImageStatusReason {
     /** A reason code for the status:
      *  - `encrypted_data_key_invalid`: image cannot be decrypted with the specified
@@ -36699,7 +39861,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Instance. */
+  /**
+   * Instance.
+   */
   export interface Instance {
     /** The availability policy for this virtual server instance. */
     availability_policy: InstanceAvailabilityPolicy;
@@ -36713,6 +39877,13 @@ namespace VpcV1 {
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user).
      */
     catalog_offering?: InstanceCatalogOffering;
+    /** If present, the cluster network that this virtual server instance resides in. */
+    cluster_network?: ClusterNetworkReference;
+    /** The cluster network attachments for this virtual server instance.
+     *
+     *  The cluster network attachments are ordered for consistent instance configuration.
+     */
+    cluster_network_attachments: InstanceClusterNetworkAttachmentReference[];
     /** The confidential compute mode for this virtual server instance. */
     confidential_compute_mode: Instance.Constants.ConfidentialComputeMode | string;
     /** The date and time that the virtual server instance was created. */
@@ -36868,7 +40039,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceAction. */
+  /**
+   * InstanceAction.
+   */
   export interface InstanceAction {
     /** Deprecated: The date and time that the action was completed. */
     completed_at?: string;
@@ -36907,7 +40080,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceAvailabilityPolicy. */
+  /**
+   * InstanceAvailabilityPolicy.
+   */
   export interface InstanceAvailabilityPolicy {
     /** The action to perform if the compute host experiences a failure:
      *  - `restart`: Automatically restart the virtual server instance after host failure
@@ -36928,7 +40103,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceAvailabilityPolicyPatch. */
+  /**
+   * InstanceAvailabilityPolicyPatch.
+   */
   export interface InstanceAvailabilityPolicyPatch {
     /** The action to perform if the compute host experiences a failure.
      *  - `restart`: Automatically restart the virtual server instance after host failure
@@ -36946,7 +40123,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceAvailabilityPolicyPrototype. */
+  /**
+   * InstanceAvailabilityPolicyPrototype.
+   */
   export interface InstanceAvailabilityPolicyPrototype {
     /** The action to perform if the compute host experiences a failure.
      *  - `restart`: Automatically restart the virtual server instance after host failure
@@ -36964,7 +40143,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceCatalogOffering. */
+  /**
+   * InstanceCatalogOffering.
+   */
   export interface InstanceCatalogOffering {
     /** The billing plan used for the catalog offering version.
      *
@@ -36981,7 +40162,14 @@ namespace VpcV1 {
     version: CatalogOfferingVersionReference;
   }
 
-  /** The [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering or offering version to use when provisioning this virtual server instance. If an offering is specified, the latest version of that offering will be used. The specified offering or offering version may be in a different account, subject to IAM policies. */
+  /**
+   * The [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering or offering version to
+   * use when provisioning this virtual server instance.
+   *
+   * If an offering is specified, the latest version of that offering will be used.
+   *
+   * The specified offering or offering version may be in a different account, subject to IAM policies.
+   */
   export interface InstanceCatalogOfferingPrototype {
     /** The billing plan to use for the catalog offering version. If unspecified, no billing
      *  plan will be used (free). Must be specified for catalog offering versions that require
@@ -36990,33 +40178,205 @@ namespace VpcV1 {
     plan?: CatalogOfferingVersionPlanIdentity;
   }
 
-  /** InstanceCollection. */
+  /**
+   * InstanceClusterNetworkAttachment.
+   */
+  export interface InstanceClusterNetworkAttachment {
+    /** The instance cluster network attachment that is immediately before. If absent, this is the
+     *  last instance cluster network attachment.
+     */
+    before?: InstanceClusterNetworkAttachmentBefore;
+    /** The cluster network interface for this instance cluster network attachment. */
+    cluster_network_interface: ClusterNetworkInterfaceReference;
+    /** The URL for this instance cluster network attachment. */
+    href: string;
+    /** The unique identifier for this instance cluster network attachment. */
+    id: string;
+    /** The reasons for the current `lifecycle_state` (if any). */
+    lifecycle_reasons: InstanceClusterNetworkAttachmentLifecycleReason[];
+    /** The lifecycle state of the instance cluster network attachment. */
+    lifecycle_state: InstanceClusterNetworkAttachment.Constants.LifecycleState | string;
+    /** The name for this instance cluster network attachment. The name is unique across all network attachments for
+     *  the instance.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: InstanceClusterNetworkAttachment.Constants.ResourceType | string;
+  }
+  export namespace InstanceClusterNetworkAttachment {
+    export namespace Constants {
+      /** The lifecycle state of the instance cluster network attachment. */
+      export enum LifecycleState {
+        DELETING = 'deleting',
+        FAILED = 'failed',
+        PENDING = 'pending',
+        STABLE = 'stable',
+        SUSPENDED = 'suspended',
+        UPDATING = 'updating',
+        WAITING = 'waiting',
+      }
+      /** The resource type. */
+      export enum ResourceType {
+        INSTANCE_CLUSTER_NETWORK_ATTACHMENT = 'instance_cluster_network_attachment',
+      }
+    }
+  }
+
+  /**
+   * The instance cluster network attachment that is immediately before. If absent, this is the last instance cluster
+   * network attachment.
+   */
+  export interface InstanceClusterNetworkAttachmentBefore {
+    /** The URL for this instance cluster network attachment. */
+    href: string;
+    /** The unique identifier for this instance cluster network attachment. */
+    id: string;
+    /** The name for this instance cluster network attachment. The name is unique across all network attachments for
+     *  the instance.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: InstanceClusterNetworkAttachmentBefore.Constants.ResourceType | string;
+  }
+  export namespace InstanceClusterNetworkAttachmentBefore {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        INSTANCE_CLUSTER_NETWORK_ATTACHMENT = 'instance_cluster_network_attachment',
+      }
+    }
+  }
+
+  /**
+   * The instance cluster network attachment to insert this instance cluster network attachment immediately before.
+   *
+   * If unspecified, this instance cluster network attachment will be inserted after all existing instance cluster
+   * network attachments.
+   */
+  export interface InstanceClusterNetworkAttachmentBeforePrototype {
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentCollection.
+   */
+  export interface InstanceClusterNetworkAttachmentCollection {
+    /** A page of ordered cluster network attachments (sorted based on the `before` property) for the instance. A
+     *  cluster network attachment represents a device to which a cluster network interface is attached.
+     */
+    cluster_network_attachments: InstanceClusterNetworkAttachment[];
+    /** A link to the first page of resources. */
+    first: PageLink;
+    /** The maximum number of resources that can be returned by the request. */
+    limit: number;
+    /** A link to the next page of resources. This property is present for all pages except the last page. */
+    next?: PageLink;
+    /** The total number of resources across all pages. */
+    total_count: number;
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentLifecycleReason.
+   */
+  export interface InstanceClusterNetworkAttachmentLifecycleReason {
+    /** A reason code for this lifecycle state:
+     *  - `internal_error`: internal error (contact IBM support)
+     *  - `resource_suspended_by_provider`: The resource has been suspended (contact IBM
+     *    support)
+     *
+     *  The enumerated values for this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+     */
+    code: InstanceClusterNetworkAttachmentLifecycleReason.Constants.Code | string;
+    /** An explanation of the reason for this lifecycle state. */
+    message: string;
+    /** Link to documentation about the reason for this lifecycle state. */
+    more_info?: string;
+  }
+  export namespace InstanceClusterNetworkAttachmentLifecycleReason {
+    export namespace Constants {
+      /** A reason code for this lifecycle state: - `internal_error`: internal error (contact IBM support) - `resource_suspended_by_provider`: The resource has been suspended (contact IBM support) The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      export enum Code {
+        INTERNAL_ERROR = 'internal_error',
+        RESOURCE_SUSPENDED_BY_PROVIDER = 'resource_suspended_by_provider',
+      }
+    }
+  }
+
+  /**
+   * A cluster network interface for the instance cluster network attachment. This can be specified using an existing
+   * cluster network interface that does not already have a `target`, or a prototype object for a new cluster network
+   * interface.
+   *
+   * This instance must reside in the same VPC as the specified cluster network interface. The cluster network interface
+   * must reside in the same cluster network as the
+   * `cluster_network_interface` of any other `cluster_network_attachments` for this instance.
+   */
+  export interface InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterface {
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentPrototypeInstanceContext.
+   */
+  export interface InstanceClusterNetworkAttachmentPrototypeInstanceContext {
+    /** A cluster network interface for the instance cluster network attachment. This can be
+     *  specified using an existing cluster network interface that does not already have a `target`,
+     *  or a prototype object for a new cluster network interface.
+     *
+     *  This instance must reside in the same VPC as the specified cluster network interface. The
+     *  cluster network interface must reside in the same cluster network as the
+     *  `cluster_network_interface` of any other `cluster_network_attachments` for this instance.
+     */
+    cluster_network_interface: InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterface;
+    /** The name for this cluster network attachment. Names must be unique within the instance the cluster network
+     *  attachment resides in. If unspecified, the name will be a hyphenated list of randomly-selected words. Names
+     *  starting with `ibm-` are reserved for provider-owned resources, and are not allowed.
+     */
+    name?: string;
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentReference.
+   */
+  export interface InstanceClusterNetworkAttachmentReference {
+    /** The URL for this instance cluster network attachment. */
+    href: string;
+    /** The unique identifier for this instance cluster network attachment. */
+    id: string;
+    /** The name for this instance cluster network attachment. The name is unique across all network attachments for
+     *  the instance.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: InstanceClusterNetworkAttachmentReference.Constants.ResourceType | string;
+  }
+  export namespace InstanceClusterNetworkAttachmentReference {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        INSTANCE_CLUSTER_NETWORK_ATTACHMENT = 'instance_cluster_network_attachment',
+      }
+    }
+  }
+
+  /**
+   * InstanceCollection.
+   */
   export interface InstanceCollection {
     /** A link to the first page of resources. */
-    first: InstanceCollectionFirst;
+    first: PageLink;
     /** A page of virtual server instances. */
     instances: Instance[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The instance console access token information. */
+  /**
+   * The instance console access token information.
+   */
   export interface InstanceConsoleAccessToken {
     /** A URL safe single-use token used to access the console WebSocket. */
     access_token: string;
@@ -37043,7 +40403,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceDefaultTrustedProfilePrototype. */
+  /**
+   * InstanceDefaultTrustedProfilePrototype.
+   */
   export interface InstanceDefaultTrustedProfilePrototype {
     /** If set to `true`, the system will create a link to the specified `target` trusted profile during instance
      *  creation. Regardless of whether a link is created by the system or manually using the IAM Identity service, it
@@ -37054,7 +40416,9 @@ namespace VpcV1 {
     target: TrustedProfileIdentity;
   }
 
-  /** InstanceDisk. */
+  /**
+   * InstanceDisk.
+   */
   export interface InstanceDisk {
     /** The date and time that the disk was created. */
     created_at: string;
@@ -37089,13 +40453,17 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceDiskCollection. */
+  /**
+   * InstanceDiskCollection.
+   */
   export interface InstanceDiskCollection {
     /** The disks for the instance. */
     disks: InstanceDisk[];
   }
 
-  /** InstanceDiskReference. */
+  /**
+   * InstanceDiskReference.
+   */
   export interface InstanceDiskReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -37119,7 +40487,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The virtual server instance GPU configuration. */
+  /**
+   * The virtual server instance GPU configuration.
+   */
   export interface InstanceGPU {
     /** The number of GPUs assigned to the instance. */
     count: number;
@@ -37131,7 +40501,9 @@ namespace VpcV1 {
     model: string;
   }
 
-  /** InstanceGroup. */
+  /**
+   * InstanceGroup.
+   */
   export interface InstanceGroup {
     /** The port used for new load balancer pool members created by this instance group.
      *
@@ -37203,33 +40575,25 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupCollection. */
+  /**
+   * InstanceGroupCollection.
+   */
   export interface InstanceGroupCollection {
     /** A link to the first page of resources. */
-    first: InstanceGroupCollectionFirst;
+    first: PageLink;
     /** A page of instance groups. */
     instance_groups: InstanceGroup[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceGroupCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceGroupCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceGroupCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** InstanceGroupLifecycleReason. */
+  /**
+   * InstanceGroupLifecycleReason.
+   */
   export interface InstanceGroupLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `internal_error`: internal error (contact IBM support)
@@ -37255,7 +40619,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManager. */
+  /**
+   * InstanceGroupManager.
+   */
   export interface InstanceGroupManager {
     /** The date and time that the instance group manager was created. */
     created_at: string;
@@ -37271,7 +40637,9 @@ namespace VpcV1 {
     updated_at: string;
   }
 
-  /** InstanceGroupManagerAction. */
+  /**
+   * InstanceGroupManagerAction.
+   */
   export interface InstanceGroupManagerAction {
     /** Indicates whether this scheduled action will be automatically deleted after it has completed and
      *  `auto_delete_timeout` hours have passed.
@@ -37324,13 +40692,17 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerActionGroupPatch. */
+  /**
+   * InstanceGroupManagerActionGroupPatch.
+   */
   export interface InstanceGroupManagerActionGroupPatch {
     /** The desired number of instance group members at the scheduled time. */
     membership_count?: number;
   }
 
-  /** InstanceGroupManagerActionManagerPatch. */
+  /**
+   * InstanceGroupManagerActionManagerPatch.
+   */
   export interface InstanceGroupManagerActionManagerPatch {
     /** The desired maximum number of instance group members at the scheduled time. */
     max_membership_count?: number;
@@ -37338,7 +40710,9 @@ namespace VpcV1 {
     min_membership_count?: number;
   }
 
-  /** InstanceGroupManagerActionPrototype. */
+  /**
+   * InstanceGroupManagerActionPrototype.
+   */
   export interface InstanceGroupManagerActionPrototype {
     /** The name for this instance group manager action. The name must not be used by another action for the
      *  instance group manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
@@ -37346,7 +40720,9 @@ namespace VpcV1 {
     name?: string;
   }
 
-  /** InstanceGroupManagerActionReference. */
+  /**
+   * InstanceGroupManagerActionReference.
+   */
   export interface InstanceGroupManagerActionReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -37372,59 +40748,41 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerActionsCollection. */
+  /**
+   * InstanceGroupManagerActionsCollection.
+   */
   export interface InstanceGroupManagerActionsCollection {
     /** A page of actions for the instance group manager. */
     actions: InstanceGroupManagerAction[];
     /** A link to the first page of resources. */
-    first: InstanceGroupManagerActionsCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceGroupManagerActionsCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceGroupManagerActionsCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceGroupManagerActionsCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** InstanceGroupManagerCollection. */
+  /**
+   * InstanceGroupManagerCollection.
+   */
   export interface InstanceGroupManagerCollection {
     /** A link to the first page of resources. */
-    first: InstanceGroupManagerCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A page of managers for the instance group. */
     managers: InstanceGroupManager[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceGroupManagerCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceGroupManagerCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceGroupManagerCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** InstanceGroupManagerPolicy. */
+  /**
+   * InstanceGroupManagerPolicy.
+   */
   export interface InstanceGroupManagerPolicy {
     /** The date and time that the instance group manager policy was created. */
     created_at: string;
@@ -37440,33 +40798,25 @@ namespace VpcV1 {
     updated_at: string;
   }
 
-  /** InstanceGroupManagerPolicyCollection. */
+  /**
+   * InstanceGroupManagerPolicyCollection.
+   */
   export interface InstanceGroupManagerPolicyCollection {
     /** A link to the first page of resources. */
-    first: InstanceGroupManagerPolicyCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceGroupManagerPolicyCollectionNext;
+    next?: PageLink;
     /** A page of policies for the instance group manager. */
     policies: InstanceGroupManagerPolicy[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceGroupManagerPolicyCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceGroupManagerPolicyCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** InstanceGroupManagerPolicyPrototype. */
+  /**
+   * InstanceGroupManagerPolicyPrototype.
+   */
   export interface InstanceGroupManagerPolicyPrototype {
     /** The name for this instance group manager policy. The name must not be used by another policy for the
      *  instance group manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
@@ -37474,7 +40824,9 @@ namespace VpcV1 {
     name?: string;
   }
 
-  /** InstanceGroupManagerPolicyReference. */
+  /**
+   * InstanceGroupManagerPolicyReference.
+   */
   export interface InstanceGroupManagerPolicyReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -37490,7 +40842,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** InstanceGroupManagerPrototype. */
+  /**
+   * InstanceGroupManagerPrototype.
+   */
   export interface InstanceGroupManagerPrototype {
     /** Indicates whether this manager will control the instance group. */
     management_enabled?: boolean;
@@ -37500,7 +40854,9 @@ namespace VpcV1 {
     name?: string;
   }
 
-  /** InstanceGroupManagerReference. */
+  /**
+   * InstanceGroupManagerReference.
+   */
   export interface InstanceGroupManagerReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -37514,27 +40870,37 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** InstanceGroupManagerScheduledActionGroup. */
+  /**
+   * InstanceGroupManagerScheduledActionGroup.
+   */
   export interface InstanceGroupManagerScheduledActionGroup {
     /** The desired number of instance group members at the scheduled time. */
     membership_count: number;
   }
 
-  /** InstanceGroupManagerScheduledActionGroupPrototype. */
+  /**
+   * InstanceGroupManagerScheduledActionGroupPrototype.
+   */
   export interface InstanceGroupManagerScheduledActionGroupPrototype {
     /** The desired number of instance group members at the scheduled time. */
     membership_count: number;
   }
 
-  /** InstanceGroupManagerScheduledActionManager. */
+  /**
+   * InstanceGroupManagerScheduledActionManager.
+   */
   export interface InstanceGroupManagerScheduledActionManager {
   }
 
-  /** InstanceGroupManagerScheduledActionManagerPrototype. */
+  /**
+   * InstanceGroupManagerScheduledActionManagerPrototype.
+   */
   export interface InstanceGroupManagerScheduledActionManagerPrototype {
   }
 
-  /** InstanceGroupMembership. */
+  /**
+   * InstanceGroupMembership.
+   */
   export interface InstanceGroupMembership {
     /** The date and time that the instance group manager policy was created. */
     created_at: string;
@@ -37578,33 +40944,25 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupMembershipCollection. */
+  /**
+   * InstanceGroupMembershipCollection.
+   */
   export interface InstanceGroupMembershipCollection {
     /** A link to the first page of resources. */
-    first: InstanceGroupMembershipCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A page of memberships for the instance group. */
     memberships: InstanceGroupMembership[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceGroupMembershipCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceGroupMembershipCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceGroupMembershipCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** InstanceGroupReference. */
+  /**
+   * InstanceGroupReference.
+   */
   export interface InstanceGroupReference {
     /** The CRN for this instance group. */
     crn: string;
@@ -37620,7 +40978,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** InstanceHealthReason. */
+  /**
+   * InstanceHealthReason.
+   */
   export interface InstanceHealthReason {
     /** A reason code for this health state:
      *  - `reservation_capacity_unavailable`: The reservation affinity pool has no
@@ -37650,7 +41010,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceInitialization. */
+  /**
+   * InstanceInitialization.
+   */
   export interface InstanceInitialization {
     /** The default trusted profile configuration specified at virtual server instance
      *  creation. If absent, no default trusted profile was specified.
@@ -37661,7 +41023,9 @@ namespace VpcV1 {
     password?: InstanceInitializationPassword;
   }
 
-  /** InstanceInitializationDefaultTrustedProfile. */
+  /**
+   * InstanceInitializationDefaultTrustedProfile.
+   */
   export interface InstanceInitializationDefaultTrustedProfile {
     /** If set to `true`, the system created a link to the specified `target` trusted profile during instance
      *  creation. Regardless of whether a link was created by the system or manually using the IAM Identity service, it
@@ -37672,7 +41036,9 @@ namespace VpcV1 {
     target: TrustedProfileReference;
   }
 
-  /** InstanceInitializationPassword. */
+  /**
+   * InstanceInitializationPassword.
+   */
   export interface InstanceInitializationPassword {
     /** The administrator password at initialization, encrypted using `encryption_key`, and returned base64-encoded. */
     encrypted_password: string;
@@ -37680,7 +41046,9 @@ namespace VpcV1 {
     encryption_key: KeyIdentityByFingerprint;
   }
 
-  /** InstanceLifecycleReason. */
+  /**
+   * InstanceLifecycleReason.
+   */
   export interface InstanceLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `failed_registration`: the instance's registration to Resource Controller has
@@ -37713,7 +41081,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The metadata service configuration. */
+  /**
+   * The metadata service configuration.
+   */
   export interface InstanceMetadataService {
     /** Indicates whether the metadata service endpoint is available to the virtual server instance. */
     enabled: boolean;
@@ -37738,7 +41108,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The metadata service configuration. */
+  /**
+   * The metadata service configuration.
+   */
   export interface InstanceMetadataServicePatch {
     /** Indicates whether the metadata service endpoint will be available to the virtual server instance. */
     enabled?: boolean;
@@ -37763,7 +41135,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The metadata service configuration. */
+  /**
+   * The metadata service configuration.
+   */
   export interface InstanceMetadataServicePrototype {
     /** Indicates whether the metadata service endpoint will be available to the virtual server instance. */
     enabled?: boolean;
@@ -37788,7 +41162,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceNetworkAttachment. */
+  /**
+   * InstanceNetworkAttachment.
+   */
   export interface InstanceNetworkAttachment {
     /** The date and time that the instance network attachment was created. */
     created_at: string;
@@ -37839,13 +41215,17 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceNetworkAttachmentCollection. */
+  /**
+   * InstanceNetworkAttachmentCollection.
+   */
   export interface InstanceNetworkAttachmentCollection {
     /** The network attachments for the instance. */
     network_attachments: InstanceNetworkAttachment[];
   }
 
-  /** InstanceNetworkAttachmentPrototype. */
+  /**
+   * InstanceNetworkAttachmentPrototype.
+   */
   export interface InstanceNetworkAttachmentPrototype {
     /** The name for this network attachment. Names must be unique within the instance the network attachment
      *  resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
@@ -37861,11 +41241,19 @@ namespace VpcV1 {
     virtual_network_interface: InstanceNetworkAttachmentPrototypeVirtualNetworkInterface;
   }
 
-  /** A virtual network interface for the instance network attachment. This can be specified using an existing virtual network interface, or a prototype object for a new virtual network interface. If an existing virtual network interface is specified, `enable_infrastructure_nat` must be `true`. */
+  /**
+   * A virtual network interface for the instance network attachment. This can be specified using an existing virtual
+   * network interface, or a prototype object for a new virtual network interface.
+   *
+   * If an existing virtual network interface is specified, `enable_infrastructure_nat` must be
+   * `true`.
+   */
   export interface InstanceNetworkAttachmentPrototypeVirtualNetworkInterface {
   }
 
-  /** InstanceNetworkAttachmentReference. */
+  /**
+   * InstanceNetworkAttachmentReference.
+   */
   export interface InstanceNetworkAttachmentReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -37897,25 +41285,46 @@ namespace VpcV1 {
     }
   }
 
-  /** The profile to use for this virtual server instance. For the profile to be changed, the instance `status` must be `stopping` or `stopped`. In addition, the requested profile must: - Have matching instance disk support. Any disks associated with the current profile will be deleted, and any disks associated with the requested profile will be created. - Be compatible with any `placement_target` constraints. For example, if the instance is placed on a dedicated host, the requested profile `family` must be the same as the dedicated host `family`. - Have the same `vcpu.architecture`. - Support the number of network attachments or network interfaces the instance currently has. */
+  /**
+   * The profile to use for this virtual server instance. Any disks associated with the current profile will be deleted,
+   * and any disks associated with the requested profile will be created.
+   *
+   * For the profile to be changed, the instance `status` must be `stopping` or `stopped`. In addition, the requested
+   * profile must:
+   * - Be compatible with any `placement_target` constraints. For example, if the
+   *   instance is placed on a dedicated host, the requested profile `family` must be
+   *   the same as the dedicated host `family`.
+   * - Have the same `vcpu.architecture`.
+   * - Support the number of network attachments or network interfaces the instance
+   *   currently has.
+   */
   export interface InstancePatchProfile {
   }
 
-  /** InstancePlacementTarget. */
+  /**
+   * InstancePlacementTarget.
+   */
   export interface InstancePlacementTarget {
   }
 
-  /** InstancePlacementTargetPatch. */
+  /**
+   * InstancePlacementTargetPatch.
+   */
   export interface InstancePlacementTargetPatch {
   }
 
-  /** InstancePlacementTargetPrototype. */
+  /**
+   * InstancePlacementTargetPrototype.
+   */
   export interface InstancePlacementTargetPrototype {
   }
 
-  /** InstanceProfile. */
+  /**
+   * InstanceProfile.
+   */
   export interface InstanceProfile {
     bandwidth: InstanceProfileBandwidth;
+    cluster_network_attachment_count: InstanceProfileClusterNetworkAttachmentCount;
     confidential_compute_modes: InstanceProfileSupportedConfidentialComputeModes;
     /** The disks for an instance with this profile. */
     disks: InstanceProfileDisk[];
@@ -37952,6 +41361,8 @@ namespace VpcV1 {
      *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
      */
     status: InstanceProfile.Constants.Status | string;
+    /** The cluster network profiles that support this instance profile. */
+    supported_cluster_network_profiles: ClusterNetworkProfileReference[];
     total_volume_bandwidth: InstanceProfileVolumeBandwidth;
     vcpu_architecture: InstanceProfileVCPUArchitecture;
     vcpu_count: InstanceProfileVCPU;
@@ -37971,32 +41382,50 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileBandwidth. */
+  /**
+   * InstanceProfileBandwidth.
+   */
   export interface InstanceProfileBandwidth {
   }
 
-  /** InstanceProfileCollection. */
+  /**
+   * InstanceProfileClusterNetworkAttachmentCount.
+   */
+  export interface InstanceProfileClusterNetworkAttachmentCount {
+  }
+
+  /**
+   * InstanceProfileCollection.
+   */
   export interface InstanceProfileCollection {
     /** A page of virtual server instance profiles. */
     profiles: InstanceProfile[];
   }
 
-  /** Disks provided by this profile. */
+  /**
+   * Disks provided by this profile.
+   */
   export interface InstanceProfileDisk {
     quantity: InstanceProfileDiskQuantity;
     size: InstanceProfileDiskSize;
     supported_interface_types: InstanceProfileDiskSupportedInterfaces;
   }
 
-  /** InstanceProfileDiskQuantity. */
+  /**
+   * InstanceProfileDiskQuantity.
+   */
   export interface InstanceProfileDiskQuantity {
   }
 
-  /** InstanceProfileDiskSize. */
+  /**
+   * InstanceProfileDiskSize.
+   */
   export interface InstanceProfileDiskSize {
   }
 
-  /** InstanceProfileDiskSupportedInterfaces. */
+  /**
+   * InstanceProfileDiskSupportedInterfaces.
+   */
   export interface InstanceProfileDiskSupportedInterfaces {
     /** The disk interface used for attaching the disk.
      *
@@ -38028,11 +41457,15 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileGPU. */
+  /**
+   * InstanceProfileGPU.
+   */
   export interface InstanceProfileGPU {
   }
 
-  /** InstanceProfileGPUManufacturer. */
+  /**
+   * InstanceProfileGPUManufacturer.
+   */
   export interface InstanceProfileGPUManufacturer {
     /** The type for this profile field. */
     type: InstanceProfileGPUManufacturer.Constants.Type | string;
@@ -38048,11 +41481,15 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileGPUMemory. */
+  /**
+   * InstanceProfileGPUMemory.
+   */
   export interface InstanceProfileGPUMemory {
   }
 
-  /** InstanceProfileGPUModel. */
+  /**
+   * InstanceProfileGPUModel.
+   */
   export interface InstanceProfileGPUModel {
     /** The type for this profile field. */
     type: InstanceProfileGPUModel.Constants.Type | string;
@@ -38068,27 +41505,39 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies an instance profile by a unique property. */
+  /**
+   * Identifies an instance profile by a unique property.
+   */
   export interface InstanceProfileIdentity {
   }
 
-  /** InstanceProfileMemory. */
+  /**
+   * InstanceProfileMemory.
+   */
   export interface InstanceProfileMemory {
   }
 
-  /** InstanceProfileNUMACount. */
+  /**
+   * InstanceProfileNUMACount.
+   */
   export interface InstanceProfileNUMACount {
   }
 
-  /** InstanceProfileNetworkAttachmentCount. */
+  /**
+   * InstanceProfileNetworkAttachmentCount.
+   */
   export interface InstanceProfileNetworkAttachmentCount {
   }
 
-  /** InstanceProfileNetworkInterfaceCount. */
+  /**
+   * InstanceProfileNetworkInterfaceCount.
+   */
   export interface InstanceProfileNetworkInterfaceCount {
   }
 
-  /** InstanceProfileOSArchitecture. */
+  /**
+   * InstanceProfileOSArchitecture.
+   */
   export interface InstanceProfileOSArchitecture {
     /** The default OS architecture for an instance with this profile. */
     default: string;
@@ -38106,11 +41555,15 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfilePortSpeed. */
+  /**
+   * InstanceProfilePortSpeed.
+   */
   export interface InstanceProfilePortSpeed {
   }
 
-  /** InstanceProfileReference. */
+  /**
+   * InstanceProfileReference.
+   */
   export interface InstanceProfileReference {
     /** The URL for this virtual server instance profile. */
     href: string;
@@ -38128,7 +41581,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileReservationTerms. */
+  /**
+   * InstanceProfileReservationTerms.
+   */
   export interface InstanceProfileReservationTerms {
     /** The type for this profile field. */
     type: InstanceProfileReservationTerms.Constants.Type | string;
@@ -38149,7 +41604,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileSupportedConfidentialComputeModes. */
+  /**
+   * InstanceProfileSupportedConfidentialComputeModes.
+   */
   export interface InstanceProfileSupportedConfidentialComputeModes {
     /** The default confidential compute mode for this profile. */
     default: InstanceProfileSupportedConfidentialComputeModes.Constants.Default | string;
@@ -38177,7 +41634,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileSupportedSecureBootModes. */
+  /**
+   * InstanceProfileSupportedSecureBootModes.
+   */
   export interface InstanceProfileSupportedSecureBootModes {
     /** The default secure boot mode for this profile. */
     default: boolean;
@@ -38195,11 +41654,15 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileVCPU. */
+  /**
+   * InstanceProfileVCPU.
+   */
   export interface InstanceProfileVCPU {
   }
 
-  /** InstanceProfileVCPUArchitecture. */
+  /**
+   * InstanceProfileVCPUArchitecture.
+   */
   export interface InstanceProfileVCPUArchitecture {
     /** The default VCPU architecture for an instance with this profile. */
     default?: string;
@@ -38217,7 +41680,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileVCPUManufacturer. */
+  /**
+   * InstanceProfileVCPUManufacturer.
+   */
   export interface InstanceProfileVCPUManufacturer {
     /** The default VCPU manufacturer for an instance with this profile. */
     default?: string;
@@ -38235,14 +41700,23 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileVolumeBandwidth. */
+  /**
+   * InstanceProfileVolumeBandwidth.
+   */
   export interface InstanceProfileVolumeBandwidth {
   }
 
-  /** InstancePrototype. */
+  /**
+   * InstancePrototype.
+   */
   export interface InstancePrototype {
     /** The availability policy to use for this virtual server instance. */
     availability_policy?: InstanceAvailabilityPolicyPrototype;
+    /** The cluster network attachments to create for this virtual server instance. A cluster network attachment
+     *  represents a device that is connected to a cluster network. The number of network attachments must match one of
+     *  the values from the instance profile's `cluster_network_attachment_count` before the instance can be started.
+     */
+    cluster_network_attachments?: InstanceClusterNetworkAttachmentPrototypeInstanceContext[];
     /** The confidential compute mode to use for this virtual server instance.
      *
      *  If unspecified, the default confidential compute mode from the profile will be used.
@@ -38328,7 +41802,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceReference. */
+  /**
+   * InstanceReference.
+   */
   export interface InstanceReference {
     /** The CRN for this virtual server instance. */
     crn: string;
@@ -38346,7 +41822,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** InstanceReservationAffinity. */
+  /**
+   * InstanceReservationAffinity.
+   */
   export interface InstanceReservationAffinity {
     /** The reservation affinity policy to use for this virtual server instance:
      *  - `disabled`: Reservations will not be used
@@ -38366,7 +41844,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceReservationAffinityPatch. */
+  /**
+   * InstanceReservationAffinityPatch.
+   */
   export interface InstanceReservationAffinityPatch {
     /** The reservation affinity policy to use for this virtual server instance:
      *  - `disabled`: Reservations will not be used
@@ -38395,7 +41875,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceReservationAffinityPrototype. */
+  /**
+   * InstanceReservationAffinityPrototype.
+   */
   export interface InstanceReservationAffinityPrototype {
     /** The reservation affinity policy to use for this virtual server instance:
      *  - `disabled`: Reservations will not be used
@@ -38424,7 +41906,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceStatusReason. */
+  /**
+   * InstanceStatusReason.
+   */
   export interface InstanceStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -38457,10 +41941,17 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplate. */
+  /**
+   * InstanceTemplate.
+   */
   export interface InstanceTemplate {
     /** The availability policy to use for this virtual server instance. */
     availability_policy?: InstanceAvailabilityPolicyPrototype;
+    /** The cluster network attachments to create for this virtual server instance. A cluster network attachment
+     *  represents a device that is connected to a cluster network. The number of network attachments must match one of
+     *  the values from the instance profile's `cluster_network_attachment_count` before the instance can be started.
+     */
+    cluster_network_attachments?: InstanceClusterNetworkAttachmentPrototypeInstanceContext[];
     /** The confidential compute mode to use for this virtual server instance.
      *
      *  If unspecified, the default confidential compute mode from the profile will be used.
@@ -38548,40 +42039,39 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateCollection. */
+  /**
+   * InstanceTemplateCollection.
+   */
   export interface InstanceTemplateCollection {
     /** A link to the first page of resources. */
-    first: InstanceTemplateCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: InstanceTemplateCollectionNext;
+    next?: PageLink;
     /** A page of instance templates. */
     templates: InstanceTemplate[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface InstanceTemplateCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface InstanceTemplateCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies an instance template by a unique property. */
+  /**
+   * Identifies an instance template by a unique property.
+   */
   export interface InstanceTemplateIdentity {
   }
 
-  /** InstanceTemplatePrototype. */
+  /**
+   * InstanceTemplatePrototype.
+   */
   export interface InstanceTemplatePrototype {
     /** The availability policy to use for this virtual server instance. */
     availability_policy?: InstanceAvailabilityPolicyPrototype;
+    /** The cluster network attachments to create for this virtual server instance. A cluster network attachment
+     *  represents a device that is connected to a cluster network. The number of network attachments must match one of
+     *  the values from the instance profile's `cluster_network_attachment_count` before the instance can be started.
+     */
+    cluster_network_attachments?: InstanceClusterNetworkAttachmentPrototypeInstanceContext[];
     /** The confidential compute mode to use for this virtual server instance.
      *
      *  If unspecified, the default confidential compute mode from the profile will be used.
@@ -38665,7 +42155,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateReference. */
+  /**
+   * InstanceTemplateReference.
+   */
   export interface InstanceTemplateReference {
     /** The CRN for this instance template. */
     crn: string;
@@ -38681,7 +42173,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** The virtual server instance VCPU configuration. */
+  /**
+   * The virtual server instance VCPU configuration.
+   */
   export interface InstanceVCPU {
     /** The VCPU architecture. */
     architecture: string;
@@ -38691,7 +42185,9 @@ namespace VpcV1 {
     manufacturer: string;
   }
 
-  /** Key. */
+  /**
+   * Key.
+   */
   export interface Key {
     /** The date and time that the key was created. */
     created_at: string;
@@ -38734,37 +42230,31 @@ namespace VpcV1 {
     }
   }
 
-  /** KeyCollection. */
+  /**
+   * KeyCollection.
+   */
   export interface KeyCollection {
     /** A link to the first page of resources. */
-    first: KeyCollectionFirst;
+    first: PageLink;
     /** A page of keys. */
     keys: Key[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: KeyCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface KeyCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface KeyCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a key by a unique property. */
+  /**
+   * Identifies a key by a unique property.
+   */
   export interface KeyIdentity {
   }
 
-  /** KeyReference. */
+  /**
+   * KeyReference.
+   */
   export interface KeyReference {
     /** The CRN for this key. */
     crn: string;
@@ -38784,17 +42274,23 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** Identifies a Cloud Object Storage bucket by a unique property. */
+  /**
+   * Identifies a Cloud Object Storage bucket by a unique property.
+   */
   export interface LegacyCloudObjectStorageBucketIdentity {
   }
 
-  /** LegacyCloudObjectStorageBucketReference. */
+  /**
+   * LegacyCloudObjectStorageBucketReference.
+   */
   export interface LegacyCloudObjectStorageBucketReference {
     /** The globally unique name of this Cloud Object Storage bucket. */
     name: string;
   }
 
-  /** LoadBalancer. */
+  /**
+   * LoadBalancer.
+   */
   export interface LoadBalancer {
     /** The access mode for this load balancer:
      *  - `private`: reachable from within its VPC, at IP addresses in `private_ips`
@@ -38940,33 +42436,30 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerCollection. */
+  /**
+   * LoadBalancerCollection.
+   */
   export interface LoadBalancerCollection {
     /** A link to the first page of resources. */
-    first: LoadBalancerCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A page of load balancers. */
     load_balancers: LoadBalancer[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: LoadBalancerCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface LoadBalancerCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface LoadBalancerCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The DNS configuration for this load balancer. If absent, DNS `A` records for this load balancer's `hostname` property will be added to the public DNS zone `lb.appdomain.cloud`. Not supported by private path load balancers. */
+  /**
+   * The DNS configuration for this load balancer.
+   *
+   * If absent, DNS `A` records for this load balancer's `hostname` property will be added to the public DNS zone
+   * `lb.appdomain.cloud`.
+   *
+   * Not supported by private path load balancers.
+   */
   export interface LoadBalancerDNS {
     /** The DNS instance associated with this load balancer. */
     instance: DNSInstanceReferenceLoadBalancerDNSContext;
@@ -38974,7 +42467,14 @@ namespace VpcV1 {
     zone: DNSZoneReference;
   }
 
-  /** The DNS configuration for this load balancer. Specify `null` to remove the existing DNS configuration, which will remove all DNS `A` records for this load balancer that had been added to `zone`, and add equivalent `A` records to the public DNS zone `lb.appdomain.cloud`. Not supported by private path load balancers. */
+  /**
+   * The DNS configuration for this load balancer.
+   *
+   * Specify `null` to remove the existing DNS configuration, which will remove all DNS `A` records for this load
+   * balancer that had been added to `zone`, and add equivalent `A` records to the public DNS zone `lb.appdomain.cloud`.
+   *
+   * Not supported by private path load balancers.
+   */
   export interface LoadBalancerDNSPatch {
     /** The DNS instance to associate with this load balancer.
      *
@@ -38989,7 +42489,14 @@ namespace VpcV1 {
     zone?: DNSZoneIdentity;
   }
 
-  /** The DNS configuration for this load balancer. If unspecified, DNS `A` records for this load balancer's `hostname` property will be added to the public DNS zone `lb.appdomain.cloud`. Otherwise, those DNS `A` records will be added to the specified `zone`. Not supported by private path load balancers. */
+  /**
+   * The DNS configuration for this load balancer.
+   *
+   * If unspecified, DNS `A` records for this load balancer's `hostname` property will be added to the public DNS zone
+   * `lb.appdomain.cloud`. Otherwise, those DNS `A` records will be added to the specified `zone`.
+   *
+   * Not supported by private path load balancers.
+   */
   export interface LoadBalancerDNSPrototype {
     /** The DNS instance to associate with this load balancer.
      *
@@ -39004,11 +42511,15 @@ namespace VpcV1 {
     zone: DNSZoneIdentity;
   }
 
-  /** Identifies a load balancer by a unique property. */
+  /**
+   * Identifies a load balancer by a unique property.
+   */
   export interface LoadBalancerIdentity {
   }
 
-  /** LoadBalancerListener. */
+  /**
+   * LoadBalancerListener.
+   */
   export interface LoadBalancerListener {
     /** If set to `true`, this listener will accept and forward PROXY protocol information. Supported by load
      *  balancers in the `application` family (otherwise always `false`). Additional restrictions:
@@ -39023,8 +42534,12 @@ namespace VpcV1 {
      *  If absent, this listener is not using a certificate instance.
      */
     certificate_instance?: CertificateInstanceReference;
-    /** The connection limit of the listener. */
-    connection_limit: number;
+    /** The concurrent connection limit for the listener. If reached, incoming connections may be queued or
+     *  rejected.
+     *
+     *  This property will be present for load balancers in the `application` family.
+     */
+    connection_limit?: number;
     /** The date and time that this listener was created. */
     created_at: string;
     /** The default pool for this listener. If absent, this listener has no default pool.
@@ -39038,8 +42553,9 @@ namespace VpcV1 {
     https_redirect?: LoadBalancerListenerHTTPSRedirect;
     /** The unique identifier for this load balancer listener. */
     id: string;
-    /** The idle connection timeout of the listener in seconds. This property will be present for load balancers in
-     *  the `application` family.
+    /** The idle connection timeout of the listener in seconds.
+     *
+     *  This property will be present for load balancers in the `application` family.
      */
     idle_connection_timeout?: number;
     /** The policies for this listener. */
@@ -39089,17 +42605,31 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerCollection. */
+  /**
+   * LoadBalancerListenerCollection.
+   */
   export interface LoadBalancerListenerCollection {
     /** The listeners for the load balancer. */
     listeners: LoadBalancerListener[];
   }
 
-  /** The default pool for this listener. If `https_redirect` is set, the default pool will not be used. The specified pool must: - Belong to this load balancer - Have the same `protocol` as this listener, or have a compatible protocol. At present, the compatible protocols are `http` and `https`. - Not already be the `default_pool` for another listener Specify `null` to remove an existing default pool. */
+  /**
+   * The default pool for this listener. If `https_redirect` is set, the default pool will not be used. The specified
+   * pool must:
+   *
+   * - Belong to this load balancer
+   * - Have the same `protocol` as this listener, or have a compatible protocol.
+   *   At present, the compatible protocols are `http` and `https`.
+   * - Not already be the `default_pool` for another listener
+   *
+   * Specify `null` to remove an existing default pool.
+   */
   export interface LoadBalancerListenerDefaultPoolPatch {
   }
 
-  /** LoadBalancerListenerHTTPSRedirect. */
+  /**
+   * LoadBalancerListenerHTTPSRedirect.
+   */
   export interface LoadBalancerListenerHTTPSRedirect {
     /** The HTTP status code for this redirect. */
     http_status_code: number;
@@ -39108,7 +42638,9 @@ namespace VpcV1 {
     uri?: string;
   }
 
-  /** LoadBalancerListenerHTTPSRedirectPatch. */
+  /**
+   * LoadBalancerListenerHTTPSRedirectPatch.
+   */
   export interface LoadBalancerListenerHTTPSRedirectPatch {
     /** The HTTP status code for this redirect. */
     http_status_code?: number;
@@ -39118,7 +42650,9 @@ namespace VpcV1 {
     uri?: string;
   }
 
-  /** LoadBalancerListenerHTTPSRedirectPrototype. */
+  /**
+   * LoadBalancerListenerHTTPSRedirectPrototype.
+   */
   export interface LoadBalancerListenerHTTPSRedirectPrototype {
     /** The HTTP status code for this redirect. */
     http_status_code: number;
@@ -39128,11 +42662,15 @@ namespace VpcV1 {
     uri?: string;
   }
 
-  /** Identifies a load balancer listener by a unique property. */
+  /**
+   * Identifies a load balancer listener by a unique property.
+   */
   export interface LoadBalancerListenerIdentity {
   }
 
-  /** LoadBalancerListenerPolicy. */
+  /**
+   * LoadBalancerListenerPolicy.
+   */
   export interface LoadBalancerListenerPolicy {
     /** The policy action:
      *  - `forward`: Requests will be forwarded to the specified `target` pool
@@ -39195,19 +42733,23 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerPolicyCollection. */
+  /**
+   * LoadBalancerListenerPolicyCollection.
+   */
   export interface LoadBalancerListenerPolicyCollection {
     /** The policies for the load balancer listener. */
     policies: LoadBalancerListenerPolicy[];
   }
 
-  /** LoadBalancerListenerPolicyPrototype. */
+  /**
+   * LoadBalancerListenerPolicyPrototype.
+   */
   export interface LoadBalancerListenerPolicyPrototype {
     /** The policy action:
      *  - `forward`: Requests will be forwarded to the specified `target` pool
-     *  - `https_redirect`: Requests will be redirected to the specified target listener. The
-     *    listener must have a `protocol` of `http`, and the target listener must have a
-     *    `protocol` of `https`
+     *  - `https_redirect`: Requests will be redirected to the specified `target.listener`.
+     *     This listener must have a `protocol` of `http`, and the target listener must
+     *     have a `protocol` of `https`.
      *  - `redirect`: Requests will be redirected to the specified `target.url`
      *  - `reject`: Requests will be rejected with a `403` status code.
      */
@@ -39222,16 +42764,19 @@ namespace VpcV1 {
     priority: number;
     /** The rule prototype objects for this policy. */
     rules?: LoadBalancerListenerPolicyRulePrototype[];
-    /** - If `action` is `forward`, specify a `LoadBalancerPoolIdentity`.
-     *  - If `action` is `https_redirect`, specify a
-     *  `LoadBalancerListenerPolicyHTTPSRedirectPrototype`.
-     *  - If `action` is `redirect`, specify a `LoadBalancerListenerPolicyRedirectURLPrototype`.
+    /** - If `action` is `forward`, use `LoadBalancerPoolIdentity` to specify a pool in this
+     *    load balancer to forward to.
+     *  - If `action` is `https_redirect`, use
+     *    `LoadBalancerListenerPolicyHTTPSRedirectPrototype` to specify a listener on this
+     *    load balancer to redirect to.
+     *  - If `action` is `redirect`, use `LoadBalancerListenerPolicyRedirectURLPrototype`to
+     *    specify a URL to redirect to.
      */
     target?: LoadBalancerListenerPolicyTargetPrototype;
   }
   export namespace LoadBalancerListenerPolicyPrototype {
     export namespace Constants {
-      /** The policy action: - `forward`: Requests will be forwarded to the specified `target` pool - `https_redirect`: Requests will be redirected to the specified target listener. The listener must have a `protocol` of `http`, and the target listener must have a `protocol` of `https` - `redirect`: Requests will be redirected to the specified `target.url` - `reject`: Requests will be rejected with a `403` status code. */
+      /** The policy action: - `forward`: Requests will be forwarded to the specified `target` pool - `https_redirect`: Requests will be redirected to the specified `target.listener`. This listener must have a `protocol` of `http`, and the target listener must have a `protocol` of `https`. - `redirect`: Requests will be redirected to the specified `target.url` - `reject`: Requests will be rejected with a `403` status code. */
       export enum Action {
         FORWARD = 'forward',
         HTTPS_REDIRECT = 'https_redirect',
@@ -39241,7 +42786,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerPolicyReference. */
+  /**
+   * LoadBalancerListenerPolicyReference.
+   */
   export interface LoadBalancerListenerPolicyReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -39257,7 +42804,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** LoadBalancerListenerPolicyRule. */
+  /**
+   * LoadBalancerListenerPolicyRule.
+   */
   export interface LoadBalancerListenerPolicyRule {
     /** The condition for the rule.
      *
@@ -39319,13 +42868,17 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerPolicyRuleCollection. */
+  /**
+   * LoadBalancerListenerPolicyRuleCollection.
+   */
   export interface LoadBalancerListenerPolicyRuleCollection {
     /** The rules for the load balancer listener policy. */
     rules: LoadBalancerListenerPolicyRule[];
   }
 
-  /** LoadBalancerListenerPolicyRulePrototype. */
+  /**
+   * LoadBalancerListenerPolicyRulePrototype.
+   */
   export interface LoadBalancerListenerPolicyRulePrototype {
     /** The condition for the rule. */
     condition: LoadBalancerListenerPolicyRulePrototype.Constants.Condition | string;
@@ -39363,7 +42916,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerPolicyRuleReference. */
+  /**
+   * LoadBalancerListenerPolicyRuleReference.
+   */
   export interface LoadBalancerListenerPolicyRuleReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -39375,19 +42930,39 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** - If `action` is `forward`, the response is a `LoadBalancerPoolReference` - If `action` is `https_redirect`, the response is a `LoadBalancerListenerPolicyHTTPSRedirect` - If `action` is `redirect`, the response is a `LoadBalancerListenerPolicyRedirectURL`. */
+  /**
+   * - If `action` is `forward`, the response is a `LoadBalancerPoolReference`
+   * - If `action` is `https_redirect`, the response is a
+   * `LoadBalancerListenerPolicyHTTPSRedirect`
+   * - If `action` is `redirect`, the response is a `LoadBalancerListenerPolicyRedirectURL`.
+   */
   export interface LoadBalancerListenerPolicyTarget {
   }
 
-  /** - If `action` is `forward`, specify a `LoadBalancerPoolIdentity`. - If `action` is `https_redirect`, specify a `LoadBalancerListenerPolicyHTTPSRedirectPatch`. - If `action` is `redirect`, specify a `LoadBalancerListenerPolicyRedirectURLPatch`. */
+  /**
+   * - If `action` is `forward`, specify a `LoadBalancerPoolIdentity`.
+   * - If `action` is `https_redirect`, specify a
+   * `LoadBalancerListenerPolicyHTTPSRedirectPatch`.
+   * - If `action` is `redirect`, specify a `LoadBalancerListenerPolicyRedirectURLPatch`.
+   */
   export interface LoadBalancerListenerPolicyTargetPatch {
   }
 
-  /** - If `action` is `forward`, specify a `LoadBalancerPoolIdentity`. - If `action` is `https_redirect`, specify a `LoadBalancerListenerPolicyHTTPSRedirectPrototype`. - If `action` is `redirect`, specify a `LoadBalancerListenerPolicyRedirectURLPrototype`. */
+  /**
+   * - If `action` is `forward`, use `LoadBalancerPoolIdentity` to specify a pool in this
+   *   load balancer to forward to.
+   * - If `action` is `https_redirect`, use
+   *   `LoadBalancerListenerPolicyHTTPSRedirectPrototype` to specify a listener on this
+   *   load balancer to redirect to.
+   * - If `action` is `redirect`, use `LoadBalancerListenerPolicyRedirectURLPrototype`to
+   *   specify a URL to redirect to.
+   */
   export interface LoadBalancerListenerPolicyTargetPrototype {
   }
 
-  /** LoadBalancerListenerPrototypeLoadBalancerContext. */
+  /**
+   * LoadBalancerListenerPrototypeLoadBalancerContext.
+   */
   export interface LoadBalancerListenerPrototypeLoadBalancerContext {
     /** If set to `true`, this listener will accept and forward PROXY protocol information. Supported by load
      *  balancers in the `application` family (otherwise always `false`). Additional restrictions:
@@ -39399,7 +42974,11 @@ namespace VpcV1 {
     accept_proxy_protocol?: boolean;
     /** The certificate instance to use for SSL termination. The listener must have a `protocol` of `https`. */
     certificate_instance?: CertificateInstanceIdentity;
-    /** The connection limit of the listener. */
+    /** The concurrent connection limit for the listener. If reached, incoming connections may be queued or
+     *  rejected.
+     *
+     *  This property will be present for load balancers in the `application` family.
+     */
     connection_limit?: number;
     /** The default pool for this listener.  If `https_redirect` is specified,
      *  the default pool will not be used. If specified, the pool must:
@@ -39420,8 +42999,9 @@ namespace VpcV1 {
      *  listener must have a `protocol` of `https`.
      */
     https_redirect?: LoadBalancerListenerHTTPSRedirectPrototype;
-    /** The idle connection timeout of the listener in seconds. Supported for load balancers in the `application`
-     *  family.
+    /** The idle connection timeout of the listener in seconds.
+     *
+     *  Supported for load balancers in the `application` family.
      */
     idle_connection_timeout?: number;
     /** The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer
@@ -39477,7 +43057,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerReference. */
+  /**
+   * LoadBalancerListenerReference.
+   */
   export interface LoadBalancerListenerReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -39489,43 +43071,57 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** LoadBalancerLogging. */
+  /**
+   * LoadBalancerLogging.
+   */
   export interface LoadBalancerLogging {
     /** The datapath logging configuration for this load balancer. */
     datapath: LoadBalancerLoggingDatapath;
   }
 
-  /** The datapath logging configuration for this load balancer. */
+  /**
+   * The datapath logging configuration for this load balancer.
+   */
   export interface LoadBalancerLoggingDatapath {
     /** Indicates whether datapath logging is active for this load balancer. */
     active: boolean;
   }
 
-  /** The datapath logging configuration for this load balancer. */
+  /**
+   * The datapath logging configuration for this load balancer.
+   */
   export interface LoadBalancerLoggingDatapathPatch {
     /** Indicates whether datapath logging will be active for this load balancer. */
     active?: boolean;
   }
 
-  /** The datapath logging configuration for this load balancer. */
+  /**
+   * The datapath logging configuration for this load balancer.
+   */
   export interface LoadBalancerLoggingDatapathPrototype {
     /** Indicates whether datapath logging will be active for this load balancer. */
     active?: boolean;
   }
 
-  /** LoadBalancerLoggingPatch. */
+  /**
+   * LoadBalancerLoggingPatch.
+   */
   export interface LoadBalancerLoggingPatch {
     /** The datapath logging configuration for this load balancer. */
     datapath?: LoadBalancerLoggingDatapathPatch;
   }
 
-  /** LoadBalancerLoggingPrototype. */
+  /**
+   * LoadBalancerLoggingPrototype.
+   */
   export interface LoadBalancerLoggingPrototype {
     /** The datapath logging configuration for this load balancer. */
     datapath?: LoadBalancerLoggingDatapathPrototype;
   }
 
-  /** LoadBalancerPool. */
+  /**
+   * LoadBalancerPool.
+   */
   export interface LoadBalancerPool {
     /** The load balancing algorithm.
      *
@@ -39607,13 +43203,17 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerPoolCollection. */
+  /**
+   * LoadBalancerPoolCollection.
+   */
   export interface LoadBalancerPoolCollection {
     /** The pools for the load balancer. */
     pools: LoadBalancerPool[];
   }
 
-  /** LoadBalancerPoolHealthMonitor. */
+  /**
+   * LoadBalancerPoolHealthMonitor.
+   */
   export interface LoadBalancerPoolHealthMonitor {
     /** The seconds to wait between health checks. */
     delay: number;
@@ -39637,11 +43237,6 @@ namespace VpcV1 {
      *
      *  If `type` is `tcp`, this property will be absent.
      */
-    url?: any;
-    /** The health check URL path.  If specified, `type` must be `http` or `https`.
-     *
-     *  Must be in the format of an [origin-form request target](https://tools.ietf.org/html/rfc7230#section-5.3.1).
-     */
     url_path?: string;
   }
   export namespace LoadBalancerPoolHealthMonitor {
@@ -39655,7 +43250,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerPoolHealthMonitorPatch. */
+  /**
+   * LoadBalancerPoolHealthMonitorPatch.
+   */
   export interface LoadBalancerPoolHealthMonitorPatch {
     /** The seconds to wait between health checks.  Must be greater than `timeout`. */
     delay: number;
@@ -39689,7 +43286,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerPoolHealthMonitorPrototype. */
+  /**
+   * LoadBalancerPoolHealthMonitorPrototype.
+   */
   export interface LoadBalancerPoolHealthMonitorPrototype {
     /** The seconds to wait between health checks.  Must be greater than `timeout`. */
     delay: number;
@@ -39721,17 +43320,23 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a load balancer pool by a unique property. */
+  /**
+   * Identifies a load balancer pool by a unique property.
+   */
   export interface LoadBalancerPoolIdentity {
   }
 
-  /** LoadBalancerPoolIdentityByName. */
+  /**
+   * LoadBalancerPoolIdentityByName.
+   */
   export interface LoadBalancerPoolIdentityByName {
     /** The name for this load balancer pool. The name is unique across all pools for the load balancer. */
     name: string;
   }
 
-  /** LoadBalancerPoolMember. */
+  /**
+   * LoadBalancerPoolMember.
+   */
   export interface LoadBalancerPoolMember {
     /** The date and time that this member was created. */
     created_at: string;
@@ -39790,13 +43395,17 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerPoolMemberCollection. */
+  /**
+   * LoadBalancerPoolMemberCollection.
+   */
   export interface LoadBalancerPoolMemberCollection {
     /** The members for the load balancer pool. */
     members: LoadBalancerPoolMember[];
   }
 
-  /** LoadBalancerPoolMemberPrototype. */
+  /**
+   * LoadBalancerPoolMemberPrototype.
+   */
   export interface LoadBalancerPoolMemberPrototype {
     /** The port the member will receive load balancer traffic on. Applies only to load balancer traffic received on
      *  a listener with a single port. (If the traffic is received on a listener with a port range, the member will
@@ -39821,7 +43430,9 @@ namespace VpcV1 {
     weight?: number;
   }
 
-  /** LoadBalancerPoolMemberReference. */
+  /**
+   * LoadBalancerPoolMemberReference.
+   */
   export interface LoadBalancerPoolMemberReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -39833,15 +43444,25 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** The pool member target. Load balancers in the `network` family support virtual server instances. Load balancers in the `application` family support IP addresses. If the load balancer has route mode enabled, the member must be in a zone the load balancer has a subnet in. */
+  /**
+   * The pool member target. Load balancers in the `network` family support virtual server instances. Load balancers in
+   * the `application` family support IP addresses. If the load balancer has route mode enabled, the member must be in a
+   * zone the load balancer has a subnet in.
+   */
   export interface LoadBalancerPoolMemberTarget {
   }
 
-  /** The pool member target. Load balancers in the `network` family support virtual server instances. Load balancers in the `application` family support IP addresses. If the load balancer has route mode enabled, the member must be in a zone the load balancer has a subnet in. */
+  /**
+   * The pool member target. Load balancers in the `network` family support virtual server instances. Load balancers in
+   * the `application` family support IP addresses. If the load balancer has route mode enabled, the member must be in a
+   * zone the load balancer has a subnet in.
+   */
   export interface LoadBalancerPoolMemberTargetPrototype {
   }
 
-  /** LoadBalancerPoolPrototype. */
+  /**
+   * LoadBalancerPoolPrototype.
+   */
   export interface LoadBalancerPoolPrototype {
     /** The load balancing algorithm. The `least_connections` algorithm is only supported for load balancers that
      *  have `availability` with value `subnet` in the profile.
@@ -39901,7 +43522,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerPoolReference. */
+  /**
+   * LoadBalancerPoolReference.
+   */
   export interface LoadBalancerPoolReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -39915,7 +43538,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** LoadBalancerPoolSessionPersistence. */
+  /**
+   * LoadBalancerPoolSessionPersistence.
+   */
   export interface LoadBalancerPoolSessionPersistence {
     /** The session persistence cookie name. */
     cookie_name?: string;
@@ -39937,7 +43562,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The session persistence configuration. Specify `null` to remove any existing session persistence configuration. */
+  /**
+   * The session persistence configuration. Specify `null` to remove any existing session persistence configuration.
+   */
   export interface LoadBalancerPoolSessionPersistencePatch {
     /** The session persistence cookie name. Names starting with `IBM` are not allowed.
      *
@@ -39962,7 +43589,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerPoolSessionPersistencePrototype. */
+  /**
+   * LoadBalancerPoolSessionPersistencePrototype.
+   */
   export interface LoadBalancerPoolSessionPersistencePrototype {
     /** The session persistence cookie name. Names starting with `IBM` are not allowed.
      *
@@ -39987,7 +43616,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerProfile. */
+  /**
+   * LoadBalancerProfile.
+   */
   export interface LoadBalancerProfile {
     access_modes: LoadBalancerProfileAccessModes;
     availability: LoadBalancerProfileAvailability;
@@ -40019,7 +43650,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerProfileAccessModes. */
+  /**
+   * LoadBalancerProfileAccessModes.
+   */
   export interface LoadBalancerProfileAccessModes {
     /** The type for this profile field. */
     type: LoadBalancerProfileAccessModes.Constants.Type | string;
@@ -40041,45 +43674,43 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerProfileAvailability. */
+  /**
+   * LoadBalancerProfileAvailability.
+   */
   export interface LoadBalancerProfileAvailability {
   }
 
-  /** LoadBalancerProfileCollection. */
+  /**
+   * LoadBalancerProfileCollection.
+   */
   export interface LoadBalancerProfileCollection {
     /** A link to the first page of resources. */
-    first: LoadBalancerProfileCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: LoadBalancerProfileCollectionNext;
+    next?: PageLink;
     /** A page of load balancer profiles. */
     profiles: LoadBalancerProfile[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface LoadBalancerProfileCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface LoadBalancerProfileCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a load balancer profile by a unique property. */
+  /**
+   * Identifies a load balancer profile by a unique property.
+   */
   export interface LoadBalancerProfileIdentity {
   }
 
-  /** LoadBalancerProfileInstanceGroupsSupported. */
+  /**
+   * LoadBalancerProfileInstanceGroupsSupported.
+   */
   export interface LoadBalancerProfileInstanceGroupsSupported {
   }
 
-  /** Indicates which logging type(s) are supported for a load balancer with this profile. */
+  /**
+   * Indicates which logging type(s) are supported for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileLoggingSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileLoggingSupported.Constants.Type | string;
@@ -40095,7 +43726,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerProfileReference. */
+  /**
+   * LoadBalancerProfileReference.
+   */
   export interface LoadBalancerProfileReference {
     /** The product family this load balancer profile belongs to.
      *
@@ -40118,23 +43751,33 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerProfileRouteModeSupported. */
+  /**
+   * LoadBalancerProfileRouteModeSupported.
+   */
   export interface LoadBalancerProfileRouteModeSupported {
   }
 
-  /** LoadBalancerProfileSecurityGroupsSupported. */
+  /**
+   * LoadBalancerProfileSecurityGroupsSupported.
+   */
   export interface LoadBalancerProfileSecurityGroupsSupported {
   }
 
-  /** LoadBalancerProfileSourceIPSessionPersistenceSupported. */
+  /**
+   * LoadBalancerProfileSourceIPSessionPersistenceSupported.
+   */
   export interface LoadBalancerProfileSourceIPSessionPersistenceSupported {
   }
 
-  /** LoadBalancerProfileUDPSupported. */
+  /**
+   * LoadBalancerProfileUDPSupported.
+   */
   export interface LoadBalancerProfileUDPSupported {
   }
 
-  /** LoadBalancerReference. */
+  /**
+   * LoadBalancerReference.
+   */
   export interface LoadBalancerReference {
     /** The CRN for this load balancer. */
     crn: string;
@@ -40160,7 +43803,9 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerStatistics. */
+  /**
+   * LoadBalancerStatistics.
+   */
   export interface LoadBalancerStatistics {
     /** Number of active connections of this load balancer. */
     active_connections: number;
@@ -40172,7 +43817,9 @@ namespace VpcV1 {
     throughput: number;
   }
 
-  /** NetworkACL. */
+  /**
+   * NetworkACL.
+   */
   export interface NetworkACL {
     /** The date and time that the network ACL was created. */
     created_at: string;
@@ -40194,37 +43841,31 @@ namespace VpcV1 {
     vpc: VPCReference;
   }
 
-  /** NetworkACLCollection. */
+  /**
+   * NetworkACLCollection.
+   */
   export interface NetworkACLCollection {
     /** A link to the first page of resources. */
-    first: NetworkACLCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A page of network ACLs. */
     network_acls: NetworkACL[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: NetworkACLCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface NetworkACLCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface NetworkACLCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a network ACL by a unique property. */
+  /**
+   * Identifies a network ACL by a unique property.
+   */
   export interface NetworkACLIdentity {
   }
 
-  /** NetworkACLPrototype. */
+  /**
+   * NetworkACLPrototype.
+   */
   export interface NetworkACLPrototype {
     /** The name for this network ACL. The name must not be used by another network ACL for the VPC. If unspecified,
      *  the name will be a hyphenated list of randomly-selected words.
@@ -40238,7 +43879,9 @@ namespace VpcV1 {
     vpc: VPCIdentity;
   }
 
-  /** NetworkACLReference. */
+  /**
+   * NetworkACLReference.
+   */
   export interface NetworkACLReference {
     /** The CRN for this network ACL. */
     crn: string;
@@ -40254,7 +43897,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** NetworkACLRule. */
+  /**
+   * NetworkACLRule.
+   */
   export interface NetworkACLRule {
     /** The action to perform for a packet matching the rule. */
     action: NetworkACLRule.Constants.Action | string;
@@ -40307,41 +43952,41 @@ namespace VpcV1 {
     }
   }
 
-  /** The rule to move this rule immediately before. Specify `null` to move this rule after all existing rules. */
+  /**
+   * The rule to move this rule immediately before.
+   *
+   * Specify `null` to move this rule after all existing rules.
+   */
   export interface NetworkACLRuleBeforePatch {
   }
 
-  /** The rule to insert this rule immediately before. If unspecified, this rule will be inserted after all existing rules. */
+  /**
+   * The rule to insert this rule immediately before.
+   *
+   * If unspecified, this rule will be inserted after all existing rules.
+   */
   export interface NetworkACLRuleBeforePrototype {
   }
 
-  /** NetworkACLRuleCollection. */
+  /**
+   * NetworkACLRuleCollection.
+   */
   export interface NetworkACLRuleCollection {
     /** A link to the first page of resources. */
-    first: NetworkACLRuleCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: NetworkACLRuleCollectionNext;
+    next?: PageLink;
     /** A page of ordered rules (sorted based on the `before` property) for the network ACL. */
     rules: NetworkACLRuleItem[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface NetworkACLRuleCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface NetworkACLRuleCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** NetworkACLRuleItem. */
+  /**
+   * NetworkACLRuleItem.
+   */
   export interface NetworkACLRuleItem {
     /** The action to perform for a packet matching the rule. */
     action: NetworkACLRuleItem.Constants.Action | string;
@@ -40396,7 +44041,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototype. */
+  /**
+   * NetworkACLRulePrototype.
+   */
   export interface NetworkACLRulePrototype {
     /** The action to perform for a packet matching the rule. */
     action: NetworkACLRulePrototype.Constants.Action | string;
@@ -40448,7 +44095,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLContext. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLContext.
+   */
   export interface NetworkACLRulePrototypeNetworkACLContext {
     /** The action to perform for a packet matching the rule. */
     action: NetworkACLRulePrototypeNetworkACLContext.Constants.Action | string;
@@ -40495,7 +44144,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRuleReference. */
+  /**
+   * NetworkACLRuleReference.
+   */
   export interface NetworkACLRuleReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -40509,7 +44160,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** NetworkInterface. */
+  /**
+   * NetworkInterface.
+   */
   export interface NetworkInterface {
     /** Indicates whether source IP spoofing is allowed on this instance network interface.
      *
@@ -40615,7 +44268,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkInterfaceBareMetalServerContextReference. */
+  /**
+   * NetworkInterfaceBareMetalServerContextReference.
+   */
   export interface NetworkInterfaceBareMetalServerContextReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -40653,11 +44308,15 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkInterfaceIPPrototype. */
+  /**
+   * NetworkInterfaceIPPrototype.
+   */
   export interface NetworkInterfaceIPPrototype {
   }
 
-  /** NetworkInterfaceInstanceContextReference. */
+  /**
+   * NetworkInterfaceInstanceContextReference.
+   */
   export interface NetworkInterfaceInstanceContextReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -40695,7 +44354,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkInterfacePrototype. */
+  /**
+   * NetworkInterfacePrototype.
+   */
   export interface NetworkInterfacePrototype {
     /** Indicates whether source IP spoofing is allowed on this instance network interface.
      *
@@ -40725,13 +44386,17 @@ namespace VpcV1 {
     subnet: SubnetIdentity;
   }
 
-  /** NetworkInterfaceUnpaginatedCollection. */
+  /**
+   * NetworkInterfaceUnpaginatedCollection.
+   */
   export interface NetworkInterfaceUnpaginatedCollection {
     /** The network interfaces for the instance. */
     network_interfaces: NetworkInterface[];
   }
 
-  /** OperatingSystem. */
+  /**
+   * OperatingSystem.
+   */
   export interface OperatingSystem {
     /** Users may create new images with this operating system. */
     allow_user_image_creation: boolean;
@@ -40770,37 +44435,39 @@ namespace VpcV1 {
     }
   }
 
-  /** OperatingSystemCollection. */
+  /**
+   * OperatingSystemCollection.
+   */
   export interface OperatingSystemCollection {
     /** A link to the first page of resources. */
-    first: OperatingSystemCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: OperatingSystemCollectionNext;
+    next?: PageLink;
     /** A page of operating systems. */
     operating_systems: OperatingSystem[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface OperatingSystemCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface OperatingSystemCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies an operating system by a unique property. */
+  /**
+   * Identifies an operating system by a unique property.
+   */
   export interface OperatingSystemIdentity {
   }
 
-  /** PlacementGroup. */
+  /**
+   * PageLink.
+   */
+  export interface PageLink {
+    /** The URL for a page of resources. */
+    href: string;
+  }
+
+  /**
+   * PlacementGroup.
+   */
   export interface PlacementGroup {
     /** The date and time that the placement group was created. */
     created_at: string;
@@ -40851,33 +44518,25 @@ namespace VpcV1 {
     }
   }
 
-  /** PlacementGroupCollection. */
+  /**
+   * PlacementGroupCollection.
+   */
   export interface PlacementGroupCollection {
     /** A link to the first page of resources. */
-    first: PlacementGroupCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: PlacementGroupCollectionNext;
+    next?: PageLink;
     /** A page of placement groups. */
     placement_groups: PlacementGroup[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface PlacementGroupCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface PlacementGroupCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** PrivatePathServiceGateway. */
+  /**
+   * PrivatePathServiceGateway.
+   */
   export interface PrivatePathServiceGateway {
     /** The date and time that the private path service gateway was created. */
     created_at: string;
@@ -40957,7 +44616,9 @@ namespace VpcV1 {
     }
   }
 
-  /** PrivatePathServiceGatewayAccountPolicy. */
+  /**
+   * PrivatePathServiceGatewayAccountPolicy.
+   */
   export interface PrivatePathServiceGatewayAccountPolicy {
     /** The access policy for the account:
      *  - permit: access will be permitted
@@ -40994,59 +44655,41 @@ namespace VpcV1 {
     }
   }
 
-  /** PrivatePathServiceGatewayAccountPolicyCollection. */
+  /**
+   * PrivatePathServiceGatewayAccountPolicyCollection.
+   */
   export interface PrivatePathServiceGatewayAccountPolicyCollection {
     /** A page of account policies for the private path service gateway. */
     account_policies: PrivatePathServiceGatewayAccountPolicy[];
     /** A link to the first page of resources. */
-    first: PrivatePathServiceGatewayAccountPolicyCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: PrivatePathServiceGatewayAccountPolicyCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface PrivatePathServiceGatewayAccountPolicyCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface PrivatePathServiceGatewayAccountPolicyCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** PrivatePathServiceGatewayCollection. */
+  /**
+   * PrivatePathServiceGatewayCollection.
+   */
   export interface PrivatePathServiceGatewayCollection {
     /** A link to the first page of resources. */
-    first: PrivatePathServiceGatewayCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: PrivatePathServiceGatewayCollectionNext;
+    next?: PageLink;
     /** A page of private path service gateways. */
     private_path_service_gateways: PrivatePathServiceGateway[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface PrivatePathServiceGatewayCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface PrivatePathServiceGatewayCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** PrivatePathServiceGatewayEndpointGatewayBinding. */
+  /**
+   * PrivatePathServiceGatewayEndpointGatewayBinding.
+   */
   export interface PrivatePathServiceGatewayEndpointGatewayBinding {
     /** The account that created the endpoint gateway. */
     account: AccountReference;
@@ -41108,33 +44751,26 @@ namespace VpcV1 {
     }
   }
 
-  /** PrivatePathServiceGatewayEndpointGatewayBindingCollection. */
+  /**
+   * PrivatePathServiceGatewayEndpointGatewayBindingCollection.
+   */
   export interface PrivatePathServiceGatewayEndpointGatewayBindingCollection {
     /** A page of endpoint gateway bindings for the private path service gateway. */
     endpoint_gateway_bindings: PrivatePathServiceGatewayEndpointGatewayBinding[];
     /** A link to the first page of resources. */
-    first: PrivatePathServiceGatewayEndpointGatewayBindingCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: PrivatePathServiceGatewayEndpointGatewayBindingCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface PrivatePathServiceGatewayEndpointGatewayBindingCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface PrivatePathServiceGatewayEndpointGatewayBindingCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface PrivatePathServiceGatewayRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  account, and identifies the owning account.
@@ -41146,7 +44782,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** PublicGateway. */
+  /**
+   * PublicGateway.
+   */
   export interface PublicGateway {
     /** The date and time that the public gateway was created. */
     created_at: string;
@@ -41187,37 +44825,31 @@ namespace VpcV1 {
     }
   }
 
-  /** PublicGatewayCollection. */
+  /**
+   * PublicGatewayCollection.
+   */
   export interface PublicGatewayCollection {
     /** A link to the first page of resources. */
-    first: PublicGatewayCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: PublicGatewayCollectionNext;
+    next?: PageLink;
     /** A page of public gateways. */
     public_gateways: PublicGateway[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface PublicGatewayCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface PublicGatewayCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** PublicGatewayFloatingIPPrototype. */
+  /**
+   * PublicGatewayFloatingIPPrototype.
+   */
   export interface PublicGatewayFloatingIPPrototype {
   }
 
-  /** The floating IP bound to this public gateway. */
+  /**
+   * The floating IP bound to this public gateway.
+   */
   export interface PublicGatewayFloatingIp {
     /** The globally unique IP address. */
     address: string;
@@ -41235,11 +44867,15 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** Identifies a public gateway by a unique property. */
+  /**
+   * Identifies a public gateway by a unique property.
+   */
   export interface PublicGatewayIdentity {
   }
 
-  /** PublicGatewayReference. */
+  /**
+   * PublicGatewayReference.
+   */
   export interface PublicGatewayReference {
     /** The CRN for this public gateway. */
     crn: string;
@@ -41265,7 +44901,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Region. */
+  /**
+   * Region.
+   */
   export interface Region {
     /** The API endpoint for this region. */
     endpoint: string;
@@ -41290,17 +44928,23 @@ namespace VpcV1 {
     }
   }
 
-  /** RegionCollection. */
+  /**
+   * RegionCollection.
+   */
   export interface RegionCollection {
     /** The regions for the account. */
     regions: Region[];
   }
 
-  /** Identifies a region by a unique property. */
+  /**
+   * Identifies a region by a unique property.
+   */
   export interface RegionIdentity {
   }
 
-  /** RegionReference. */
+  /**
+   * RegionReference.
+   */
   export interface RegionReference {
     /** The URL for this region. */
     href: string;
@@ -41308,7 +44952,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** Reservation. */
+  /**
+   * Reservation.
+   */
   export interface Reservation {
     /** The affinity policy to use for this reservation:
      *  - `restricted`: The reservation must be manually requested
@@ -41388,7 +45034,11 @@ namespace VpcV1 {
     }
   }
 
-  /** The capacity configuration for this reservation If absent, this reservation has no assigned capacity. */
+  /**
+   * The capacity configuration for this reservation
+   *
+   * If absent, this reservation has no assigned capacity.
+   */
   export interface ReservationCapacity {
     /** The amount allocated to this capacity reservation. */
     allocated: number;
@@ -41398,8 +45048,9 @@ namespace VpcV1 {
      *  - `allocating`: The capacity reservation is being allocated for use
      *  - `allocated`: The total capacity of the reservation has been allocated for use
      *  - `degraded`: The capacity reservation has been allocated for use, but some of the
-     *    capacity is not available.
-     *    See https://cloud.ibm.com/docs/vpc?topic=vpc-capacity-status for more information.
+     *    capacity is not available. See [capacity status
+     *    reasons](https://cloud.ibm.com/docs/vpc?topic=vpc-reserved-capacity-status-reasons)
+     *    for more information.
      *  - `unallocated`: The capacity reservation is not allocated for use
      *
      *  The enumerated values for this property may
@@ -41413,7 +45064,7 @@ namespace VpcV1 {
   }
   export namespace ReservationCapacity {
     export namespace Constants {
-      /** The status of the capacity reservation: - `allocating`: The capacity reservation is being allocated for use - `allocated`: The total capacity of the reservation has been allocated for use - `degraded`: The capacity reservation has been allocated for use, but some of the capacity is not available. See https://cloud.ibm.com/docs/vpc?topic=vpc-capacity-status for more information. - `unallocated`: The capacity reservation is not allocated for use The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+      /** The status of the capacity reservation: - `allocating`: The capacity reservation is being allocated for use - `allocated`: The total capacity of the reservation has been allocated for use - `degraded`: The capacity reservation has been allocated for use, but some of the capacity is not available. See [capacity status reasons](https://cloud.ibm.com/docs/vpc?topic=vpc-reserved-capacity-status-reasons) for more information. - `unallocated`: The capacity reservation is not allocated for use The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
       export enum Status {
         ALLOCATED = 'allocated',
         ALLOCATING = 'allocating',
@@ -41423,45 +45074,43 @@ namespace VpcV1 {
     }
   }
 
-  /** The capacity reservation configuration to use. The configuration can only be changed for reservations with a `status` of `inactive`. */
+  /**
+   * The capacity reservation configuration to use.
+   *
+   * The configuration can only be changed for reservations with a `status` of `inactive`.
+   */
   export interface ReservationCapacityPatch {
     /** The total amount to use for this capacity reservation. */
     total?: number;
   }
 
-  /** The capacity reservation configuration to use. */
+  /**
+   * The capacity reservation configuration to use.
+   */
   export interface ReservationCapacityPrototype {
     /** The total amount to use for this capacity reservation. */
     total: number;
   }
 
-  /** ReservationCollection. */
+  /**
+   * ReservationCollection.
+   */
   export interface ReservationCollection {
     /** A link to the first page of resources. */
-    first: ReservationCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ReservationCollectionNext;
+    next?: PageLink;
     /** A page of reservations. */
     reservations: Reservation[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ReservationCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ReservationCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The committed use reservation configuration. */
+  /**
+   * The committed use reservation configuration.
+   */
   export interface ReservationCommittedUse {
     /** The expiration date and time for this committed use reservation.
      *
@@ -41496,7 +45145,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservationCommittedUsePatch. */
+  /**
+   * ReservationCommittedUsePatch.
+   */
   export interface ReservationCommittedUsePatch {
     /** The policy to apply when the committed use term expires:
      *  - `release`: Release any available capacity and let the reservation expire.
@@ -41524,7 +45175,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservationCommittedUsePrototype. */
+  /**
+   * ReservationCommittedUsePrototype.
+   */
   export interface ReservationCommittedUsePrototype {
     /** The policy to apply when the committed use term expires:
      *  - `release`: Release any available capacity and let the reservation expire.
@@ -41550,11 +45203,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a reservation by a unique property. */
+  /**
+   * Identifies a reservation by a unique property.
+   */
   export interface ReservationIdentity {
   }
 
-  /** The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles) for this reservation. */
+  /**
+   * The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles) for this reservation.
+   */
   export interface ReservationProfile {
     /** The URL for this virtual server instance profile. */
     href: string;
@@ -41572,7 +45229,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles) to use for this reservation. */
+  /**
+   * The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles) to use for this reservation.
+   */
   export interface ReservationProfilePatch {
     /** The globally unique name of the profile. */
     name?: string;
@@ -41588,7 +45247,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles) to use for this reservation. */
+  /**
+   * The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-profiles) to use for this reservation.
+   */
   export interface ReservationProfilePrototype {
     /** The globally unique name of the profile. */
     name: string;
@@ -41604,7 +45265,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservationReference. */
+  /**
+   * ReservationReference.
+   */
   export interface ReservationReference {
     /** The CRN for this reservation. */
     crn: string;
@@ -41630,7 +45293,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservationStatusReason. */
+  /**
+   * ReservationStatusReason.
+   */
   export interface ReservationStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -41653,7 +45318,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIP. */
+  /**
+   * ReservedIP.
+   */
   export interface ReservedIP {
     /** The IP address.
      *
@@ -41688,6 +45355,9 @@ namespace VpcV1 {
     /** The target this reserved IP is bound to.
      *
      *  If absent, this reserved IP is provider-owned or unbound.
+     *
+     *  The resources supported by this property may
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
      */
     target?: ReservedIPTarget;
   }
@@ -41715,137 +45385,89 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPCollection. */
+  /**
+   * ReservedIPCollection.
+   */
   export interface ReservedIPCollection {
     /** A link to the first page of resources. */
-    first: ReservedIPCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ReservedIPCollectionNext;
+    next?: PageLink;
     /** A page of reserved IPs in the subnet. */
     reserved_ips: ReservedIP[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** ReservedIPCollectionBareMetalServerNetworkInterfaceContext. */
+  /**
+   * ReservedIPCollectionBareMetalServerNetworkInterfaceContext.
+   */
   export interface ReservedIPCollectionBareMetalServerNetworkInterfaceContext {
     /** A link to the first page of resources. */
-    first: ReservedIPCollectionBareMetalServerNetworkInterfaceContextFirst;
+    first: PageLink;
     /** A page of reserved IPs bound to the bare metal server network interface. */
     ips: ReservedIP[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ReservedIPCollectionBareMetalServerNetworkInterfaceContextNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ReservedIPCollectionBareMetalServerNetworkInterfaceContextFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ReservedIPCollectionBareMetalServerNetworkInterfaceContextNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ReservedIPCollectionEndpointGatewayContext. */
+  /**
+   * ReservedIPCollectionEndpointGatewayContext.
+   */
   export interface ReservedIPCollectionEndpointGatewayContext {
     /** A link to the first page of resources. */
-    first: ReservedIPCollectionEndpointGatewayContextFirst;
+    first: PageLink;
     /** A page of reserved IPs bound to the endpoint gateway. */
     ips: ReservedIP[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ReservedIPCollectionEndpointGatewayContextNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ReservedIPCollectionEndpointGatewayContextFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ReservedIPCollectionEndpointGatewayContextNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the first page of resources. */
-  export interface ReservedIPCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ReservedIPCollectionInstanceNetworkInterfaceContext. */
+  /**
+   * ReservedIPCollectionInstanceNetworkInterfaceContext.
+   */
   export interface ReservedIPCollectionInstanceNetworkInterfaceContext {
     /** A link to the first page of resources. */
-    first: ReservedIPCollectionInstanceNetworkInterfaceContextFirst;
+    first: PageLink;
     /** A page of reserved IPs bound to the instance network interface. */
     ips: ReservedIP[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ReservedIPCollectionInstanceNetworkInterfaceContextNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ReservedIPCollectionInstanceNetworkInterfaceContextFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ReservedIPCollectionInstanceNetworkInterfaceContextNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ReservedIPCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ReservedIPCollectionVirtualNetworkInterfaceContext. */
+  /**
+   * ReservedIPCollectionVirtualNetworkInterfaceContext.
+   */
   export interface ReservedIPCollectionVirtualNetworkInterfaceContext {
     /** A link to the first page of resources. */
-    first: ReservedIPCollectionVirtualNetworkInterfaceContextFirst;
+    first: PageLink;
     /** A page of reserved IPs bound to the virtual network interface specified by the identifier in the URL. */
     ips: ReservedIPReference[];
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ReservedIPCollectionVirtualNetworkInterfaceContextNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ReservedIPCollectionVirtualNetworkInterfaceContextFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ReservedIPCollectionVirtualNetworkInterfaceContextNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ReservedIPReference. */
+  /**
+   * ReservedIPReference.
+   */
   export interface ReservedIPReference {
     /** The IP address.
      *
@@ -41877,25 +45499,47 @@ namespace VpcV1 {
     }
   }
 
-  /** The target this reserved IP is bound to. If absent, this reserved IP is provider-owned or unbound. */
+  /**
+   * The target this reserved IP is bound to.
+   *
+   * If absent, this reserved IP is provider-owned or unbound.
+   *
+   * The resources supported by this property may
+   * [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+   */
   export interface ReservedIPTarget {
   }
 
-  /** The target to bind this reserved IP to.  The target must be in the same VPC. The following targets are supported: - An endpoint gateway not already bound to a reserved IP in the subnet's zone. - A virtual network interface. If unspecified, the reserved IP will be created unbound. */
+  /**
+   * The target to bind this reserved IP to.  The target must be in the same VPC.
+   *
+   * The following targets are supported:
+   * - An endpoint gateway not already bound to a reserved IP in the subnet's zone.
+   * - A virtual network interface.
+   *
+   * If unspecified, the reserved IP will be created unbound.
+   */
   export interface ReservedIPTargetPrototype {
   }
 
-  /** Identifies one or more resources according to the specified filter property. */
+  /**
+   * Identifies one or more resources according to the specified filter property.
+   */
   export interface ResourceFilter {
     /** The resource type. */
     resource_type?: string;
   }
 
-  /** The resource group to use. If unspecified, the account's [default resource group](https://cloud.ibm.com/apidocs/resource-manager#introduction) will be used. */
+  /**
+   * The resource group to use. If unspecified, the account's [default resource
+   * group](https://cloud.ibm.com/apidocs/resource-manager#introduction) will be used.
+   */
   export interface ResourceGroupIdentity {
   }
 
-  /** ResourceGroupReference. */
+  /**
+   * ResourceGroupReference.
+   */
   export interface ResourceGroupReference {
     /** The URL for this resource group. */
     href: string;
@@ -41905,7 +45549,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** Route. */
+  /**
+   * Route.
+   */
   export interface Route {
     /** The action to perform with a packet matching the route:
      *  - `delegate`: delegate to system-provided routes
@@ -41994,164 +45640,76 @@ namespace VpcV1 {
     }
   }
 
-  /** RouteCollection. */
+  /**
+   * RouteCollection.
+   */
   export interface RouteCollection {
     /** A link to the first page of resources. */
-    first: RouteCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: RouteCollectionNext;
+    next?: PageLink;
     /** A page of routes in the routing table. */
     routes: Route[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface RouteCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface RouteCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** RouteCollectionVPCContext. */
+  /**
+   * RouteCollectionVPCContext.
+   */
   export interface RouteCollectionVPCContext {
     /** A link to the first page of resources. */
-    first: RouteCollectionVPCContextFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: RouteCollectionVPCContextNext;
+    next?: PageLink;
     /** A page of routes in the routing table. */
-    routes: RouteCollectionVPCContextRoutesItem[];
+    routes: Route[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface RouteCollectionVPCContextFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface RouteCollectionVPCContextNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** RouteCollectionVPCContextRoutesItem. */
-  export interface RouteCollectionVPCContextRoutesItem {
-    /** The action to perform with a packet matching the route:
-     *  - `delegate`: delegate to system-provided routes
-     *  - `delegate_vpc`: delegate to system-provided routes, ignoring Internet-bound routes
-     *  - `deliver`: deliver the packet to the specified `next_hop`
-     *  - `drop`: drop the packet
-     *
-     *  The enumerated values for this property may
-     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
-     */
-    action: RouteCollectionVPCContextRoutesItem.Constants.Action | string;
-    /** Indicates whether this route will be advertised to the ingress sources specified by the
-     *  `advertise_routes_to` routing table property.
-     */
-    advertise: boolean;
-    /** The date and time that the route was created. */
-    created_at: string;
-    /** If present, the resource that created the route. Routes with this property present cannot
-     *  be directly deleted. All routes with an `origin` of `service` will have this property set,
-     *  and future `origin` values may also have this property set.
-     */
-    creator?: RouteCreator;
-    /** The destination CIDR of the route. */
-    destination: string;
-    /** The URL for this route. */
-    href: string;
-    /** The unique identifier for this route. */
-    id: string;
-    /** The lifecycle state of the route. */
-    lifecycle_state: RouteCollectionVPCContextRoutesItem.Constants.LifecycleState | string;
-    /** The name for this route. The name is unique across all routes in the routing table. */
-    name: string;
-    /** If `action` is `deliver`, the next hop that packets will be delivered to.  For
-     *  other `action` values, its `address` will be `0.0.0.0`.
-     */
-    next_hop: RouteNextHop;
-    /** The origin of this route:
-     *  - `service`: route was directly created by a service
-     *  - `user`: route was directly created by a user
-     *
-     *  The enumerated values for this property may
-     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
-     */
-    origin: RouteCollectionVPCContextRoutesItem.Constants.Origin | string;
-    /** The priority of this route. Smaller values have higher priority.
-     *
-     *  If a routing table contains multiple routes with the same `zone` and `destination`, the route with the highest
-     *  priority (smallest value) is selected. If two routes have the same `destination` and `priority`, traffic is
-     *  distributed between them.
-     */
-    priority: number;
-    /** The zone the route applies to.
-     *
-     *  If subnets are attached to the route's routing table, egress traffic from those
-     *  subnets in this zone will be subject to this route. If this route's routing table
-     *  has any of `route_direct_link_ingress`, `route_internet_ingress`,
-     *  `route_transit_gateway_ingress` or `route_vpc_zone_ingress`  set to`true`, traffic
-     *  from those ingress sources arriving in this zone will be subject to this route.
-     */
-    zone: ZoneReference;
-  }
-  export namespace RouteCollectionVPCContextRoutesItem {
-    export namespace Constants {
-      /** The action to perform with a packet matching the route: - `delegate`: delegate to system-provided routes - `delegate_vpc`: delegate to system-provided routes, ignoring Internet-bound routes - `deliver`: deliver the packet to the specified `next_hop` - `drop`: drop the packet The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
-      export enum Action {
-        DELEGATE = 'delegate',
-        DELEGATE_VPC = 'delegate_vpc',
-        DELIVER = 'deliver',
-        DROP = 'drop',
-      }
-      /** The lifecycle state of the route. */
-      export enum LifecycleState {
-        DELETING = 'deleting',
-        FAILED = 'failed',
-        PENDING = 'pending',
-        STABLE = 'stable',
-        SUSPENDED = 'suspended',
-        UPDATING = 'updating',
-        WAITING = 'waiting',
-      }
-      /** The origin of this route: - `service`: route was directly created by a service - `user`: route was directly created by a user The enumerated values for this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
-      export enum Origin {
-        SERVICE = 'service',
-        USER = 'user',
-      }
-    }
-  }
-
-  /** If present, the resource that created the route. Routes with this property present cannot be directly deleted. All routes with an `origin` of `service` will have this property set, and future `origin` values may also have this property set. */
+  /**
+   * If present, the resource that created the route. Routes with this property present cannot be directly deleted. All
+   * routes with an `origin` of `service` will have this property set, and future `origin` values may also have this
+   * property set.
+   */
   export interface RouteCreator {
   }
 
-  /** RouteNextHop. */
+  /**
+   * RouteNextHop.
+   */
   export interface RouteNextHop {
   }
 
-  /** If `action` is `deliver`, the next hop that packets will be delivered to (must not be `0.0.0.0`). For other `action` values, specify `0.0.0.0` or remove it by specifying `null`. At most two routes per `zone` in a table can have the same `destination` and `priority`, and only when each route has an `action` of `deliver` and `next_hop` is an IP address. */
+  /**
+   * If `action` is `deliver`, the next hop that packets will be delivered to (must not be
+   * `0.0.0.0`). For other `action` values, specify `0.0.0.0` or remove it by specifying
+   * `null`.
+   *
+   * At most two routes per `zone` in a table can have the same `destination` and `priority`, and only when each route
+   * has an `action` of `deliver` and `next_hop` is an IP address.
+   */
   export interface RouteNextHopPatch {
   }
 
-  /** If `action` is `deliver`, the next hop that packets will be delivered to (must not be `0.0.0.0`). For other `action` values, it must be omitted or specified as `0.0.0.0`. At most two routes per `zone` in a table can have the same `destination` and `priority`, and only when each route has an `action` of `deliver` and `next_hop` is an IP address. */
+  /**
+   * If `action` is `deliver`, the next hop that packets will be delivered to (must not be
+   * `0.0.0.0`). For other `action` values, it must be omitted or specified as `0.0.0.0`.
+   *
+   * At most two routes per `zone` in a table can have the same `destination` and `priority`, and only when each route
+   * has an `action` of `deliver` and `next_hop` is an IP address.
+   */
   export interface RouteNextHopPrototype {
   }
 
-  /** RoutePrototype. */
+  /**
+   * RoutePrototype.
+   */
   export interface RoutePrototype {
     /** The action to perform with a packet matching the route:
      *  - `delegate`: delegate to system-provided routes
@@ -42214,7 +45772,9 @@ namespace VpcV1 {
     }
   }
 
-  /** RouteReference. */
+  /**
+   * RouteReference.
+   */
   export interface RouteReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -42228,12 +45788,14 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** RoutingTable. */
+  /**
+   * RoutingTable.
+   */
   export interface RoutingTable {
     /** The filters specifying the resources that may create routes in this routing table.
      *
-     *  At present, only the `resource_type` filter is permitted, and only the values
-     *  `vpn_gateway` and `vpn_server` are supported, but filter support is expected to expand in the future.
+     *  The resources and types of filters supported by this property is expected to
+     *  [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
      */
     accept_routes_from: ResourceFilter[];
     /** The ingress sources to advertise routes to. Routes in the table with `advertise` enabled will be advertised
@@ -42328,37 +45890,31 @@ namespace VpcV1 {
     }
   }
 
-  /** RoutingTableCollection. */
+  /**
+   * RoutingTableCollection.
+   */
   export interface RoutingTableCollection {
     /** A link to the first page of resources. */
-    first: RoutingTableCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: RoutingTableCollectionNext;
+    next?: PageLink;
     /** A page of routing tables. */
     routing_tables: RoutingTable[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface RoutingTableCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface RoutingTableCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a routing table by a unique property. */
+  /**
+   * Identifies a routing table by a unique property.
+   */
   export interface RoutingTableIdentity {
   }
 
-  /** RoutingTableReference. */
+  /**
+   * RoutingTableReference.
+   */
   export interface RoutingTableReference {
     /** The CRN for this VPC routing table. */
     crn: string;
@@ -42384,7 +45940,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroup. */
+  /**
+   * SecurityGroup.
+   */
   export interface SecurityGroup {
     /** The date and time that this security group was created. */
     created_at: string;
@@ -42406,37 +45964,31 @@ namespace VpcV1 {
     vpc: VPCReference;
   }
 
-  /** SecurityGroupCollection. */
+  /**
+   * SecurityGroupCollection.
+   */
   export interface SecurityGroupCollection {
     /** A link to the first page of resources. */
-    first: SecurityGroupCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: SecurityGroupCollectionNext;
+    next?: PageLink;
     /** A page of security groups. */
     security_groups: SecurityGroup[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface SecurityGroupCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface SecurityGroupCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a security group by a unique property. */
+  /**
+   * Identifies a security group by a unique property.
+   */
   export interface SecurityGroupIdentity {
   }
 
-  /** SecurityGroupReference. */
+  /**
+   * SecurityGroupReference.
+   */
   export interface SecurityGroupReference {
     /** The CRN for this security group. */
     crn: string;
@@ -42452,7 +46004,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** SecurityGroupRule. */
+  /**
+   * SecurityGroupRule.
+   */
   export interface SecurityGroupRule {
     /** The direction of traffic to allow. */
     direction: SecurityGroupRule.Constants.Direction | string;
@@ -42505,25 +46059,45 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupRuleCollection. */
+  /**
+   * SecurityGroupRuleCollection.
+   */
   export interface SecurityGroupRuleCollection {
     /** The rules for the security group. */
     rules: SecurityGroupRule[];
   }
 
-  /** The local IP address or range of local IP addresses to which this rule will allow inbound traffic (or from which, for outbound traffic). A CIDR block of `0.0.0.0/0` allows traffic to all local IP addresses (or from all local IP addresses, for outbound rules). */
+  /**
+   * The local IP address or range of local IP addresses to which this rule will allow inbound traffic (or from which,
+   * for outbound traffic). A CIDR block of `0.0.0.0/0` allows traffic to all local IP addresses (or from all local IP
+   * addresses, for outbound rules).
+   */
   export interface SecurityGroupRuleLocal {
   }
 
-  /** The local IP address or range of local IP addresses to which this rule will allow inbound traffic (or from which, for outbound traffic). Can be specified as an IP address or a CIDR block. Specify a CIDR block of `0.0.0.0/0` to allow traffic to all local IP addresses (or from all local IP addresses, for outbound rules). */
+  /**
+   * The local IP address or range of local IP addresses to which this rule will allow inbound traffic (or from which,
+   * for outbound traffic). Can be specified as an IP address or a CIDR block.
+   *
+   * Specify a CIDR block of `0.0.0.0/0` to allow traffic to all local IP addresses (or from all local IP addresses, for
+   * outbound rules).
+   */
   export interface SecurityGroupRuleLocalPatch {
   }
 
-  /** The local IP address or range of local IP addresses to which this rule will allow inbound traffic (or from which, for outbound traffic) If unspecified, a CIDR block of `0.0.0.0/0` will be used to allow traffic to all local IP addresses (or from all local IP addresses, for outbound rules). */
+  /**
+   * The local IP address or range of local IP addresses to which this rule will allow inbound traffic (or from which,
+   * for outbound traffic)
+   *
+   * If unspecified, a CIDR block of `0.0.0.0/0` will be used to allow traffic to all local IP addresses (or from all
+   * local IP addresses, for outbound rules).
+   */
   export interface SecurityGroupRuleLocalPrototype {
   }
 
-  /** SecurityGroupRulePrototype. */
+  /**
+   * SecurityGroupRulePrototype.
+   */
   export interface SecurityGroupRulePrototype {
     /** The direction of traffic to allow. */
     direction: SecurityGroupRulePrototype.Constants.Direction | string;
@@ -42573,49 +46147,60 @@ namespace VpcV1 {
     }
   }
 
-  /** The remote IP addresses or security groups from which this rule allows traffic (or to which, for outbound rules). A CIDR block of `0.0.0.0/0` allows traffic from any source (or to any destination, for outbound rules). */
+  /**
+   * The remote IP addresses or security groups from which this rule allows traffic (or to which, for outbound rules). A
+   * CIDR block of `0.0.0.0/0` allows traffic from any source
+   * (or to any destination, for outbound rules).
+   */
   export interface SecurityGroupRuleRemote {
   }
 
-  /** The remote IP addresses or security groups from which this rule will allow traffic (or to which, for outbound rules). Can be specified as an IP address, a CIDR block, or a security group. A CIDR block of `0.0.0.0/0` will allow traffic from any source (or to any destination, for outbound rules). */
+  /**
+   * The remote IP addresses or security groups from which this rule will allow traffic (or to which, for outbound
+   * rules). Can be specified as an IP address, a CIDR block, or a security group. A CIDR block of `0.0.0.0/0` will
+   * allow traffic from any source (or to any destination, for outbound rules).
+   */
   export interface SecurityGroupRuleRemotePatch {
   }
 
-  /** The remote IP addresses or security groups from which this rule will allow traffic (or to which, for outbound rules). Can be specified as an IP address, a CIDR block, or a security group within the VPC. If unspecified, a CIDR block of `0.0.0.0/0` will be used to allow traffic from any source (or to any destination, for outbound rules). */
+  /**
+   * The remote IP addresses or security groups from which this rule will allow traffic (or to which, for outbound
+   * rules). Can be specified as an IP address, a CIDR block, or a security group within the VPC.
+   *
+   * If unspecified, a CIDR block of `0.0.0.0/0` will be used to allow traffic from any source
+   * (or to any destination, for outbound rules).
+   */
   export interface SecurityGroupRuleRemotePrototype {
   }
 
-  /** SecurityGroupTargetCollection. */
+  /**
+   * SecurityGroupTargetCollection.
+   */
   export interface SecurityGroupTargetCollection {
     /** A link to the first page of resources. */
-    first: SecurityGroupTargetCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: SecurityGroupTargetCollectionNext;
+    next?: PageLink;
     /** A page of targets for the security group. */
     targets: SecurityGroupTargetReference[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface SecurityGroupTargetCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface SecurityGroupTargetCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A target of this security group. The resources supported by this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+  /**
+   * A target of this security group.
+   *
+   * The resources supported by this property may
+   * [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+   */
   export interface SecurityGroupTargetReference {
   }
 
-  /** Share. */
+  /**
+   * Share.
+   */
   export interface Share {
     /** The access control mode for the share:
      *
@@ -42797,7 +46382,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareAccessorBinding. */
+  /**
+   * ShareAccessorBinding.
+   */
   export interface ShareAccessorBinding {
     /** The accessor for this share accessor binding.
      *
@@ -42835,37 +46422,34 @@ namespace VpcV1 {
     }
   }
 
-  /** The accessor for this share accessor binding. The resources supported by this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+  /**
+   * The accessor for this share accessor binding.
+   *
+   * The resources supported by this property may
+   * [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+   */
   export interface ShareAccessorBindingAccessor {
   }
 
-  /** ShareAccessorBindingCollection. */
+  /**
+   * ShareAccessorBindingCollection.
+   */
   export interface ShareAccessorBindingCollection {
     /** A page of accessor bindings for the share. */
     accessor_bindings: ShareAccessorBinding[];
     /** A link to the first page of resources. */
-    first: ShareAccessorBindingCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ShareAccessorBindingCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ShareAccessorBindingCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ShareAccessorBindingCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ShareAccessorBindingReference. */
+  /**
+   * ShareAccessorBindingReference.
+   */
   export interface ShareAccessorBindingReference {
     /** The URL for this share accessor binding. */
     href: string;
@@ -42883,37 +46467,31 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareCollection. */
+  /**
+   * ShareCollection.
+   */
   export interface ShareCollection {
     /** A link to the first page of resources. */
-    first: ShareCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ShareCollectionNext;
+    next?: PageLink;
     /** A page of file shares. */
     shares: Share[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ShareCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ShareCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a file share by a unique property. */
+  /**
+   * Identifies a file share by a unique property.
+   */
   export interface ShareIdentity {
   }
 
-  /** ShareInitialOwner. */
+  /**
+   * ShareInitialOwner.
+   */
   export interface ShareInitialOwner {
     /** The initial group identifier for the file share. */
     gid?: number;
@@ -42921,7 +46499,9 @@ namespace VpcV1 {
     uid?: number;
   }
 
-  /** ShareJob. */
+  /**
+   * ShareJob.
+   */
   export interface ShareJob {
     /** The status of the file share job:
      *  - `cancelled`: This job has been cancelled.
@@ -42965,7 +46545,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareJobStatusReason. */
+  /**
+   * ShareJobStatusReason.
+   */
   export interface ShareJobStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -42989,7 +46571,12 @@ namespace VpcV1 {
     }
   }
 
-  /** Information about the latest synchronization for this file share. This property will be present when the `replication_role` is `replica` and at least one replication sync has been completed. */
+  /**
+   * Information about the latest synchronization for this file share.
+   *
+   * This property will be present when the `replication_role` is `replica` and at least one replication sync has been
+   * completed.
+   */
   export interface ShareLatestSync {
     /** The completed date and time of last synchronization between the replica share and its source. */
     completed_at: string;
@@ -42999,7 +46586,9 @@ namespace VpcV1 {
     started_at: string;
   }
 
-  /** ShareLifecycleReason. */
+  /**
+   * ShareLifecycleReason.
+   */
   export interface ShareLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `origin_share_access_revoked`: The resource has been revoked by the share owner
@@ -43027,7 +46616,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareMountTarget. */
+  /**
+   * ShareMountTarget.
+   */
   export interface ShareMountTarget {
     /** The access control mode for the share:
      *
@@ -43126,33 +46717,25 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareMountTargetCollection. */
+  /**
+   * ShareMountTargetCollection.
+   */
   export interface ShareMountTargetCollection {
     /** A link to the first page of resources. */
-    first: ShareMountTargetCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A page of mount targets for the share. */
     mount_targets: ShareMountTarget[];
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ShareMountTargetCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ShareMountTargetCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ShareMountTargetCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ShareMountTargetPrototype. */
+  /**
+   * ShareMountTargetPrototype.
+   */
   export interface ShareMountTargetPrototype {
     /** The name for this share mount target. The name must not be used by another mount target for the file share. */
     name?: string;
@@ -43176,7 +46759,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareMountTargetReference. */
+  /**
+   * ShareMountTargetReference.
+   */
   export interface ShareMountTargetReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -43200,11 +46785,15 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareMountTargetVirtualNetworkInterfacePrototype. */
+  /**
+   * ShareMountTargetVirtualNetworkInterfacePrototype.
+   */
   export interface ShareMountTargetVirtualNetworkInterfacePrototype {
   }
 
-  /** ShareProfile. */
+  /**
+   * ShareProfile.
+   */
   export interface ShareProfile {
     /** The permitted capacity range (in gigabytes) for a share with this profile. */
     capacity: ShareProfileCapacity;
@@ -43236,45 +46825,43 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareProfileCapacity. */
+  /**
+   * ShareProfileCapacity.
+   */
   export interface ShareProfileCapacity {
   }
 
-  /** ShareProfileCollection. */
+  /**
+   * ShareProfileCollection.
+   */
   export interface ShareProfileCollection {
     /** A link to the first page of resources. */
-    first: ShareProfileCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: ShareProfileCollectionNext;
+    next?: PageLink;
     /** A page of share profiles. */
     profiles: ShareProfile[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface ShareProfileCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface ShareProfileCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** ShareProfileIOPS. */
+  /**
+   * ShareProfileIOPS.
+   */
   export interface ShareProfileIOPS {
   }
 
-  /** Identifies a share profile by a unique property. */
+  /**
+   * Identifies a share profile by a unique property.
+   */
   export interface ShareProfileIdentity {
   }
 
-  /** ShareProfileReference. */
+  /**
+   * ShareProfileReference.
+   */
   export interface ShareProfileReference {
     /** The URL for this share profile. */
     href: string;
@@ -43292,7 +46879,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SharePrototype. */
+  /**
+   * SharePrototype.
+   */
   export interface SharePrototype {
     /** The transit encryption modes to allow for this share. If unspecified:
      *  - If share mount targets are specified, and those share mount targets all specify a
@@ -43324,7 +46913,11 @@ namespace VpcV1 {
     }
   }
 
-  /** Configuration for a replica file share to create and associate with this file share. If unspecified, a replica may be subsequently added by creating a new file share with a `source_share` referencing this file share. */
+  /**
+   * Configuration for a replica file share to create and associate with this file share. If unspecified, a replica may
+   * be subsequently added by creating a new file share with a
+   * `source_share` referencing this file share.
+   */
   export interface SharePrototypeShareContext {
     /** The transit encryption modes to allow for this share. If unspecified:
      *  - If share mount targets are specified, and those share mount targets all specify a
@@ -43354,7 +46947,7 @@ namespace VpcV1 {
     profile: ShareProfileIdentity;
     /** The cron specification for the file share replication schedule.
      *
-     *  Replication of a share can be scheduled to occur at most once per hour.
+     *  Replication of a share can be scheduled to occur at most once every 15 minutes.
      */
     replication_cron_spec: string;
     /** The resource group to use. If unspecified, the resource group from the source share will be used. */
@@ -43376,7 +46969,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareReference. */
+  /**
+   * ShareReference.
+   */
   export interface ShareReference {
     /** The CRN for this file share. */
     crn: string;
@@ -43406,7 +47001,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface ShareRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  account, and identifies the owning account.
@@ -43418,7 +47016,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** ShareReplicationStatusReason. */
+  /**
+   * ShareReplicationStatusReason.
+   */
   export interface ShareReplicationStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -43442,7 +47042,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Snapshot. */
+  /**
+   * Snapshot.
+   */
   export interface Snapshot {
     /** If present, the backup policy plan which created this snapshot. */
     backup_policy_plan?: BackupPolicyPlanReference;
@@ -43494,6 +47096,10 @@ namespace VpcV1 {
     name: string;
     /** The operating system included in this snapshot. */
     operating_system?: OperatingSystem;
+    /** Indicates the progress (as a percentage) of storing this snapshot. Only stored snapshots can be used for
+     *  restoration.
+     */
+    progress: number;
     /** The resource group for this snapshot. */
     resource_group: ResourceGroupReference;
     /** The resource type. */
@@ -43541,7 +47147,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SnapshotCatalogOffering. */
+  /**
+   * SnapshotCatalogOffering.
+   */
   export interface SnapshotCatalogOffering {
     /** The billing plan associated with the catalog offering version.
      *
@@ -43555,7 +47163,9 @@ namespace VpcV1 {
     version: CatalogOfferingVersionReference;
   }
 
-  /** SnapshotClone. */
+  /**
+   * SnapshotClone.
+   */
   export interface SnapshotClone {
     /** Indicates whether this snapshot clone is available for use. */
     available: boolean;
@@ -43565,45 +47175,41 @@ namespace VpcV1 {
     zone: ZoneReference;
   }
 
-  /** SnapshotCloneCollection. */
+  /**
+   * SnapshotCloneCollection.
+   */
   export interface SnapshotCloneCollection {
     /** The clones for the snapshot. */
     clones: SnapshotClone[];
   }
 
-  /** SnapshotClonePrototype. */
+  /**
+   * SnapshotClonePrototype.
+   */
   export interface SnapshotClonePrototype {
     /** The zone this snapshot clone will reside in. Must be in the same region as the snapshot. */
     zone: ZoneIdentity;
   }
 
-  /** SnapshotCollection. */
+  /**
+   * SnapshotCollection.
+   */
   export interface SnapshotCollection {
     /** A link to the first page of resources. */
-    first: SnapshotCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: SnapshotCollectionNext;
+    next?: PageLink;
     /** A page of snapshots. */
     snapshots: Snapshot[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface SnapshotCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface SnapshotCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** SnapshotConsistencyGroup. */
+  /**
+   * SnapshotConsistencyGroup.
+   */
   export interface SnapshotConsistencyGroup {
     /** If present, the backup policy plan which created this snapshot consistency group. */
     backup_policy_plan?: BackupPolicyPlanReference;
@@ -43656,33 +47262,25 @@ namespace VpcV1 {
     }
   }
 
-  /** SnapshotConsistencyGroupCollection. */
+  /**
+   * SnapshotConsistencyGroupCollection.
+   */
   export interface SnapshotConsistencyGroupCollection {
     /** A link to the first page of resources. */
-    first: SnapshotConsistencyGroupCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: SnapshotConsistencyGroupCollectionNext;
+    next?: PageLink;
     /** A page of snapshot consistency groups. */
     snapshot_consistency_groups: SnapshotConsistencyGroup[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface SnapshotConsistencyGroupCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface SnapshotConsistencyGroupCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** SnapshotConsistencyGroupPrototype. */
+  /**
+   * SnapshotConsistencyGroupPrototype.
+   */
   export interface SnapshotConsistencyGroupPrototype {
     /** Indicates whether deleting the snapshot consistency group will also delete the snapshots in the group. */
     delete_snapshots_on_delete?: boolean;
@@ -43698,7 +47296,9 @@ namespace VpcV1 {
     resource_group?: ResourceGroupIdentity;
   }
 
-  /** SnapshotConsistencyGroupReference. */
+  /**
+   * SnapshotConsistencyGroupReference.
+   */
   export interface SnapshotConsistencyGroupReference {
     /** The CRN of this snapshot consistency group. */
     crn: string;
@@ -43726,7 +47326,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SnapshotCopiesItem. */
+  /**
+   * SnapshotCopiesItem.
+   */
   export interface SnapshotCopiesItem {
     /** The CRN for the copied snapshot. */
     crn: string;
@@ -43756,11 +47358,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a snapshot by a unique property. */
+  /**
+   * Identifies a snapshot by a unique property.
+   */
   export interface SnapshotIdentity {
   }
 
-  /** SnapshotPrototype. */
+  /**
+   * SnapshotPrototype.
+   */
   export interface SnapshotPrototype {
     /** Clones to create for this snapshot. */
     clones?: SnapshotClonePrototype[];
@@ -43776,7 +47382,9 @@ namespace VpcV1 {
     user_tags?: string[];
   }
 
-  /** SnapshotPrototypeSnapshotConsistencyGroupContext. */
+  /**
+   * SnapshotPrototypeSnapshotConsistencyGroupContext.
+   */
   export interface SnapshotPrototypeSnapshotConsistencyGroupContext {
     /** The name for this snapshot. The name must not be used by another snapshot in the region. If unspecified, the
      *  name will be a hyphenated list of randomly-selected words.
@@ -43788,7 +47396,9 @@ namespace VpcV1 {
     user_tags?: string[];
   }
 
-  /** SnapshotReference. */
+  /**
+   * SnapshotReference.
+   */
   export interface SnapshotReference {
     /** The CRN of this snapshot. */
     crn: string;
@@ -43818,7 +47428,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface SnapshotRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  account, and identifies the owning account.
@@ -43830,7 +47443,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** If present, the source snapshot this snapshot was created from. */
+  /**
+   * If present, the source snapshot this snapshot was created from.
+   */
   export interface SnapshotSourceSnapshot {
     /** The CRN of the source snapshot. */
     crn: string;
@@ -43862,7 +47477,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Subnet. */
+  /**
+   * Subnet.
+   */
   export interface Subnet {
     /** The number of IPv4 addresses in this subnet that are not in-use, and have not been reserved by the user or
      *  the provider.
@@ -43929,37 +47546,31 @@ namespace VpcV1 {
     }
   }
 
-  /** SubnetCollection. */
+  /**
+   * SubnetCollection.
+   */
   export interface SubnetCollection {
     /** A link to the first page of resources. */
-    first: SubnetCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: SubnetCollectionNext;
+    next?: PageLink;
     /** A page of subnets. */
     subnets: Subnet[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface SubnetCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface SubnetCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** Identifies a subnet by a unique property. */
+  /**
+   * Identifies a subnet by a unique property.
+   */
   export interface SubnetIdentity {
   }
 
-  /** SubnetPrototype. */
+  /**
+   * SubnetPrototype.
+   */
   export interface SubnetPrototype {
     /** The IP version(s) to support for this subnet. */
     ip_version?: SubnetPrototype.Constants.IpVersion | string;
@@ -43995,11 +47606,15 @@ namespace VpcV1 {
     }
   }
 
-  /** The public gateway to use for internet-bound traffic for this subnet. */
+  /**
+   * The public gateway to use for internet-bound traffic for this subnet.
+   */
   export interface SubnetPublicGatewayPatch {
   }
 
-  /** SubnetReference. */
+  /**
+   * SubnetReference.
+   */
   export interface SubnetReference {
     /** The CRN for this subnet. */
     crn: string;
@@ -44025,11 +47640,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a trusted profile by a unique property. */
+  /**
+   * Identifies a trusted profile by a unique property.
+   */
   export interface TrustedProfileIdentity {
   }
 
-  /** TrustedProfileReference. */
+  /**
+   * TrustedProfileReference.
+   */
   export interface TrustedProfileReference {
     /** The CRN for this trusted profile. */
     crn: string;
@@ -44047,7 +47666,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The VCPU configuration. */
+  /**
+   * The VCPU configuration.
+   */
   export interface VCPU {
     /** The VCPU architecture. */
     architecture: string;
@@ -44057,7 +47678,9 @@ namespace VpcV1 {
     manufacturer: string;
   }
 
-  /** VPC. */
+  /**
+   * VPC.
+   */
   export interface VPC {
     /** Indicates whether this VPC is connected to Classic Infrastructure. If true, this VPC's resources have
      *  private network connectivity to the account's Classic Infrastructure resources. Only one VPC, per region, may be
@@ -44134,7 +47757,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCCSESourceIP. */
+  /**
+   * VPCCSESourceIP.
+   */
   export interface VPCCSESourceIP {
     /** The cloud service endpoint source IP address for this zone. */
     ip: IP;
@@ -44142,33 +47767,25 @@ namespace VpcV1 {
     zone: ZoneReference;
   }
 
-  /** VPCCollection. */
+  /**
+   * VPCCollection.
+   */
   export interface VPCCollection {
     /** A link to the first page of resources. */
-    first: VPCCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPCCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
     /** A page of VPCs. */
     vpcs: VPC[];
   }
 
-  /** A link to the first page of resources. */
-  export interface VPCCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPCCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The DNS configuration for this VPC. */
+  /**
+   * The DNS configuration for this VPC.
+   */
   export interface VPCDNS {
     /** Indicates whether this VPC is enabled as a DNS name resolution hub. */
     enable_hub: boolean;
@@ -44178,7 +47795,9 @@ namespace VpcV1 {
     resolver: VPCDNSResolver;
   }
 
-  /** The DNS configuration for this VPC. */
+  /**
+   * The DNS configuration for this VPC.
+   */
   export interface VPCDNSPatch {
     /** Indicates whether this VPC is enabled as a DNS name resolution hub.
      *
@@ -44191,14 +47810,21 @@ namespace VpcV1 {
     resolver?: VPCDNSResolverPatch;
   }
 
-  /** The DNS configuration for this VPC. If unspecified, the system will assign DNS servers capable of resolving hosts and endpoint gateways within this VPC, and hosts on the internet. */
+  /**
+   * The DNS configuration for this VPC.
+   *
+   * If unspecified, the system will assign DNS servers capable of resolving hosts and endpoint gateways within this
+   * VPC, and hosts on the internet.
+   */
   export interface VPCDNSPrototype {
     /** Indicates whether this VPC is enabled as a DNS name resolution hub. */
     enable_hub?: boolean;
     resolver?: VPCDNSResolverPrototype;
   }
 
-  /** VPCDNSResolutionBinding. */
+  /**
+   * VPCDNSResolutionBinding.
+   */
   export interface VPCDNSResolutionBinding {
     /** The date and time that the DNS resolution binding was created. */
     created_at: string;
@@ -44261,33 +47887,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCDNSResolutionBindingCollection. */
+  /**
+   * VPCDNSResolutionBindingCollection.
+   */
   export interface VPCDNSResolutionBindingCollection {
     /** A page of DNS resolution bindings for the VPC. */
     dns_resolution_bindings: VPCDNSResolutionBinding[];
     /** A link to the first page of resources. */
-    first: VPCDNSResolutionBindingCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPCDNSResolutionBindingCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface VPCDNSResolutionBindingCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPCDNSResolutionBindingCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VPCDNSResolutionBindingHealthReason. */
+  /**
+   * VPCDNSResolutionBindingHealthReason.
+   */
   export interface VPCDNSResolutionBindingHealthReason {
     /** A reason code for this health state. */
     code: VPCDNSResolutionBindingHealthReason.Constants.Code | string;
@@ -44306,7 +47924,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCDNSResolver. */
+  /**
+   * VPCDNSResolver.
+   */
   export interface VPCDNSResolver {
     /** The DNS servers for this VPC. The servers are populated:
      *
@@ -44341,7 +47961,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCDNSResolverPatch. */
+  /**
+   * VPCDNSResolverPatch.
+   */
   export interface VPCDNSResolverPatch {
     /** The DNS servers to use for this VPC, replacing any existing servers. All the DNS servers must either:
      *
@@ -44397,7 +48019,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCDNSResolverPrototype. */
+  /**
+   * VPCDNSResolverPrototype.
+   */
   export interface VPCDNSResolverPrototype {
     /** The type of the DNS resolver to use.
      *
@@ -44417,11 +48041,21 @@ namespace VpcV1 {
     }
   }
 
-  /** The VPC to provide DNS server addresses for this VPC.  The specified VPC must be configured with a [DNS Services](https://cloud.ibm.com/docs/dns-svcs) custom resolver and must be in one of this VPC's DNS resolution bindings. Specify `null` to remove an existing VPC. This property must be set if and only if `dns.resolver.type` is `delegated`. */
+  /**
+   * The VPC to provide DNS server addresses for this VPC.  The specified VPC must be configured with a [DNS
+   * Services](https://cloud.ibm.com/docs/dns-svcs) custom resolver and must be in one of this VPC's DNS resolution
+   * bindings.
+   *
+   * Specify `null` to remove an existing VPC.
+   *
+   * This property must be set if and only if `dns.resolver.type` is `delegated`.
+   */
   export interface VPCDNSResolverVPCPatch {
   }
 
-  /** VPCHealthReason. */
+  /**
+   * VPCHealthReason.
+   */
   export interface VPCHealthReason {
     /** A reason code for this health state. */
     code: VPCHealthReason.Constants.Code | string;
@@ -44440,11 +48074,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a VPC by a unique property. */
+  /**
+   * Identifies a VPC by a unique property.
+   */
   export interface VPCIdentity {
   }
 
-  /** VPCReference. */
+  /**
+   * VPCReference.
+   */
   export interface VPCReference {
     /** The CRN for this VPC. */
     crn: string;
@@ -44470,7 +48108,11 @@ namespace VpcV1 {
     }
   }
 
-  /** A VPC whose DNS resolver is delegated to provide DNS servers for this VPC. The VPC may be remote and therefore may not be directly retrievable. */
+  /**
+   * A VPC whose DNS resolver is delegated to provide DNS servers for this VPC.
+   *
+   * The VPC may be remote and therefore may not be directly retrievable.
+   */
   export interface VPCReferenceDNSResolverContext {
     /** The CRN for this VPC. */
     crn: string;
@@ -44500,7 +48142,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCReferenceRemote. */
+  /**
+   * VPCReferenceRemote.
+   */
   export interface VPCReferenceRemote {
     /** The CRN for this VPC. */
     crn: string;
@@ -44526,7 +48170,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface VPCRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  account, and identifies the owning account.
@@ -44538,7 +48185,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** VPNGateway. */
+  /**
+   * VPNGateway.
+   */
   export interface VPNGateway {
     /** Connections for this VPN gateway. */
     connections: VPNGatewayConnectionReference[];
@@ -44603,33 +48252,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayCollection. */
+  /**
+   * VPNGatewayCollection.
+   */
   export interface VPNGatewayCollection {
     /** A link to the first page of resources. */
-    first: VPNGatewayCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPNGatewayCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
     /** A page of VPN gateways. */
     vpn_gateways: VPNGateway[];
   }
 
-  /** A link to the first page of resources. */
-  export interface VPNGatewayCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPNGatewayCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VPNGatewayConnection. */
+  /**
+   * VPNGatewayConnection.
+   */
   export interface VPNGatewayConnection {
     /** If set to false, the VPN gateway connection is shut down. */
     admin_state_up: boolean;
@@ -44709,39 +48350,33 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionCIDRs. */
+  /**
+   * VPNGatewayConnectionCIDRs.
+   */
   export interface VPNGatewayConnectionCIDRs {
     /** The CIDRs for this resource. */
     cidrs: string[];
   }
 
-  /** VPNGatewayConnectionCollection. */
+  /**
+   * VPNGatewayConnectionCollection.
+   */
   export interface VPNGatewayConnectionCollection {
     /** A page of connections for the VPN gateway. */
     connections: VPNGatewayConnection[];
     /** A link to the first page of resources. */
-    first: VPNGatewayConnectionCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPNGatewayConnectionCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface VPNGatewayConnectionCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPNGatewayConnectionCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** The Dead Peer Detection settings. */
+  /**
+   * The Dead Peer Detection settings.
+   */
   export interface VPNGatewayConnectionDPD {
     /** Dead Peer Detection actions. */
     action: VPNGatewayConnectionDPD.Constants.Action | string;
@@ -44762,7 +48397,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The Dead Peer Detection settings. */
+  /**
+   * The Dead Peer Detection settings.
+   */
   export interface VPNGatewayConnectionDPDPatch {
     /** Dead Peer Detection actions. */
     action?: VPNGatewayConnectionDPDPatch.Constants.Action | string;
@@ -44783,7 +48420,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The Dead Peer Detection settings. */
+  /**
+   * The Dead Peer Detection settings.
+   */
   export interface VPNGatewayConnectionDPDPrototype {
     /** Dead Peer Detection actions. */
     action?: VPNGatewayConnectionDPDPrototype.Constants.Action | string;
@@ -44804,7 +48443,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentity. */
+  /**
+   * VPNGatewayConnectionIKEIdentity.
+   */
   export interface VPNGatewayConnectionIKEIdentity {
     /** The IKE identity type.
      *
@@ -44825,7 +48466,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityPrototype. */
+  /**
+   * VPNGatewayConnectionIKEIdentityPrototype.
+   */
   export interface VPNGatewayConnectionIKEIdentityPrototype {
     /** The IKE identity type. */
     type: VPNGatewayConnectionIKEIdentityPrototype.Constants.Type | string;
@@ -44842,27 +48485,43 @@ namespace VpcV1 {
     }
   }
 
-  /** The IKE policy to use. Specify `null` to remove any existing policy, [resulting in auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1). */
+  /**
+   * The IKE policy to use. Specify `null` to remove any existing policy, [resulting in
+   * auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1).
+   */
   export interface VPNGatewayConnectionIKEPolicyPatch {
   }
 
-  /** The IKE policy to use. If unspecified, [auto-negotiation will be used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1). */
+  /**
+   * The IKE policy to use. If unspecified, [auto-negotiation will be
+   * used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ike-auto-negotiation-phase-1).
+   */
   export interface VPNGatewayConnectionIKEPolicyPrototype {
   }
 
-  /** The IPsec policy to use. Specify `null` to remove any existing policy, [resulting in auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2). */
+  /**
+   * The IPsec policy to use. Specify `null` to remove any existing policy, [resulting in
+   * auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
+   */
   export interface VPNGatewayConnectionIPsecPolicyPatch {
   }
 
-  /** The IPsec policy to use. If unspecified, [auto-negotiation will be used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2). */
+  /**
+   * The IPsec policy to use. If unspecified, [auto-negotiation will be
+   * used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
+   */
   export interface VPNGatewayConnectionIPsecPolicyPrototype {
   }
 
-  /** VPNGatewayConnectionPeerPatch. */
+  /**
+   * VPNGatewayConnectionPeerPatch.
+   */
   export interface VPNGatewayConnectionPeerPatch {
   }
 
-  /** VPNGatewayConnectionPolicyModeLocal. */
+  /**
+   * VPNGatewayConnectionPolicyModeLocal.
+   */
   export interface VPNGatewayConnectionPolicyModeLocal {
     /** The local CIDRs for this VPN gateway connection. */
     cidrs: string[];
@@ -44874,7 +48533,9 @@ namespace VpcV1 {
     ike_identities: VPNGatewayConnectionIKEIdentity[];
   }
 
-  /** VPNGatewayConnectionPolicyModeLocalPrototype. */
+  /**
+   * VPNGatewayConnectionPolicyModeLocalPrototype.
+   */
   export interface VPNGatewayConnectionPolicyModeLocalPrototype {
     /** The local CIDRs for this VPN gateway connection. */
     cidrs: string[];
@@ -44888,7 +48549,9 @@ namespace VpcV1 {
     ike_identities?: VPNGatewayConnectionIKEIdentityPrototype[];
   }
 
-  /** VPNGatewayConnectionPolicyModePeer. */
+  /**
+   * VPNGatewayConnectionPolicyModePeer.
+   */
   export interface VPNGatewayConnectionPolicyModePeer {
     /** The peer CIDRs for this VPN gateway connection. */
     cidrs: string[];
@@ -44907,7 +48570,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionPolicyModePeerPrototype. */
+  /**
+   * VPNGatewayConnectionPolicyModePeerPrototype.
+   */
   export interface VPNGatewayConnectionPolicyModePeerPrototype {
     /** The peer CIDRs for this VPN gateway connection. */
     cidrs: string[];
@@ -44922,7 +48587,9 @@ namespace VpcV1 {
     ike_identity?: VPNGatewayConnectionIKEIdentityPrototype;
   }
 
-  /** VPNGatewayConnectionPrototype. */
+  /**
+   * VPNGatewayConnectionPrototype.
+   */
   export interface VPNGatewayConnectionPrototype {
     /** If set to false, the VPN gateway connection is shut down. */
     admin_state_up?: boolean;
@@ -44962,7 +48629,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionReference. */
+  /**
+   * VPNGatewayConnectionReference.
+   */
   export interface VPNGatewayConnectionReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -44986,7 +48655,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionStaticRouteModeLocal. */
+  /**
+   * VPNGatewayConnectionStaticRouteModeLocal.
+   */
   export interface VPNGatewayConnectionStaticRouteModeLocal {
     /** The local IKE identities.
      *
@@ -44996,7 +48667,9 @@ namespace VpcV1 {
     ike_identities: VPNGatewayConnectionIKEIdentity[];
   }
 
-  /** VPNGatewayConnectionStaticRouteModeLocalPrototype. */
+  /**
+   * VPNGatewayConnectionStaticRouteModeLocalPrototype.
+   */
   export interface VPNGatewayConnectionStaticRouteModeLocalPrototype {
     /** The local IKE identities to use.
      *
@@ -45009,7 +48682,9 @@ namespace VpcV1 {
     ike_identities?: VPNGatewayConnectionIKEIdentityPrototype[];
   }
 
-  /** VPNGatewayConnectionStaticRouteModePeer. */
+  /**
+   * VPNGatewayConnectionStaticRouteModePeer.
+   */
   export interface VPNGatewayConnectionStaticRouteModePeer {
     /** The peer IKE identity. */
     ike_identity: VPNGatewayConnectionIKEIdentity;
@@ -45026,7 +48701,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionStaticRouteModePeerPrototype. */
+  /**
+   * VPNGatewayConnectionStaticRouteModePeerPrototype.
+   */
   export interface VPNGatewayConnectionStaticRouteModePeerPrototype {
     /** The peer IKE identity to use.
      *
@@ -45039,7 +48716,9 @@ namespace VpcV1 {
     ike_identity?: VPNGatewayConnectionIKEIdentityPrototype;
   }
 
-  /** VPNGatewayConnectionStaticRouteModeTunnel. */
+  /**
+   * VPNGatewayConnectionStaticRouteModeTunnel.
+   */
   export interface VPNGatewayConnectionStaticRouteModeTunnel {
     /** The IP address of the VPN gateway member in which the tunnel resides. */
     public_ip: IP;
@@ -45062,7 +48741,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionStatusReason. */
+  /**
+   * VPNGatewayConnectionStatusReason.
+   */
   export interface VPNGatewayConnectionStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -45090,7 +48771,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionTunnelStatusReason. */
+  /**
+   * VPNGatewayConnectionTunnelStatusReason.
+   */
   export interface VPNGatewayConnectionTunnelStatusReason {
     /** A reason code for this status:
      *  - `cannot_authenticate_connection`: Failed to authenticate a connection because of
@@ -45132,7 +48815,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayHealthReason. */
+  /**
+   * VPNGatewayHealthReason.
+   */
   export interface VPNGatewayHealthReason {
     /** A reason code for this health state:
      *  - `cannot_create_vpc_route`: VPN cannot create route (check for conflict)
@@ -45160,7 +48845,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayLifecycleReason. */
+  /**
+   * VPNGatewayLifecycleReason.
+   */
   export interface VPNGatewayLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `internal_error`: internal error (contact IBM support)
@@ -45186,7 +48873,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayMember. */
+  /**
+   * VPNGatewayMember.
+   */
   export interface VPNGatewayMember {
     /** The reasons for the current `health_state` (if any). */
     health_reasons: VPNGatewayMemberHealthReason[];
@@ -45244,7 +48933,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayMemberHealthReason. */
+  /**
+   * VPNGatewayMemberHealthReason.
+   */
   export interface VPNGatewayMemberHealthReason {
     /** A reason code for this health state:
      *  - `cannot_reserve_ip_address`: IP address exhaustion (release addresses on the VPN's
@@ -45270,7 +48961,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayMemberLifecycleReason. */
+  /**
+   * VPNGatewayMemberLifecycleReason.
+   */
   export interface VPNGatewayMemberLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `internal_error`: internal error (contact IBM support)
@@ -45296,7 +48989,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayPrototype. */
+  /**
+   * VPNGatewayPrototype.
+   */
   export interface VPNGatewayPrototype {
     /** The name for this VPN gateway. The name must not be used by another VPN gateway in the VPC. If unspecified,
      *  the name will be a hyphenated list of randomly-selected words.
@@ -45310,7 +49005,9 @@ namespace VpcV1 {
     subnet: SubnetIdentity;
   }
 
-  /** VPNServer. */
+  /**
+   * VPNServer.
+   */
   export interface VPNServer {
     /** The certificate instance for this VPN server. */
     certificate: CertificateInstanceReference;
@@ -45417,7 +49114,9 @@ namespace VpcV1 {
     }
   }
 
-  /** An authentication method for this VPN server. */
+  /**
+   * An authentication method for this VPN server.
+   */
   export interface VPNServerAuthentication {
     /** The type of authentication.
      *
@@ -45436,11 +49135,15 @@ namespace VpcV1 {
     }
   }
 
-  /** The type of identity provider to be used by VPN client. */
+  /**
+   * The type of identity provider to be used by VPN client.
+   */
   export interface VPNServerAuthenticationByUsernameIdProvider {
   }
 
-  /** An authentication method for this VPN server. */
+  /**
+   * An authentication method for this VPN server.
+   */
   export interface VPNServerAuthenticationPrototype {
     /** The type of authentication. */
     method: VPNServerAuthenticationPrototype.Constants.Method | string;
@@ -45455,7 +49158,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerClient. */
+  /**
+   * VPNServerClient.
+   */
   export interface VPNServerClient {
     /** The IP address assigned to this VPN client from `client_ip_pool`. */
     client_ip: IP;
@@ -45511,59 +49216,41 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerClientCollection. */
+  /**
+   * VPNServerClientCollection.
+   */
   export interface VPNServerClientCollection {
     /** A page of clients of the VPN server. */
     clients: VPNServerClient[];
     /** A link to the first page of resources. */
-    first: VPNServerClientCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPNServerClientCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface VPNServerClientCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPNServerClientCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VPNServerCollection. */
+  /**
+   * VPNServerCollection.
+   */
   export interface VPNServerCollection {
     /** A link to the first page of resources. */
-    first: VPNServerCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPNServerCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
     /** A page of VPN servers. */
     vpn_servers: VPNServer[];
   }
 
-  /** A link to the first page of resources. */
-  export interface VPNServerCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPNServerCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VPNServerHealthReason. */
+  /**
+   * VPNServerHealthReason.
+   */
   export interface VPNServerHealthReason {
     /** A reason code for this health state:
      *  - `cannot_access_client_certificate`: VPN server's client certificate is inaccessible
@@ -45599,7 +49286,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerLifecycleReason. */
+  /**
+   * VPNServerLifecycleReason.
+   */
   export interface VPNServerLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `internal_error`: internal error (contact IBM support)
@@ -45625,7 +49314,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerRoute. */
+  /**
+   * VPNServerRoute.
+   */
   export interface VPNServerRoute {
     /** The action to perform with a packet matching the VPN route:
      *  - `translate`: translate the source IP address to one of the private IP addresses of
@@ -45699,33 +49390,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerRouteCollection. */
+  /**
+   * VPNServerRouteCollection.
+   */
   export interface VPNServerRouteCollection {
     /** A link to the first page of resources. */
-    first: VPNServerRouteCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VPNServerRouteCollectionNext;
+    next?: PageLink;
     /** A page of routes for the VPN server. */
     routes: VPNServerRoute[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface VPNServerRouteCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VPNServerRouteCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VPNServerRouteHealthReason. */
+  /**
+   * VPNServerRouteHealthReason.
+   */
   export interface VPNServerRouteHealthReason {
     /** A reason code for this health state:
      *  - `internal_error`: Internal error (contact IBM support)
@@ -45748,7 +49431,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerRouteLifecycleReason. */
+  /**
+   * VPNServerRouteLifecycleReason.
+   */
   export interface VPNServerRouteLifecycleReason {
     /** A reason code for this lifecycle state:
      *  - `internal_error`: internal error (contact IBM support)
@@ -45774,7 +49459,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VirtualNetworkInterface. */
+  /**
+   * VirtualNetworkInterface.
+   */
   export interface VirtualNetworkInterface {
     /** Indicates whether source IP spoofing is allowed on this interface. If `false`, source IP spoofing is
      *  prevented on this interface. If `true`, source IP spoofing is allowed on this interface.
@@ -45872,41 +49559,37 @@ namespace VpcV1 {
     }
   }
 
-  /** VirtualNetworkInterfaceCollection. */
+  /**
+   * VirtualNetworkInterfaceCollection.
+   */
   export interface VirtualNetworkInterfaceCollection {
     /** A link to the first page of resources. */
-    first: VirtualNetworkInterfaceCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VirtualNetworkInterfaceCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
     /** A page of virtual network interfaces. */
     virtual_network_interfaces: VirtualNetworkInterface[];
   }
 
-  /** A link to the first page of resources. */
-  export interface VirtualNetworkInterfaceCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VirtualNetworkInterfaceCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VirtualNetworkInterfaceIPPrototype. */
+  /**
+   * VirtualNetworkInterfaceIPPrototype.
+   */
   export interface VirtualNetworkInterfaceIPPrototype {
   }
 
-  /** VirtualNetworkInterfacePrimaryIPPrototype. */
+  /**
+   * VirtualNetworkInterfacePrimaryIPPrototype.
+   */
   export interface VirtualNetworkInterfacePrimaryIPPrototype {
   }
 
-  /** VirtualNetworkInterfaceReferenceAttachmentContext. */
+  /**
+   * VirtualNetworkInterfaceReferenceAttachmentContext.
+   */
   export interface VirtualNetworkInterfaceReferenceAttachmentContext {
     /** The CRN for this virtual network interface. */
     crn: string;
@@ -45930,11 +49613,18 @@ namespace VpcV1 {
     }
   }
 
-  /** A virtual network interface target. The resources supported by this property may [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future. */
+  /**
+   * A virtual network interface target.
+   *
+   * The resources supported by this property may
+   * [expand](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
+   */
   export interface VirtualNetworkInterfaceTarget {
   }
 
-  /** Volume. */
+  /**
+   * Volume.
+   */
   export interface Volume {
     /** Indicates whether a running virtual server instance has an attachment to this volume. */
     active: boolean;
@@ -46079,7 +49769,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeAttachment. */
+  /**
+   * VolumeAttachment.
+   */
   export interface VolumeAttachment {
     /** The maximum bandwidth (in megabits per second) for the volume when attached to this instance. This may be
      *  lower than the volume bandwidth depending on the configuration of the instance.
@@ -46135,19 +49827,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeAttachmentCollection. */
+  /**
+   * VolumeAttachmentCollection.
+   */
   export interface VolumeAttachmentCollection {
     /** The volume attachments for the instance. */
     volume_attachments: VolumeAttachment[];
   }
 
-  /** VolumeAttachmentDevice. */
+  /**
+   * VolumeAttachmentDevice.
+   */
   export interface VolumeAttachmentDevice {
     /** A unique identifier for the device which is exposed to the instance operating system. */
-    id?: string;
+    id: string;
   }
 
-  /** VolumeAttachmentPrototype. */
+  /**
+   * VolumeAttachmentPrototype.
+   */
   export interface VolumeAttachmentPrototype {
     /** Indicates whether deleting the instance will also delete the attached volume. */
     delete_volume_on_instance_delete?: boolean;
@@ -46159,7 +49857,9 @@ namespace VpcV1 {
     volume: VolumeAttachmentPrototypeVolume;
   }
 
-  /** VolumeAttachmentPrototypeInstanceByImageContext. */
+  /**
+   * VolumeAttachmentPrototypeInstanceByImageContext.
+   */
   export interface VolumeAttachmentPrototypeInstanceByImageContext {
     /** Indicates whether deleting the instance will also delete the attached volume. */
     delete_volume_on_instance_delete?: boolean;
@@ -46171,7 +49871,9 @@ namespace VpcV1 {
     volume: VolumePrototypeInstanceByImageContext;
   }
 
-  /** VolumeAttachmentPrototypeInstanceBySourceSnapshotContext. */
+  /**
+   * VolumeAttachmentPrototypeInstanceBySourceSnapshotContext.
+   */
   export interface VolumeAttachmentPrototypeInstanceBySourceSnapshotContext {
     /** Indicates whether deleting the instance will also delete the attached volume. */
     delete_volume_on_instance_delete?: boolean;
@@ -46183,7 +49885,9 @@ namespace VpcV1 {
     volume: VolumePrototypeInstanceBySourceSnapshotContext;
   }
 
-  /** VolumeAttachmentPrototypeInstanceByVolumeContext. */
+  /**
+   * VolumeAttachmentPrototypeInstanceByVolumeContext.
+   */
   export interface VolumeAttachmentPrototypeInstanceByVolumeContext {
     /** Indicates whether deleting the instance will also delete the attached volume. */
     delete_volume_on_instance_delete?: boolean;
@@ -46195,11 +49899,15 @@ namespace VpcV1 {
     volume: VolumeIdentity;
   }
 
-  /** An existing volume to attach to the instance, or a prototype object for a new volume. */
+  /**
+   * An existing volume to attach to the instance, or a prototype object for a new volume.
+   */
   export interface VolumeAttachmentPrototypeVolume {
   }
 
-  /** VolumeAttachmentReferenceInstanceContext. */
+  /**
+   * VolumeAttachmentReferenceInstanceContext.
+   */
   export interface VolumeAttachmentReferenceInstanceContext {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -46223,7 +49931,9 @@ namespace VpcV1 {
     volume?: VolumeReferenceVolumeAttachmentContext;
   }
 
-  /** VolumeAttachmentReferenceVolumeContext. */
+  /**
+   * VolumeAttachmentReferenceVolumeContext.
+   */
   export interface VolumeAttachmentReferenceVolumeContext {
     /** Indicates whether deleting the instance will also delete the attached volume. */
     delete_volume_on_instance_delete: boolean;
@@ -46261,7 +49971,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeCatalogOffering. */
+  /**
+   * VolumeCatalogOffering.
+   */
   export interface VolumeCatalogOffering {
     /** The billing plan associated with the catalog offering version.
      *
@@ -46275,33 +49987,25 @@ namespace VpcV1 {
     version: CatalogOfferingVersionReference;
   }
 
-  /** VolumeCollection. */
+  /**
+   * VolumeCollection.
+   */
   export interface VolumeCollection {
     /** A link to the first page of resources. */
-    first: VolumeCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VolumeCollectionNext;
+    next?: PageLink;
     /** The total number of resources across all pages. */
     total_count: number;
     /** A page of volumes. */
     volumes: Volume[];
   }
 
-  /** A link to the first page of resources. */
-  export interface VolumeCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VolumeCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VolumeHealthReason. */
+  /**
+   * VolumeHealthReason.
+   */
   export interface VolumeHealthReason {
     /** A reason code for this health state. */
     code: VolumeHealthReason.Constants.Code | string;
@@ -46320,11 +50024,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a volume by a unique property. */
+  /**
+   * Identifies a volume by a unique property.
+   */
   export interface VolumeIdentity {
   }
 
-  /** VolumeProfile. */
+  /**
+   * VolumeProfile.
+   */
   export interface VolumeProfile {
     adjustable_capacity_states: VolumeProfileAdjustableCapacityStates;
     adjustable_iops_states: VolumeProfileAdjustableIOPSStates;
@@ -46353,7 +50061,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeProfileAdjustableCapacityStates. */
+  /**
+   * VolumeProfileAdjustableCapacityStates.
+   */
   export interface VolumeProfileAdjustableCapacityStates {
     /** The type for this profile field. */
     type: VolumeProfileAdjustableCapacityStates.Constants.Type | string;
@@ -46375,7 +50085,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeProfileAdjustableIOPSStates. */
+  /**
+   * VolumeProfileAdjustableIOPSStates.
+   */
   export interface VolumeProfileAdjustableIOPSStates {
     /** The type for this profile field. */
     type: VolumeProfileAdjustableIOPSStates.Constants.Type | string;
@@ -46397,49 +50109,49 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeProfileBootCapacity. */
+  /**
+   * VolumeProfileBootCapacity.
+   */
   export interface VolumeProfileBootCapacity {
   }
 
-  /** VolumeProfileCapacity. */
+  /**
+   * VolumeProfileCapacity.
+   */
   export interface VolumeProfileCapacity {
   }
 
-  /** VolumeProfileCollection. */
+  /**
+   * VolumeProfileCollection.
+   */
   export interface VolumeProfileCollection {
     /** A link to the first page of resources. */
-    first: VolumeProfileCollectionFirst;
+    first: PageLink;
     /** The maximum number of resources that can be returned by the request. */
     limit: number;
     /** A link to the next page of resources. This property is present for all pages except the last page. */
-    next?: VolumeProfileCollectionNext;
+    next?: PageLink;
     /** A page of volume profiles. */
     profiles: VolumeProfile[];
     /** The total number of resources across all pages. */
     total_count: number;
   }
 
-  /** A link to the first page of resources. */
-  export interface VolumeProfileCollectionFirst {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** A link to the next page of resources. This property is present for all pages except the last page. */
-  export interface VolumeProfileCollectionNext {
-    /** The URL for a page of resources. */
-    href: string;
-  }
-
-  /** VolumeProfileIOPS. */
+  /**
+   * VolumeProfileIOPS.
+   */
   export interface VolumeProfileIOPS {
   }
 
-  /** Identifies a volume profile by a unique property. */
+  /**
+   * Identifies a volume profile by a unique property.
+   */
   export interface VolumeProfileIdentity {
   }
 
-  /** VolumeProfileReference. */
+  /**
+   * VolumeProfileReference.
+   */
   export interface VolumeProfileReference {
     /** The URL for this volume profile. */
     href: string;
@@ -46447,7 +50159,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** VolumePrototype. */
+  /**
+   * VolumePrototype.
+   */
   export interface VolumePrototype {
     /** The maximum I/O operations per second (IOPS) to use for this volume. If specified, the `family` of the
      *  volume profile must be `custom` or `defined_performance`.
@@ -46469,7 +50183,9 @@ namespace VpcV1 {
     zone: ZoneIdentity;
   }
 
-  /** VolumePrototypeInstanceByImageContext. */
+  /**
+   * VolumePrototypeInstanceByImageContext.
+   */
   export interface VolumePrototypeInstanceByImageContext {
     /** The capacity to use for the volume (in gigabytes). The specified value must be at least the image's
      *  `minimum_provisioned_size`, at most 250 gigabytes, and within the
@@ -46499,7 +50215,9 @@ namespace VpcV1 {
     user_tags?: string[];
   }
 
-  /** VolumePrototypeInstanceBySourceSnapshotContext. */
+  /**
+   * VolumePrototypeInstanceBySourceSnapshotContext.
+   */
   export interface VolumePrototypeInstanceBySourceSnapshotContext {
     /** The capacity to use for the volume (in gigabytes). The specified value must be at least the snapshot's
      *  `minimum_capacity`, at most 250 gigabytes, and within the `boot_capacity` range of the volume's profile.
@@ -46531,7 +50249,9 @@ namespace VpcV1 {
     user_tags?: string[];
   }
 
-  /** VolumeReference. */
+  /**
+   * VolumeReference.
+   */
   export interface VolumeReference {
     /** The CRN for this volume. */
     crn: string;
@@ -46561,7 +50281,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeReferenceVolumeAttachmentContext. */
+  /**
+   * VolumeReferenceVolumeAttachmentContext.
+   */
   export interface VolumeReferenceVolumeAttachmentContext {
     /** The CRN for this volume. */
     crn: string;
@@ -46587,7 +50309,10 @@ namespace VpcV1 {
     }
   }
 
-  /** If present, this property indicates that the resource associated with this reference is remote and therefore may not be directly retrievable. */
+  /**
+   * If present, this property indicates that the resource associated with this reference is remote and therefore may
+   * not be directly retrievable.
+   */
   export interface VolumeRemote {
     /** If present, this property indicates that the referenced resource is remote to this
      *  region, and identifies the native region.
@@ -46595,7 +50320,9 @@ namespace VpcV1 {
     region?: RegionReference;
   }
 
-  /** VolumeStatusReason. */
+  /**
+   * VolumeStatusReason.
+   */
   export interface VolumeStatusReason {
     /** A snake case string succinctly identifying the status reason.
      *
@@ -46617,7 +50344,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Zone. */
+  /**
+   * Zone.
+   */
   export interface Zone {
     /** The physical data center assigned to this logical zone.
      *
@@ -46659,17 +50388,23 @@ namespace VpcV1 {
     }
   }
 
-  /** ZoneCollection. */
+  /**
+   * ZoneCollection.
+   */
   export interface ZoneCollection {
     /** The zones for the region. */
     zones: Zone[];
   }
 
-  /** Identifies a zone by a unique property. */
+  /**
+   * Identifies a zone by a unique property.
+   */
   export interface ZoneIdentity {
   }
 
-  /** ZoneReference. */
+  /**
+   * ZoneReference.
+   */
   export interface ZoneReference {
     /** The URL for this zone. */
     href: string;
@@ -46677,13 +50412,17 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** AccountIdentityById. */
+  /**
+   * AccountIdentityById.
+   */
   export interface AccountIdentityById extends AccountIdentity {
     /** The unique identifier for this account. */
     id: string;
   }
 
-  /** BackupPolicyJobSourceInstanceReference. */
+  /**
+   * BackupPolicyJobSourceInstanceReference.
+   */
   export interface BackupPolicyJobSourceInstanceReference extends BackupPolicyJobSource {
     /** The CRN for this virtual server instance. */
     crn: string;
@@ -46701,7 +50440,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** BackupPolicyJobSourceVolumeReference. */
+  /**
+   * BackupPolicyJobSourceVolumeReference.
+   */
   export interface BackupPolicyJobSourceVolumeReference extends BackupPolicyJobSource {
     /** The CRN for this volume. */
     crn: string;
@@ -46731,7 +50472,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyMatchResourceTypeInstance. */
+  /**
+   * BackupPolicyMatchResourceTypeInstance.
+   */
   export interface BackupPolicyMatchResourceTypeInstance extends BackupPolicy {
     /** The included content for backups created using this policy:
      *  - `boot_volume`: Include the instance's boot volume.
@@ -46784,7 +50527,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyMatchResourceTypeVolume. */
+  /**
+   * BackupPolicyMatchResourceTypeVolume.
+   */
   export interface BackupPolicyMatchResourceTypeVolume extends BackupPolicy {
     /** The resource type this backup policy applies to. Resources that have both a matching type and a matching
      *  user tag will be subject to the backup policy.
@@ -46824,7 +50569,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyPrototypeBackupPolicyMatchResourceTypeInstancePrototype. */
+  /**
+   * BackupPolicyPrototypeBackupPolicyMatchResourceTypeInstancePrototype.
+   */
   export interface BackupPolicyPrototypeBackupPolicyMatchResourceTypeInstancePrototype extends BackupPolicyPrototype {
     /** The included content for backups created using this policy:
      *  - `boot_volume`: Include the instance's boot volume.
@@ -46850,7 +50597,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyPrototypeBackupPolicyMatchResourceTypeVolumePrototype. */
+  /**
+   * BackupPolicyPrototypeBackupPolicyMatchResourceTypeVolumePrototype.
+   */
   export interface BackupPolicyPrototypeBackupPolicyMatchResourceTypeVolumePrototype extends BackupPolicyPrototype {
     /** The resource type this backup policy will apply to. Resources that have both a matching type and a matching
      *  user tag will be subject to the backup policy.
@@ -46866,11 +50615,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies an enterprise by a unique property. */
+  /**
+   * Identifies an enterprise by a unique property.
+   */
   export interface BackupPolicyScopePrototypeEnterpriseIdentity extends BackupPolicyScopePrototype {
   }
 
-  /** BackupPolicyScopeAccountReference. */
+  /**
+   * BackupPolicyScopeAccountReference.
+   */
   export interface BackupPolicyScopeAccountReference extends BackupPolicyScope {
     /** The unique identifier for this account. */
     id: string;
@@ -46886,7 +50639,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BackupPolicyScopeEnterpriseReference. */
+  /**
+   * BackupPolicyScopeEnterpriseReference.
+   */
   export interface BackupPolicyScopeEnterpriseReference extends BackupPolicyScope {
     /** The CRN for this enterprise. */
     crn: string;
@@ -46904,7 +50659,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerBootTargetBareMetalServerDiskReference. */
+  /**
+   * BareMetalServerBootTargetBareMetalServerDiskReference.
+   */
   export interface BareMetalServerBootTargetBareMetalServerDiskReference extends BareMetalServerBootTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -46928,7 +50685,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerInitializationUserAccountBareMetalServerInitializationHostUserAccount. */
+  /**
+   * BareMetalServerInitializationUserAccountBareMetalServerInitializationHostUserAccount.
+   */
   export interface BareMetalServerInitializationUserAccountBareMetalServerInitializationHostUserAccount extends BareMetalServerInitializationUserAccount {
     /** The password at initialization, encrypted using `encryption_key`, and returned base64-encoded. */
     encrypted_password: string;
@@ -46948,7 +50707,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkAttachmentByPCI. */
+  /**
+   * BareMetalServerNetworkAttachmentByPCI.
+   */
   export interface BareMetalServerNetworkAttachmentByPCI extends BareMetalServerNetworkAttachment {
     /** The VLAN IDs allowed for `vlan` attachments using this PCI attachment. */
     allowed_vlans: number[];
@@ -46988,7 +50749,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkAttachmentByVLAN. */
+  /**
+   * BareMetalServerNetworkAttachmentByVLAN.
+   */
   export interface BareMetalServerNetworkAttachmentByVLAN extends BareMetalServerNetworkAttachment {
     /** Indicates if the data path for the network attachment can float to another bare metal server. Can only be
      *  `true` for network attachments with an `interface_type` of `vlan`.
@@ -47039,11 +50802,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity extends BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterface {
   }
 
-  /** The virtual network interface for this target. */
+  /**
+   * The virtual network interface for this target.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfacePrototypeBareMetalServerNetworkAttachmentContext extends BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterface {
     /** Indicates whether source IP spoofing is allowed on this interface. If `false`, source IP spoofing is
      *  prevented on this interface. If `true`, source IP spoofing is allowed on this interface.
@@ -47125,7 +50892,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkAttachmentPrototypeBareMetalServerNetworkAttachmentByPCIPrototype. */
+  /**
+   * BareMetalServerNetworkAttachmentPrototypeBareMetalServerNetworkAttachmentByPCIPrototype.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeBareMetalServerNetworkAttachmentByPCIPrototype extends BareMetalServerNetworkAttachmentPrototype {
     /** The VLAN IDs to allow for `vlan` attachments using this PCI attachment. */
     allowed_vlans?: number[];
@@ -47147,7 +50916,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkAttachmentPrototypeBareMetalServerNetworkAttachmentByVLANPrototype. */
+  /**
+   * BareMetalServerNetworkAttachmentPrototypeBareMetalServerNetworkAttachmentByVLANPrototype.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeBareMetalServerNetworkAttachmentByVLANPrototype extends BareMetalServerNetworkAttachmentPrototype {
     /** Indicates if the data path for the network attachment can float to another bare metal server. Can only be
      *  `true` for network attachments with an `interface_type` of `vlan`.
@@ -47179,7 +50950,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfaceByHiperSocket. */
+  /**
+   * BareMetalServerNetworkInterfaceByHiperSocket.
+   */
   export interface BareMetalServerNetworkInterfaceByHiperSocket extends BareMetalServerNetworkInterface {
     /** - `hipersocket`: a virtual network device that provides high-speed TCP/IP connectivity
      *    within a `s390x` based system.
@@ -47211,7 +50984,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfaceByPCI. */
+  /**
+   * BareMetalServerNetworkInterfaceByPCI.
+   */
   export interface BareMetalServerNetworkInterfaceByPCI extends BareMetalServerNetworkInterface {
     /** The VLAN IDs allowed for `vlan` interfaces using this PCI interface.
      *
@@ -47254,7 +51029,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfaceByVLAN. */
+  /**
+   * BareMetalServerNetworkInterfaceByVLAN.
+   */
   export interface BareMetalServerNetworkInterfaceByVLAN extends BareMetalServerNetworkInterface {
     /** Indicates if the data path for the network interface can float to another bare metal server. Can only be
      *  `true` for network interfaces with an `interface_type` of `vlan`.
@@ -47314,7 +51091,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByHiperSocketPrototype. */
+  /**
+   * BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByHiperSocketPrototype.
+   */
   export interface BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByHiperSocketPrototype extends BareMetalServerNetworkInterfacePrototype {
     /** - `hipersocket`: a virtual network device that provides high-speed TCP/IP connectivity
      *    within a `s390x` based system.
@@ -47331,7 +51110,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByPCIPrototype. */
+  /**
+   * BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByPCIPrototype.
+   */
   export interface BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByPCIPrototype extends BareMetalServerNetworkInterfacePrototype {
     /** The VLAN IDs to allow for `vlan` interfaces using this PCI interface. */
     allowed_vlans?: number[];
@@ -47353,7 +51134,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByVLANPrototype. */
+  /**
+   * BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByVLANPrototype.
+   */
   export interface BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByVLANPrototype extends BareMetalServerNetworkInterfacePrototype {
     /** Indicates if the data path for the network interface can float to another bare metal server. Can only be
      *  `true` for network interfaces with an `interface_type` of `vlan`.
@@ -47398,7 +51181,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerPrimaryNetworkAttachmentPrototypeBareMetalServerPrimaryNetworkAttachmentByPCIPrototype. */
+  /**
+   * BareMetalServerPrimaryNetworkAttachmentPrototypeBareMetalServerPrimaryNetworkAttachmentByPCIPrototype.
+   */
   export interface BareMetalServerPrimaryNetworkAttachmentPrototypeBareMetalServerPrimaryNetworkAttachmentByPCIPrototype extends BareMetalServerPrimaryNetworkAttachmentPrototype {
     /** The VLAN IDs to allow for `vlan` attachments using this PCI attachment. */
     allowed_vlans?: number[];
@@ -47420,7 +51205,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The total bandwidth shared across the bare metal server network attachments or bare metal server network interfaces of a bare metal server with this profile depends on its configuration. */
+  /**
+   * The total bandwidth shared across the bare metal server network attachments or bare metal server network interfaces
+   * of a bare metal server with this profile depends on its configuration.
+   */
   export interface BareMetalServerProfileBandwidthDependent extends BareMetalServerProfileBandwidth {
     /** The type for this profile field. */
     type: BareMetalServerProfileBandwidthDependent.Constants.Type | string;
@@ -47434,7 +51222,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total bandwidth values (in megabits per second) shared across the bare metal server network attachments or bare metal server network interfaces of a bare metal server with this profile. */
+  /**
+   * The permitted total bandwidth values (in megabits per second) shared across the bare metal server network
+   * attachments or bare metal server network interfaces of a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileBandwidthEnum extends BareMetalServerProfileBandwidth {
     /** The default value for this profile field. */
     default: number;
@@ -47452,7 +51243,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The total bandwidth (in megabits per second) shared across the bare metal server network attachments or bare metal server network interfaces of a bare metal server with this profile. */
+  /**
+   * The total bandwidth (in megabits per second) shared across the bare metal server network attachments or bare metal
+   * server network interfaces of a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileBandwidthFixed extends BareMetalServerProfileBandwidth {
     /** The type for this profile field. */
     type: BareMetalServerProfileBandwidthFixed.Constants.Type | string;
@@ -47468,7 +51262,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total bandwidth range (in megabits per second) shared across the network attachments or network interfaces of a bare metal server with this profile. */
+  /**
+   * The permitted total bandwidth range (in megabits per second) shared across the network attachments or network
+   * interfaces of a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileBandwidthRange extends BareMetalServerProfileBandwidth {
     /** The default value for this profile field. */
     default: number;
@@ -47490,7 +51287,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The CPU core count for a bare metal server with this profile depends on its configuration. */
+  /**
+   * The CPU core count for a bare metal server with this profile depends on its configuration.
+   */
   export interface BareMetalServerProfileCPUCoreCountDependent extends BareMetalServerProfileCPUCoreCount {
     /** The type for this profile field. */
     type: BareMetalServerProfileCPUCoreCountDependent.Constants.Type | string;
@@ -47504,7 +51303,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted values for CPU cores for a bare metal server with this profile. */
+  /**
+   * The permitted values for CPU cores for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileCPUCoreCountEnum extends BareMetalServerProfileCPUCoreCount {
     /** The default value for this profile field. */
     default: number;
@@ -47522,7 +51323,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The CPU core count for a bare metal server with this profile. */
+  /**
+   * The CPU core count for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileCPUCoreCountFixed extends BareMetalServerProfileCPUCoreCount {
     /** The type for this profile field. */
     type: BareMetalServerProfileCPUCoreCountFixed.Constants.Type | string;
@@ -47538,7 +51341,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for the number of CPU cores for a bare metal server with this profile. */
+  /**
+   * The permitted range for the number of CPU cores for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileCPUCoreCountRange extends BareMetalServerProfileCPUCoreCount {
     /** The default value for this profile field. */
     default: number;
@@ -47560,7 +51365,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The CPU socket count for a bare metal server with this profile depends on its configuration. */
+  /**
+   * The CPU socket count for a bare metal server with this profile depends on its configuration.
+   */
   export interface BareMetalServerProfileCPUSocketCountDependent extends BareMetalServerProfileCPUSocketCount {
     /** The type for this profile field. */
     type: BareMetalServerProfileCPUSocketCountDependent.Constants.Type | string;
@@ -47574,7 +51381,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted values for CPU sockets for a bare metal server with this profile. */
+  /**
+   * The permitted values for CPU sockets for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileCPUSocketCountEnum extends BareMetalServerProfileCPUSocketCount {
     /** The default value for this profile field. */
     default: number;
@@ -47592,7 +51401,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of CPU sockets for a bare metal server with this profile. */
+  /**
+   * The number of CPU sockets for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileCPUSocketCountFixed extends BareMetalServerProfileCPUSocketCount {
     /** The type for this profile field. */
     type: BareMetalServerProfileCPUSocketCountFixed.Constants.Type | string;
@@ -47608,7 +51419,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for the number of CPU sockets for a bare metal server with this profile. */
+  /**
+   * The permitted range for the number of CPU sockets for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileCPUSocketCountRange extends BareMetalServerProfileCPUSocketCount {
     /** The default value for this profile field. */
     default: number;
@@ -47630,7 +51443,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of disks of this configuration for a bare metal server with this profile depends on its bare metal server configuration. */
+  /**
+   * The number of disks of this configuration for a bare metal server with this profile depends on its bare metal
+   * server configuration.
+   */
   export interface BareMetalServerProfileDiskQuantityDependent extends BareMetalServerProfileDiskQuantity {
     /** The type for this profile field. */
     type: BareMetalServerProfileDiskQuantityDependent.Constants.Type | string;
@@ -47644,7 +51460,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted the number of disks of this configuration for a bare metal server with this profile. */
+  /**
+   * The permitted the number of disks of this configuration for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileDiskQuantityEnum extends BareMetalServerProfileDiskQuantity {
     /** The default value for this profile field. */
     default: number;
@@ -47662,7 +51480,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of disks of this configuration for a bare metal server with this profile. */
+  /**
+   * The number of disks of this configuration for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileDiskQuantityFixed extends BareMetalServerProfileDiskQuantity {
     /** The type for this profile field. */
     type: BareMetalServerProfileDiskQuantityFixed.Constants.Type | string;
@@ -47678,7 +51498,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for the number of disks of this configuration for a bare metal server with this profile. */
+  /**
+   * The permitted range for the number of disks of this configuration for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileDiskQuantityRange extends BareMetalServerProfileDiskQuantity {
     /** The default value for this profile field. */
     default: number;
@@ -47700,7 +51522,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The disk size in GB (gigabytes) of this configuration for a bare metal server with this profile depends on its bare metal server configuration. */
+  /**
+   * The disk size in GB (gigabytes) of this configuration for a bare metal server with this profile depends on its bare
+   * metal server configuration.
+   */
   export interface BareMetalServerProfileDiskSizeDependent extends BareMetalServerProfileDiskSize {
     /** The type for this profile field. */
     type: BareMetalServerProfileDiskSizeDependent.Constants.Type | string;
@@ -47714,7 +51539,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted disk size in GB (gigabytes) of this configuration for a bare metal server with this profile. */
+  /**
+   * The permitted disk size in GB (gigabytes) of this configuration for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileDiskSizeEnum extends BareMetalServerProfileDiskSize {
     /** The default value for this profile field. */
     default: number;
@@ -47732,7 +51559,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The size of the disk in GB (gigabytes). */
+  /**
+   * The size of the disk in GB (gigabytes).
+   */
   export interface BareMetalServerProfileDiskSizeFixed extends BareMetalServerProfileDiskSize {
     /** The type for this profile field. */
     type: BareMetalServerProfileDiskSizeFixed.Constants.Type | string;
@@ -47748,7 +51577,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for the disk size of this configuration in GB (gigabytes) for a bare metal server with this profile. */
+  /**
+   * The permitted range for the disk size of this configuration in GB (gigabytes) for a bare metal server with this
+   * profile.
+   */
   export interface BareMetalServerProfileDiskSizeRange extends BareMetalServerProfileDiskSize {
     /** The default value for this profile field. */
     default: number;
@@ -47770,19 +51602,25 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerProfileIdentityByHref. */
+  /**
+   * BareMetalServerProfileIdentityByHref.
+   */
   export interface BareMetalServerProfileIdentityByHref extends BareMetalServerProfileIdentity {
     /** The URL for this bare metal server profile. */
     href: string;
   }
 
-  /** BareMetalServerProfileIdentityByName. */
+  /**
+   * BareMetalServerProfileIdentityByName.
+   */
   export interface BareMetalServerProfileIdentityByName extends BareMetalServerProfileIdentity {
     /** The name for this bare metal server profile. */
     name: string;
   }
 
-  /** The memory value for a bare metal server with this profile depends on its configuration. */
+  /**
+   * The memory value for a bare metal server with this profile depends on its configuration.
+   */
   export interface BareMetalServerProfileMemoryDependent extends BareMetalServerProfileMemory {
     /** The type for this profile field. */
     type: BareMetalServerProfileMemoryDependent.Constants.Type | string;
@@ -47796,7 +51634,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted memory values (in gibibytes) for a bare metal server with this profile. */
+  /**
+   * The permitted memory values (in gibibytes) for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileMemoryEnum extends BareMetalServerProfileMemory {
     /** The default value for this profile field. */
     default: number;
@@ -47814,7 +51654,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The memory (in gibibytes) for a bare metal server with this profile. */
+  /**
+   * The memory (in gibibytes) for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileMemoryFixed extends BareMetalServerProfileMemory {
     /** The type for this profile field. */
     type: BareMetalServerProfileMemoryFixed.Constants.Type | string;
@@ -47830,7 +51672,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted memory range (in gibibytes) for a bare metal server with this profile. */
+  /**
+   * The permitted memory range (in gibibytes) for a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileMemoryRange extends BareMetalServerProfileMemory {
     /** The default value for this profile field. */
     default: number;
@@ -47852,7 +51696,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of network attachments supported on a bare metal server with this profile is dependent on its configuration. */
+  /**
+   * The number of network attachments supported on a bare metal server with this profile is dependent on its
+   * configuration.
+   */
   export interface BareMetalServerProfileNetworkAttachmentCountDependent extends BareMetalServerProfileNetworkAttachmentCount {
     /** The type for this profile field. */
     type: BareMetalServerProfileNetworkAttachmentCountDependent.Constants.Type | string;
@@ -47866,7 +51713,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of network attachments supported on a bare metal server with this profile. */
+  /**
+   * The number of network attachments supported on a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileNetworkAttachmentCountRange extends BareMetalServerProfileNetworkAttachmentCount {
     /** The maximum value for this profile field. */
     max?: number;
@@ -47884,7 +51733,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of bare metal server network interfaces supported on a bare metal server with this profile is dependent on its configuration. */
+  /**
+   * The number of bare metal server network interfaces supported on a bare metal server with this profile is dependent
+   * on its configuration.
+   */
   export interface BareMetalServerProfileNetworkInterfaceCountDependent extends BareMetalServerProfileNetworkInterfaceCount {
     /** The type for this profile field. */
     type: BareMetalServerProfileNetworkInterfaceCountDependent.Constants.Type | string;
@@ -47898,7 +51750,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of bare metal server network interfaces supported on a bare metal server with this profile. */
+  /**
+   * The number of bare metal server network interfaces supported on a bare metal server with this profile.
+   */
   export interface BareMetalServerProfileNetworkInterfaceCountRange extends BareMetalServerProfileNetworkInterfaceCount {
     /** The maximum value for this profile field. */
     max?: number;
@@ -47916,7 +51770,9 @@ namespace VpcV1 {
     }
   }
 
-  /** BareMetalServerPrototypeBareMetalServerByNetworkAttachment. */
+  /**
+   * BareMetalServerPrototypeBareMetalServerByNetworkAttachment.
+   */
   export interface BareMetalServerPrototypeBareMetalServerByNetworkAttachment extends BareMetalServerPrototype {
     /** The additional network attachments to create for the bare metal server. */
     network_attachments?: BareMetalServerNetworkAttachmentPrototype[];
@@ -47924,7 +51780,9 @@ namespace VpcV1 {
     primary_network_attachment: BareMetalServerPrimaryNetworkAttachmentPrototype;
   }
 
-  /** BareMetalServerPrototypeBareMetalServerByNetworkInterface. */
+  /**
+   * BareMetalServerPrototypeBareMetalServerByNetworkInterface.
+   */
   export interface BareMetalServerPrototypeBareMetalServerByNetworkInterface extends BareMetalServerPrototype {
     /** The additional bare metal server network interfaces to create. */
     network_interfaces?: BareMetalServerNetworkInterfacePrototype[];
@@ -47932,13 +51790,17 @@ namespace VpcV1 {
     primary_network_interface: BareMetalServerPrimaryNetworkInterfacePrototype;
   }
 
-  /** CatalogOfferingIdentityCatalogOfferingByCRN. */
+  /**
+   * CatalogOfferingIdentityCatalogOfferingByCRN.
+   */
   export interface CatalogOfferingIdentityCatalogOfferingByCRN extends CatalogOfferingIdentity {
     /** The CRN for this [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering. */
     crn: string;
   }
 
-  /** CatalogOfferingVersionIdentityCatalogOfferingVersionByCRN. */
+  /**
+   * CatalogOfferingVersionIdentityCatalogOfferingVersionByCRN.
+   */
   export interface CatalogOfferingVersionIdentityCatalogOfferingVersionByCRN extends CatalogOfferingVersionIdentity {
     /** The CRN for this version of a
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering.
@@ -47946,7 +51808,9 @@ namespace VpcV1 {
     crn: string;
   }
 
-  /** CatalogOfferingVersionPlanIdentityCatalogOfferingVersionPlanByCRN. */
+  /**
+   * CatalogOfferingVersionPlanIdentityCatalogOfferingVersionPlanByCRN.
+   */
   export interface CatalogOfferingVersionPlanIdentityCatalogOfferingVersionPlanByCRN extends CatalogOfferingVersionPlanIdentity {
     /** The CRN for this
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering version's billing plan.
@@ -47954,66 +51818,246 @@ namespace VpcV1 {
     crn: string;
   }
 
-  /** CertificateInstanceIdentityByCRN. */
+  /**
+   * CertificateInstanceIdentityByCRN.
+   */
   export interface CertificateInstanceIdentityByCRN extends CertificateInstanceIdentity {
     /** The CRN for this certificate instance. */
     crn: string;
   }
 
-  /** CloudObjectStorageBucketIdentityByCRN. */
+  /**
+   * CloudObjectStorageBucketIdentityByCRN.
+   */
   export interface CloudObjectStorageBucketIdentityByCRN extends CloudObjectStorageBucketIdentity {
     /** The CRN of this Cloud Object Storage bucket. */
     crn: string;
   }
 
-  /** CloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName. */
+  /**
+   * CloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName.
+   */
   export interface CloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName extends CloudObjectStorageBucketIdentity {
     /** The globally unique name of this Cloud Object Storage bucket. */
     name: string;
   }
 
-  /** DNSInstanceIdentityByCRN. */
+  /**
+   * Identifies a cluster network subnet reserved IP by a unique property. Required if `subnet` is not specified. The
+   * cluster network subnet reserved IP must be currently unbound.
+   */
+  export interface ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContext extends ClusterNetworkInterfacePrimaryIPPrototype {
+  }
+
+  /**
+   * The prototype for a new cluster network subnet reserved IP. Requires `subnet` to be specified.
+   */
+  export interface ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPPrototypeClusterNetworkInterfacePrimaryIPContext extends ClusterNetworkInterfacePrimaryIPPrototype {
+    /** The IP address to reserve, which must not already be reserved on the subnet.
+     *
+     *  If unspecified, an available address on the subnet will automatically be selected.
+     */
+    address?: string;
+    /** Indicates whether this cluster network subnet reserved IP member will be automatically deleted when either
+     *  `target` is deleted, or the cluster network subnet reserved IP is unbound.
+     */
+    auto_delete?: boolean;
+    /** The name for this cluster network subnet reserved IP. The name must not be used by another reserved IP in
+     *  the cluster network subnet. Names starting with `ibm-` are reserved for provider-owned resources, and are not
+     *  allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
+     */
+    name?: string;
+  }
+
+  /**
+   * ClusterNetworkInterfaceTargetInstanceClusterNetworkAttachmentReferenceClusterNetworkInterfaceContext.
+   */
+  export interface ClusterNetworkInterfaceTargetInstanceClusterNetworkAttachmentReferenceClusterNetworkInterfaceContext extends ClusterNetworkInterfaceTarget {
+    /** The URL for this instance cluster network attachment. */
+    href: string;
+    /** The unique identifier for this instance cluster network attachment. */
+    id: string;
+    /** The name for this instance cluster network attachment. The name is unique across all network attachments for
+     *  the instance.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkInterfaceTargetInstanceClusterNetworkAttachmentReferenceClusterNetworkInterfaceContext.Constants.ResourceType | string;
+  }
+  export namespace ClusterNetworkInterfaceTargetInstanceClusterNetworkAttachmentReferenceClusterNetworkInterfaceContext {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        INSTANCE_CLUSTER_NETWORK_ATTACHMENT = 'instance_cluster_network_attachment',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkProfileIdentityByHref.
+   */
+  export interface ClusterNetworkProfileIdentityByHref extends ClusterNetworkProfileIdentity {
+    /** The URL for this cluster network profile. */
+    href: string;
+  }
+
+  /**
+   * ClusterNetworkProfileIdentityByName.
+   */
+  export interface ClusterNetworkProfileIdentityByName extends ClusterNetworkProfileIdentity {
+    /** The globally unique name for this cluster network profile. */
+    name: string;
+  }
+
+  /**
+   * ClusterNetworkSubnetIdentityByHref.
+   */
+  export interface ClusterNetworkSubnetIdentityByHref extends ClusterNetworkSubnetIdentity {
+    /** The URL for this cluster network subnet. */
+    href: string;
+  }
+
+  /**
+   * ClusterNetworkSubnetIdentityById.
+   */
+  export interface ClusterNetworkSubnetIdentityById extends ClusterNetworkSubnetIdentity {
+    /** The unique identifier for this cluster network subnet. */
+    id: string;
+  }
+
+  /**
+   * ClusterNetworkSubnetPrototypeClusterNetworkSubnetByIPv4CIDRBlockPrototype.
+   */
+  export interface ClusterNetworkSubnetPrototypeClusterNetworkSubnetByIPv4CIDRBlockPrototype extends ClusterNetworkSubnetPrototype {
+    /** The IPv4 range of the cluster network subnet, expressed in CIDR format. The prefix length of the cluster
+     *  network subnet's CIDR must be between `/8` (16,777,216 addresses) and `/29`
+     *  (8 addresses). The IPv4 range of the cluster network subnet's CIDR must be within the cluster network's
+     *  `subnet_prefixes`.
+     *
+     *  The range must not overlap with any of the following reserved address ranges:
+     *
+     *    - `127.0.0.0/8` (IPv4 loopback addresses)
+     *    - `169.254.0.0/16` (IPv4 link-local addresses)
+     *    - `224.0.0.0/4` (IPv4 multicast addresses).
+     */
+    ipv4_cidr_block: string;
+  }
+  export namespace ClusterNetworkSubnetPrototypeClusterNetworkSubnetByIPv4CIDRBlockPrototype {
+    export namespace Constants {
+      /** The IP version(s) to support for this cluster network subnet. */
+      export enum IpVersion {
+        IPV4 = 'ipv4',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetPrototypeClusterNetworkSubnetByTotalCountPrototype.
+   */
+  export interface ClusterNetworkSubnetPrototypeClusterNetworkSubnetByTotalCountPrototype extends ClusterNetworkSubnetPrototype {
+    /** The total number of IPv4 addresses required. Must be a power of 2.
+     *
+     *  A CIDR will be allocated from a subnet prefix in the cluster network that has an
+     *  `allocation_policy` of `auto`. There must be a subnet prefix that has a free CIDR range with at least this
+     *  number of addresses.
+     */
+    total_ipv4_address_count: number;
+  }
+  export namespace ClusterNetworkSubnetPrototypeClusterNetworkSubnetByTotalCountPrototype {
+    export namespace Constants {
+      /** The IP version(s) to support for this cluster network subnet. */
+      export enum IpVersion {
+        IPV4 = 'ipv4',
+      }
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetReservedIPTargetClusterNetworkInterfaceReferenceClusterNetworkSubnetReservedIPTargetContext.
+   */
+  export interface ClusterNetworkSubnetReservedIPTargetClusterNetworkInterfaceReferenceClusterNetworkSubnetReservedIPTargetContext extends ClusterNetworkSubnetReservedIPTarget {
+    /** If present, this property indicates the referenced resource has been deleted, and provides
+     *  some supplementary information.
+     */
+    deleted?: Deleted;
+    /** The URL for this cluster network interface. */
+    href: string;
+    /** The unique identifier for this cluster network interface. */
+    id: string;
+    /** The name for this cluster network interface. The name is unique across all interfaces in the cluster
+     *  network.
+     */
+    name: string;
+    /** The resource type. */
+    resource_type: ClusterNetworkSubnetReservedIPTargetClusterNetworkInterfaceReferenceClusterNetworkSubnetReservedIPTargetContext.Constants.ResourceType | string;
+  }
+  export namespace ClusterNetworkSubnetReservedIPTargetClusterNetworkInterfaceReferenceClusterNetworkSubnetReservedIPTargetContext {
+    export namespace Constants {
+      /** The resource type. */
+      export enum ResourceType {
+        CLUSTER_NETWORK_INTERFACE = 'cluster_network_interface',
+      }
+    }
+  }
+
+  /**
+   * DNSInstanceIdentityByCRN.
+   */
   export interface DNSInstanceIdentityByCRN extends DNSInstanceIdentity {
     /** The CRN for this DNS instance. */
     crn: string;
   }
 
-  /** DNSZoneIdentityById. */
+  /**
+   * DNSZoneIdentityById.
+   */
   export interface DNSZoneIdentityById extends DNSZoneIdentity {
     id: string;
   }
 
-  /** DedicatedHostGroupIdentityByCRN. */
+  /**
+   * DedicatedHostGroupIdentityByCRN.
+   */
   export interface DedicatedHostGroupIdentityByCRN extends DedicatedHostGroupIdentity {
     /** The CRN for this dedicated host group. */
     crn: string;
   }
 
-  /** DedicatedHostGroupIdentityByHref. */
+  /**
+   * DedicatedHostGroupIdentityByHref.
+   */
   export interface DedicatedHostGroupIdentityByHref extends DedicatedHostGroupIdentity {
     /** The URL for this dedicated host group. */
     href: string;
   }
 
-  /** DedicatedHostGroupIdentityById. */
+  /**
+   * DedicatedHostGroupIdentityById.
+   */
   export interface DedicatedHostGroupIdentityById extends DedicatedHostGroupIdentity {
     /** The unique identifier for this dedicated host group. */
     id: string;
   }
 
-  /** DedicatedHostProfileIdentityByHref. */
+  /**
+   * DedicatedHostProfileIdentityByHref.
+   */
   export interface DedicatedHostProfileIdentityByHref extends DedicatedHostProfileIdentity {
     /** The URL for this dedicated host profile. */
     href: string;
   }
 
-  /** DedicatedHostProfileIdentityByName. */
+  /**
+   * DedicatedHostProfileIdentityByName.
+   */
   export interface DedicatedHostProfileIdentityByName extends DedicatedHostProfileIdentity {
     /** The globally unique name for this dedicated host profile. */
     name: string;
   }
 
-  /** The memory value for a dedicated host with this profile depends on its configuration. */
+  /**
+   * The memory value for a dedicated host with this profile depends on its configuration.
+   */
   export interface DedicatedHostProfileMemoryDependent extends DedicatedHostProfileMemory {
     /** The type for this profile field. */
     type: DedicatedHostProfileMemoryDependent.Constants.Type | string;
@@ -48027,7 +52071,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted memory values (in gibibytes) for a dedicated host with this profile. */
+  /**
+   * The permitted memory values (in gibibytes) for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileMemoryEnum extends DedicatedHostProfileMemory {
     /** The default value for this profile field. */
     default: number;
@@ -48045,7 +52091,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The memory (in gibibytes) for a dedicated host with this profile. */
+  /**
+   * The memory (in gibibytes) for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileMemoryFixed extends DedicatedHostProfileMemory {
     /** The type for this profile field. */
     type: DedicatedHostProfileMemoryFixed.Constants.Type | string;
@@ -48061,7 +52109,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted memory range (in gibibytes) for a dedicated host with this profile. */
+  /**
+   * The permitted memory range (in gibibytes) for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileMemoryRange extends DedicatedHostProfileMemory {
     /** The default value for this profile field. */
     default: number;
@@ -48083,7 +52133,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The CPU socket count for a dedicated host with this profile depends on its configuration. */
+  /**
+   * The CPU socket count for a dedicated host with this profile depends on its configuration.
+   */
   export interface DedicatedHostProfileSocketDependent extends DedicatedHostProfileSocket {
     /** The type for this profile field. */
     type: DedicatedHostProfileSocketDependent.Constants.Type | string;
@@ -48097,7 +52149,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted values for CPU socket count for a dedicated host with this profile. */
+  /**
+   * The permitted values for CPU socket count for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileSocketEnum extends DedicatedHostProfileSocket {
     /** The default value for this profile field. */
     default: number;
@@ -48115,7 +52169,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The CPU socket count for a dedicated host with this profile. */
+  /**
+   * The CPU socket count for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileSocketFixed extends DedicatedHostProfileSocket {
     /** The type for this profile field. */
     type: DedicatedHostProfileSocketFixed.Constants.Type | string;
@@ -48131,7 +52187,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for CPU socket count for a dedicated host with this profile. */
+  /**
+   * The permitted range for CPU socket count for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileSocketRange extends DedicatedHostProfileSocket {
     /** The default value for this profile field. */
     default: number;
@@ -48153,7 +52211,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The VCPU count for a dedicated host with this profile depends on its configuration. */
+  /**
+   * The VCPU count for a dedicated host with this profile depends on its configuration.
+   */
   export interface DedicatedHostProfileVCPUDependent extends DedicatedHostProfileVCPU {
     /** The type for this profile field. */
     type: DedicatedHostProfileVCPUDependent.Constants.Type | string;
@@ -48167,7 +52227,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted values for VCPU count for a dedicated host with this profile. */
+  /**
+   * The permitted values for VCPU count for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileVCPUEnum extends DedicatedHostProfileVCPU {
     /** The default value for this profile field. */
     default: number;
@@ -48185,7 +52247,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The VCPU count for a dedicated host with this profile. */
+  /**
+   * The VCPU count for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileVCPUFixed extends DedicatedHostProfileVCPU {
     /** The type for this profile field. */
     type: DedicatedHostProfileVCPUFixed.Constants.Type | string;
@@ -48201,7 +52265,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for VCPU count for a dedicated host with this profile. */
+  /**
+   * The permitted range for VCPU count for a dedicated host with this profile.
+   */
   export interface DedicatedHostProfileVCPURange extends DedicatedHostProfileVCPU {
     /** The default value for this profile field. */
     default: number;
@@ -48223,20 +52289,26 @@ namespace VpcV1 {
     }
   }
 
-  /** DedicatedHostPrototypeDedicatedHostByGroup. */
+  /**
+   * DedicatedHostPrototypeDedicatedHostByGroup.
+   */
   export interface DedicatedHostPrototypeDedicatedHostByGroup extends DedicatedHostPrototype {
     /** The dedicated host group for this dedicated host. */
     group: DedicatedHostGroupIdentity;
   }
 
-  /** DedicatedHostPrototypeDedicatedHostByZone. */
+  /**
+   * DedicatedHostPrototypeDedicatedHostByZone.
+   */
   export interface DedicatedHostPrototypeDedicatedHostByZone extends DedicatedHostPrototype {
     group?: DedicatedHostGroupPrototypeDedicatedHostByZoneContext;
     /** The zone this dedicated host will reside in. */
     zone: ZoneIdentity;
   }
 
-  /** EncryptionKeyIdentityByCRN. */
+  /**
+   * EncryptionKeyIdentityByCRN.
+   */
   export interface EncryptionKeyIdentityByCRN extends EncryptionKeyIdentity {
     /** The CRN of the [Key Protect Root
      *  Key](https://cloud.ibm.com/docs/key-protect?topic=key-protect-getting-started-tutorial) or [Hyper Protect Crypto
@@ -48245,11 +52317,15 @@ namespace VpcV1 {
     crn: string;
   }
 
-  /** Identifies a reserved IP by a unique property. */
+  /**
+   * Identifies a reserved IP by a unique property.
+   */
   export interface EndpointGatewayReservedIPReservedIPIdentity extends EndpointGatewayReservedIP {
   }
 
-  /** EndpointGatewayReservedIPReservedIPPrototypeTargetContext. */
+  /**
+   * EndpointGatewayReservedIPReservedIPPrototypeTargetContext.
+   */
   export interface EndpointGatewayReservedIPReservedIPPrototypeTargetContext extends EndpointGatewayReservedIP {
     /** The IP address to reserve, which must not already be reserved on the subnet.
      *
@@ -48269,7 +52345,9 @@ namespace VpcV1 {
     subnet: SubnetIdentity;
   }
 
-  /** EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypePrivatePathServiceGatewayPrototype. */
+  /**
+   * EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypePrivatePathServiceGatewayPrototype.
+   */
   export interface EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypePrivatePathServiceGatewayPrototype extends EndpointGatewayTargetPrototype {
     /** The CRN for this private path service gateway. */
     crn: string;
@@ -48285,7 +52363,9 @@ namespace VpcV1 {
     }
   }
 
-  /** EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypeProviderCloudServicePrototype. */
+  /**
+   * EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypeProviderCloudServicePrototype.
+   */
   export interface EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypeProviderCloudServicePrototype extends EndpointGatewayTargetPrototype {
     /** The CRN for this provider cloud service, or the CRN for the user's instance of a provider cloud service. */
     crn: string;
@@ -48301,7 +52381,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The name of this provider infrastructure service. */
+  /**
+   * The name of this provider infrastructure service.
+   */
   export interface EndpointGatewayTargetPrototypeEndpointGatewayTargetResourceTypeProviderInfrastructureServicePrototype extends EndpointGatewayTargetPrototype {
     /** The name of a provider infrastructure service. Must be:
      *  - `ibm-ntp-server`: An NTP (Network Time Protocol) server provided by IBM.
@@ -48319,7 +52401,9 @@ namespace VpcV1 {
     }
   }
 
-  /** EndpointGatewayTargetPrivatePathServiceGatewayReference. */
+  /**
+   * EndpointGatewayTargetPrivatePathServiceGatewayReference.
+   */
   export interface EndpointGatewayTargetPrivatePathServiceGatewayReference extends EndpointGatewayTarget {
     /** The CRN for this private path service gateway. */
     crn: string;
@@ -48351,7 +52435,9 @@ namespace VpcV1 {
     }
   }
 
-  /** EndpointGatewayTargetProviderCloudServiceReference. */
+  /**
+   * EndpointGatewayTargetProviderCloudServiceReference.
+   */
   export interface EndpointGatewayTargetProviderCloudServiceReference extends EndpointGatewayTarget {
     /** The CRN for this provider cloud service, or the CRN for the user's instance of a provider cloud service. */
     crn: string;
@@ -48367,7 +52453,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The name of this provider infrastructure service. */
+  /**
+   * The name of this provider infrastructure service.
+   */
   export interface EndpointGatewayTargetProviderInfrastructureServiceReference extends EndpointGatewayTarget {
     /** The name of a provider infrastructure service. Must be:
      *  - `ibm-ntp-server`: An NTP (Network Time Protocol) server provided by IBM.
@@ -48385,7 +52473,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FloatingIPPrototypeFloatingIPByTarget. */
+  /**
+   * FloatingIPPrototypeFloatingIPByTarget.
+   */
   export interface FloatingIPPrototypeFloatingIPByTarget extends FloatingIPPrototype {
     /** The target resource to bind this floating IP to.
      *
@@ -48399,37 +52489,53 @@ namespace VpcV1 {
     target: FloatingIPTargetPrototype;
   }
 
-  /** FloatingIPPrototypeFloatingIPByZone. */
+  /**
+   * FloatingIPPrototypeFloatingIPByZone.
+   */
   export interface FloatingIPPrototypeFloatingIPByZone extends FloatingIPPrototype {
     /** The zone this floating IP will reside in. */
     zone: ZoneIdentity;
   }
 
-  /** Identifies a bare metal server network interface by a unique property. */
+  /**
+   * Identifies a bare metal server network interface by a unique property.
+   */
   export interface FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentity extends FloatingIPTargetPatch {
   }
 
-  /** Identifies an instance network interface by a unique property. */
+  /**
+   * Identifies an instance network interface by a unique property.
+   */
   export interface FloatingIPTargetPatchNetworkInterfaceIdentity extends FloatingIPTargetPatch {
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface FloatingIPTargetPatchVirtualNetworkInterfaceIdentity extends FloatingIPTargetPatch {
   }
 
-  /** Identifies a bare metal server network interface by a unique property. */
+  /**
+   * Identifies a bare metal server network interface by a unique property.
+   */
   export interface FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentity extends FloatingIPTargetPrototype {
   }
 
-  /** Identifies an instance network interface by a unique property. */
+  /**
+   * Identifies an instance network interface by a unique property.
+   */
   export interface FloatingIPTargetPrototypeNetworkInterfaceIdentity extends FloatingIPTargetPrototype {
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentity extends FloatingIPTargetPrototype {
   }
 
-  /** FloatingIPTargetBareMetalServerNetworkInterfaceReference. */
+  /**
+   * FloatingIPTargetBareMetalServerNetworkInterfaceReference.
+   */
   export interface FloatingIPTargetBareMetalServerNetworkInterfaceReference extends FloatingIPTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -48465,7 +52571,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FloatingIPTargetNetworkInterfaceReference. */
+  /**
+   * FloatingIPTargetNetworkInterfaceReference.
+   */
   export interface FloatingIPTargetNetworkInterfaceReference extends FloatingIPTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -48501,7 +52609,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FloatingIPTargetPublicGatewayReference. */
+  /**
+   * FloatingIPTargetPublicGatewayReference.
+   */
   export interface FloatingIPTargetPublicGatewayReference extends FloatingIPTarget {
     /** The CRN for this public gateway. */
     crn: string;
@@ -48527,7 +52637,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FloatingIPTargetVirtualNetworkInterfaceReference. */
+  /**
+   * FloatingIPTargetVirtualNetworkInterfaceReference.
+   */
   export interface FloatingIPTargetVirtualNetworkInterfaceReference extends FloatingIPTarget {
     /** The CRN for this virtual network interface. */
     crn: string;
@@ -48559,31 +52671,45 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a virtual server instance by a unique property. */
+  /**
+   * Identifies a virtual server instance by a unique property.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceIdentity extends FlowLogCollectorTargetPrototype {
   }
 
-  /** Identifies an instance network attachment by a unique property. */
+  /**
+   * Identifies an instance network attachment by a unique property.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentity extends FlowLogCollectorTargetPrototype {
   }
 
-  /** Identifies an instance network interface by a unique property. */
+  /**
+   * Identifies an instance network interface by a unique property.
+   */
   export interface FlowLogCollectorTargetPrototypeNetworkInterfaceIdentity extends FlowLogCollectorTargetPrototype {
   }
 
-  /** Identifies a subnet by a unique property. */
+  /**
+   * Identifies a subnet by a unique property.
+   */
   export interface FlowLogCollectorTargetPrototypeSubnetIdentity extends FlowLogCollectorTargetPrototype {
   }
 
-  /** Identifies a VPC by a unique property. */
+  /**
+   * Identifies a VPC by a unique property.
+   */
   export interface FlowLogCollectorTargetPrototypeVPCIdentity extends FlowLogCollectorTargetPrototype {
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentity extends FlowLogCollectorTargetPrototype {
   }
 
-  /** FlowLogCollectorTargetInstanceNetworkAttachmentReference. */
+  /**
+   * FlowLogCollectorTargetInstanceNetworkAttachmentReference.
+   */
   export interface FlowLogCollectorTargetInstanceNetworkAttachmentReference extends FlowLogCollectorTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -48615,7 +52741,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FlowLogCollectorTargetInstanceReference. */
+  /**
+   * FlowLogCollectorTargetInstanceReference.
+   */
   export interface FlowLogCollectorTargetInstanceReference extends FlowLogCollectorTarget {
     /** The CRN for this virtual server instance. */
     crn: string;
@@ -48633,7 +52761,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** FlowLogCollectorTargetNetworkInterfaceReferenceTargetContext. */
+  /**
+   * FlowLogCollectorTargetNetworkInterfaceReferenceTargetContext.
+   */
   export interface FlowLogCollectorTargetNetworkInterfaceReferenceTargetContext extends FlowLogCollectorTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -48668,7 +52798,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FlowLogCollectorTargetSubnetReference. */
+  /**
+   * FlowLogCollectorTargetSubnetReference.
+   */
   export interface FlowLogCollectorTargetSubnetReference extends FlowLogCollectorTarget {
     /** The CRN for this subnet. */
     crn: string;
@@ -48694,7 +52826,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FlowLogCollectorTargetVPCReference. */
+  /**
+   * FlowLogCollectorTargetVPCReference.
+   */
   export interface FlowLogCollectorTargetVPCReference extends FlowLogCollectorTarget {
     /** The CRN for this VPC. */
     crn: string;
@@ -48720,7 +52854,9 @@ namespace VpcV1 {
     }
   }
 
-  /** FlowLogCollectorTargetVirtualNetworkInterfaceReferenceAttachmentContext. */
+  /**
+   * FlowLogCollectorTargetVirtualNetworkInterfaceReferenceAttachmentContext.
+   */
   export interface FlowLogCollectorTargetVirtualNetworkInterfaceReferenceAttachmentContext extends FlowLogCollectorTarget {
     /** The CRN for this virtual network interface. */
     crn: string;
@@ -48744,25 +52880,33 @@ namespace VpcV1 {
     }
   }
 
-  /** ImageIdentityByCRN. */
+  /**
+   * ImageIdentityByCRN.
+   */
   export interface ImageIdentityByCRN extends ImageIdentity {
     /** The CRN for this image. */
     crn: string;
   }
 
-  /** ImageIdentityByHref. */
+  /**
+   * ImageIdentityByHref.
+   */
   export interface ImageIdentityByHref extends ImageIdentity {
     /** The URL for this image. */
     href: string;
   }
 
-  /** ImageIdentityById. */
+  /**
+   * ImageIdentityById.
+   */
   export interface ImageIdentityById extends ImageIdentity {
     /** The unique identifier for this image. */
     id: string;
   }
 
-  /** ImagePrototypeImageByFile. */
+  /**
+   * ImagePrototypeImageByFile.
+   */
   export interface ImagePrototypeImageByFile extends ImagePrototype {
     /** A base64-encoded, encrypted representation of the key that was used to encrypt the data for this image.
      *
@@ -48791,7 +52935,9 @@ namespace VpcV1 {
     operating_system: OperatingSystemIdentity;
   }
 
-  /** ImagePrototypeImageBySourceVolume. */
+  /**
+   * ImagePrototypeImageBySourceVolume.
+   */
   export interface ImagePrototypeImageBySourceVolume extends ImagePrototype {
     /** The root key used to wrap the system-generated data encryption key for the image.
      *
@@ -48808,7 +52954,9 @@ namespace VpcV1 {
     source_volume: VolumeIdentity;
   }
 
-  /** InstanceCatalogOfferingPrototypeCatalogOfferingByOffering. */
+  /**
+   * InstanceCatalogOfferingPrototypeCatalogOfferingByOffering.
+   */
   export interface InstanceCatalogOfferingPrototypeCatalogOfferingByOffering extends InstanceCatalogOfferingPrototype {
     /** Identifies a [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user)
      *  offering by a unique property.
@@ -48816,7 +52964,9 @@ namespace VpcV1 {
     offering: CatalogOfferingIdentity;
   }
 
-  /** InstanceCatalogOfferingPrototypeCatalogOfferingByVersion. */
+  /**
+   * InstanceCatalogOfferingPrototypeCatalogOfferingByVersion.
+   */
   export interface InstanceCatalogOfferingPrototypeCatalogOfferingByVersion extends InstanceCatalogOfferingPrototype {
     /** Identifies a version of a
      *  [catalog](https://cloud.ibm.com/docs/account?topic=account-restrict-by-user) offering by a
@@ -48825,11 +52975,67 @@ namespace VpcV1 {
     version: CatalogOfferingVersionIdentity;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototype. */
+  /**
+   * InstanceClusterNetworkAttachmentBeforePrototypeInstanceClusterNetworkAttachmentIdentityByHref.
+   */
+  export interface InstanceClusterNetworkAttachmentBeforePrototypeInstanceClusterNetworkAttachmentIdentityByHref extends InstanceClusterNetworkAttachmentBeforePrototype {
+    /** The URL for this instance cluster network attachment. */
+    href: string;
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentBeforePrototypeInstanceClusterNetworkAttachmentIdentityById.
+   */
+  export interface InstanceClusterNetworkAttachmentBeforePrototypeInstanceClusterNetworkAttachmentIdentityById extends InstanceClusterNetworkAttachmentBeforePrototype {
+    /** The unique identifier for this instance cluster network attachment. */
+    id: string;
+  }
+
+  /**
+   * Identifies a cluster network interface by a unique property.
+   */
+  export interface InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentity extends InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterface {
+  }
+
+  /**
+   * The cluster network interface for this target.
+   */
+  export interface InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceInstanceClusterNetworkInterfacePrototypeInstanceClusterNetworkAttachment extends InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterface {
+    /** Indicates whether this cluster network interface will be automatically deleted when `target` is deleted. */
+    auto_delete?: boolean;
+    /** The name for this cluster network interface. The name must not be used by another interface in the cluster
+     *  network. Names beginning with `ibm-` are reserved for provider-owned resources, and are not allowed. If
+     *  unspecified, the name will be a hyphenated list of randomly-selected words.
+     */
+    name?: string;
+    /** The primary IP address to bind to the cluster network interface. May be either
+     *  a cluster network subnet reserved IP identity, or a cluster network subnet reserved IP
+     *  prototype object which will be used to create a new cluster network subnet reserved IP.
+     *
+     *  If a cluster network subnet reserved IP identity is provided, the specified cluster
+     *  network subnet reserved IP must be unbound.
+     *
+     *  If a cluster network subnet reserved IP prototype object with an address is provided,
+     *  the address must be available on the cluster network interface's cluster network
+     *  subnet. If no address is specified, an available address on the cluster network subnet
+     *  will be automatically selected and reserved.
+     */
+    primary_ip?: ClusterNetworkInterfacePrimaryIPPrototype;
+    /** The associated cluster network subnet. Required if `primary_ip` does not specify a
+     *  cluster network subnet reserved IP identity.
+     */
+    subnet?: ClusterNetworkSubnetIdentity;
+  }
+
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototype.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototype extends InstanceGroupManagerActionPrototype {
   }
 
-  /** InstanceGroupManagerActionScheduledAction. */
+  /**
+   * InstanceGroupManagerActionScheduledAction.
+   */
   export interface InstanceGroupManagerActionScheduledAction extends InstanceGroupManagerAction {
     /** The type of action for the instance group. */
     action_type: InstanceGroupManagerActionScheduledAction.Constants.ActionType | string;
@@ -48865,7 +53071,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerAutoScale. */
+  /**
+   * InstanceGroupManagerAutoScale.
+   */
   export interface InstanceGroupManagerAutoScale extends InstanceGroupManager {
     /** The time window in seconds to aggregate metrics prior to evaluation. */
     aggregation_window: number;
@@ -48889,7 +53097,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype. */
+  /**
+   * InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype.
+   */
   export interface InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype extends InstanceGroupManagerPolicyPrototype {
     /** The type of metric to be evaluated. */
     metric_type: InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype.Constants.MetricType | string;
@@ -48914,7 +53124,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerPolicyInstanceGroupManagerTargetPolicy. */
+  /**
+   * InstanceGroupManagerPolicyInstanceGroupManagerTargetPolicy.
+   */
   export interface InstanceGroupManagerPolicyInstanceGroupManagerTargetPolicy extends InstanceGroupManagerPolicy {
     /** The type of metric to be evaluated
      *
@@ -48947,7 +53159,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerPrototypeInstanceGroupManagerAutoScalePrototype. */
+  /**
+   * InstanceGroupManagerPrototypeInstanceGroupManagerAutoScalePrototype.
+   */
   export interface InstanceGroupManagerPrototypeInstanceGroupManagerAutoScalePrototype extends InstanceGroupManagerPrototype {
     /** The time window in seconds to aggregate metrics prior to evaluation. */
     aggregation_window?: number;
@@ -48969,7 +53183,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerPrototypeInstanceGroupManagerScheduledPrototype. */
+  /**
+   * InstanceGroupManagerPrototypeInstanceGroupManagerScheduledPrototype.
+   */
   export interface InstanceGroupManagerPrototypeInstanceGroupManagerScheduledPrototype extends InstanceGroupManagerPrototype {
     /** The type of instance group manager. */
     manager_type: InstanceGroupManagerPrototypeInstanceGroupManagerScheduledPrototype.Constants.ManagerType | string;
@@ -48983,7 +53199,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerScheduled. */
+  /**
+   * InstanceGroupManagerScheduled.
+   */
   export interface InstanceGroupManagerScheduled extends InstanceGroupManager {
     /** The actions of the instance group manager. */
     actions: InstanceGroupManagerActionReference[];
@@ -48999,7 +53217,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerScheduledActionManagerAutoScale. */
+  /**
+   * InstanceGroupManagerScheduledActionManagerAutoScale.
+   */
   export interface InstanceGroupManagerScheduledActionManagerAutoScale extends InstanceGroupManagerScheduledActionManager {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -49017,7 +53237,11 @@ namespace VpcV1 {
     min_membership_count?: number;
   }
 
-  /** The auto scale manager to update, and one or more properties to be updated. Either `id` or `href` must be specified, in addition to at least one of `min_membership_count` and `max_membership_count`. */
+  /**
+   * The auto scale manager to update, and one or more properties to be updated. Either `id` or `href` must be
+   * specified, in addition to at least one of `min_membership_count` and
+   * `max_membership_count`.
+   */
   export interface InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototype extends InstanceGroupManagerScheduledActionManagerPrototype {
     /** The desired maximum number of instance group members at the scheduled time. */
     max_membership_count?: number;
@@ -49025,11 +53249,15 @@ namespace VpcV1 {
     min_membership_count?: number;
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity extends InstanceNetworkAttachmentPrototypeVirtualNetworkInterface {
   }
 
-  /** The virtual network interface for this target. */
+  /**
+   * The virtual network interface for this target.
+   */
   export interface InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfacePrototypeInstanceNetworkAttachmentContext extends InstanceNetworkAttachmentPrototypeVirtualNetworkInterface {
     /** Indicates whether source IP spoofing is allowed on this interface. If `false`, source IP spoofing is
      *  prevented on this interface. If `true`, source IP spoofing is allowed on this interface.
@@ -49111,39 +53339,55 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePatchProfileInstanceProfileIdentityByHref. */
+  /**
+   * InstancePatchProfileInstanceProfileIdentityByHref.
+   */
   export interface InstancePatchProfileInstanceProfileIdentityByHref extends InstancePatchProfile {
     /** The URL for this virtual server instance profile. */
     href: string;
   }
 
-  /** InstancePatchProfileInstanceProfileIdentityByName. */
+  /**
+   * InstancePatchProfileInstanceProfileIdentityByName.
+   */
   export interface InstancePatchProfileInstanceProfileIdentityByName extends InstancePatchProfile {
     /** The globally unique name for this virtual server instance profile. */
     name: string;
   }
 
-  /** Identifies a dedicated host group by a unique property. */
+  /**
+   * Identifies a dedicated host group by a unique property.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostGroupIdentity extends InstancePlacementTargetPatch {
   }
 
-  /** Identifies a dedicated host by a unique property. */
+  /**
+   * Identifies a dedicated host by a unique property.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostIdentity extends InstancePlacementTargetPatch {
   }
 
-  /** Identifies a dedicated host group by a unique property. */
+  /**
+   * Identifies a dedicated host group by a unique property.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostGroupIdentity extends InstancePlacementTargetPrototype {
   }
 
-  /** Identifies a dedicated host by a unique property. */
+  /**
+   * Identifies a dedicated host by a unique property.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostIdentity extends InstancePlacementTargetPrototype {
   }
 
-  /** Identifies a placement group by a unique property. */
+  /**
+   * Identifies a placement group by a unique property.
+   */
   export interface InstancePlacementTargetPrototypePlacementGroupIdentity extends InstancePlacementTargetPrototype {
   }
 
-  /** InstancePlacementTargetDedicatedHostGroupReference. */
+  /**
+   * InstancePlacementTargetDedicatedHostGroupReference.
+   */
   export interface InstancePlacementTargetDedicatedHostGroupReference extends InstancePlacementTarget {
     /** The CRN for this dedicated host group. */
     crn: string;
@@ -49169,7 +53413,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePlacementTargetDedicatedHostReference. */
+  /**
+   * InstancePlacementTargetDedicatedHostReference.
+   */
   export interface InstancePlacementTargetDedicatedHostReference extends InstancePlacementTarget {
     /** The CRN for this dedicated host. */
     crn: string;
@@ -49195,7 +53441,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePlacementTargetPlacementGroupReference. */
+  /**
+   * InstancePlacementTargetPlacementGroupReference.
+   */
   export interface InstancePlacementTargetPlacementGroupReference extends InstancePlacementTarget {
     /** The CRN for this placement group. */
     crn: string;
@@ -49221,7 +53469,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The total bandwidth shared across the network attachments or network interfaces and storage volumes of an instance with this profile depends on its configuration. */
+  /**
+   * The total bandwidth shared across the network attachments or network interfaces and storage volumes of an instance
+   * with this profile depends on its configuration.
+   */
   export interface InstanceProfileBandwidthDependent extends InstanceProfileBandwidth {
     /** The type for this profile field. */
     type: InstanceProfileBandwidthDependent.Constants.Type | string;
@@ -49235,7 +53486,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total bandwidth values (in megabits per second) shared across the network attachments or network interfaces and storage volumes of an instance with this profile. */
+  /**
+   * The permitted total bandwidth values (in megabits per second) shared across the network attachments or network
+   * interfaces and storage volumes of an instance with this profile.
+   */
   export interface InstanceProfileBandwidthEnum extends InstanceProfileBandwidth {
     /** The default value for this profile field. */
     default: number;
@@ -49253,7 +53507,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The total bandwidth (in megabits per second) shared across the network attachments or network interfaces and storage volumes of an instance with this profile. */
+  /**
+   * The total bandwidth (in megabits per second) shared across the network attachments or network interfaces and
+   * storage volumes of an instance with this profile.
+   */
   export interface InstanceProfileBandwidthFixed extends InstanceProfileBandwidth {
     /** The type for this profile field. */
     type: InstanceProfileBandwidthFixed.Constants.Type | string;
@@ -49269,7 +53526,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total bandwidth range (in megabits per second) shared across the network attachments or network interfaces and storage volumes of an instance with this profile. */
+  /**
+   * The permitted total bandwidth range (in megabits per second) shared across the network attachments or network
+   * interfaces and storage volumes of an instance with this profile.
+   */
   export interface InstanceProfileBandwidthRange extends InstanceProfileBandwidth {
     /** The default value for this profile field. */
     default: number;
@@ -49291,7 +53551,66 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of disks of this configuration for an instance with this profile depends on its instance configuration. */
+  /**
+   * The number of cluster network attachments supported on an instance with this profile is dependent on its
+   * configuration.
+   */
+  export interface InstanceProfileClusterNetworkAttachmentCountDependent extends InstanceProfileClusterNetworkAttachmentCount {
+    /** The type for this profile field. */
+    type: InstanceProfileClusterNetworkAttachmentCountDependent.Constants.Type | string;
+  }
+  export namespace InstanceProfileClusterNetworkAttachmentCountDependent {
+    export namespace Constants {
+      /** The type for this profile field. */
+      export enum Type {
+        DEPENDENT = 'dependent',
+      }
+    }
+  }
+
+  /**
+   * The permitted values for cluster network attachment count for an instance with this profile.
+   */
+  export interface InstanceProfileClusterNetworkAttachmentCountEnum extends InstanceProfileClusterNetworkAttachmentCount {
+    default?: number;
+    /** The type for this profile field. */
+    type: InstanceProfileClusterNetworkAttachmentCountEnum.Constants.Type | string;
+    /** The permitted values for this profile field. */
+    values: number[];
+  }
+  export namespace InstanceProfileClusterNetworkAttachmentCountEnum {
+    export namespace Constants {
+      /** The type for this profile field. */
+      export enum Type {
+        ENUM = 'enum',
+      }
+    }
+  }
+
+  /**
+   * The number of network attachments supported on an instance with this profile.
+   */
+  export interface InstanceProfileClusterNetworkAttachmentCountRange extends InstanceProfileClusterNetworkAttachmentCount {
+    /** The maximum value for this profile field. */
+    max?: number;
+    /** The minimum value for this profile field. */
+    min?: number;
+    step?: number;
+    /** The type for this profile field. */
+    type: InstanceProfileClusterNetworkAttachmentCountRange.Constants.Type | string;
+  }
+  export namespace InstanceProfileClusterNetworkAttachmentCountRange {
+    export namespace Constants {
+      /** The type for this profile field. */
+      export enum Type {
+        RANGE = 'range',
+      }
+    }
+  }
+
+  /**
+   * The number of disks of this configuration for an instance with this profile depends on its instance configuration.
+   */
   export interface InstanceProfileDiskQuantityDependent extends InstanceProfileDiskQuantity {
     /** The type for this profile field. */
     type: InstanceProfileDiskQuantityDependent.Constants.Type | string;
@@ -49305,7 +53624,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted the number of disks of this configuration for an instance with this profile. */
+  /**
+   * The permitted the number of disks of this configuration for an instance with this profile.
+   */
   export interface InstanceProfileDiskQuantityEnum extends InstanceProfileDiskQuantity {
     /** The default value for this profile field. */
     default: number;
@@ -49323,7 +53644,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of disks of this configuration for an instance with this profile. */
+  /**
+   * The number of disks of this configuration for an instance with this profile.
+   */
   export interface InstanceProfileDiskQuantityFixed extends InstanceProfileDiskQuantity {
     /** The type for this profile field. */
     type: InstanceProfileDiskQuantityFixed.Constants.Type | string;
@@ -49339,7 +53662,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for the number of disks of this configuration for an instance with this profile. */
+  /**
+   * The permitted range for the number of disks of this configuration for an instance with this profile.
+   */
   export interface InstanceProfileDiskQuantityRange extends InstanceProfileDiskQuantity {
     /** The default value for this profile field. */
     default: number;
@@ -49361,7 +53686,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The disk size in GB (gigabytes) of this configuration for an instance with this profile depends on its instance configuration. */
+  /**
+   * The disk size in GB (gigabytes) of this configuration for an instance with this profile depends on its instance
+   * configuration.
+   */
   export interface InstanceProfileDiskSizeDependent extends InstanceProfileDiskSize {
     /** The type for this profile field. */
     type: InstanceProfileDiskSizeDependent.Constants.Type | string;
@@ -49375,7 +53703,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted disk size in GB (gigabytes) of this configuration for an instance with this profile. */
+  /**
+   * The permitted disk size in GB (gigabytes) of this configuration for an instance with this profile.
+   */
   export interface InstanceProfileDiskSizeEnum extends InstanceProfileDiskSize {
     /** The default value for this profile field. */
     default: number;
@@ -49393,7 +53723,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The size of the disk in GB (gigabytes). */
+  /**
+   * The size of the disk in GB (gigabytes).
+   */
   export interface InstanceProfileDiskSizeFixed extends InstanceProfileDiskSize {
     /** The type for this profile field. */
     type: InstanceProfileDiskSizeFixed.Constants.Type | string;
@@ -49409,7 +53741,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for the disk size of this configuration in GB (gigabytes) for an instance with this profile. */
+  /**
+   * The permitted range for the disk size of this configuration in GB (gigabytes) for an instance with this profile.
+   */
   export interface InstanceProfileDiskSizeRange extends InstanceProfileDiskSize {
     /** The default value for this profile field. */
     default: number;
@@ -49431,7 +53765,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The GPU count for an instance with this profile depends on its configuration. */
+  /**
+   * The GPU count for an instance with this profile depends on its configuration.
+   */
   export interface InstanceProfileGPUDependent extends InstanceProfileGPU {
     /** The type for this profile field. */
     type: InstanceProfileGPUDependent.Constants.Type | string;
@@ -49445,7 +53781,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted GPU count values for an instance with this profile. */
+  /**
+   * The permitted GPU count values for an instance with this profile.
+   */
   export interface InstanceProfileGPUEnum extends InstanceProfileGPU {
     /** The default value for this profile field. */
     default: number;
@@ -49463,7 +53801,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The GPU count for an instance with this profile. */
+  /**
+   * The GPU count for an instance with this profile.
+   */
   export interface InstanceProfileGPUFixed extends InstanceProfileGPU {
     /** The type for this profile field. */
     type: InstanceProfileGPUFixed.Constants.Type | string;
@@ -49479,7 +53819,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The overall GPU memory value for an instance with this profile depends on its configuration. */
+  /**
+   * The overall GPU memory value for an instance with this profile depends on its configuration.
+   */
   export interface InstanceProfileGPUMemoryDependent extends InstanceProfileGPUMemory {
     /** The type for this profile field. */
     type: InstanceProfileGPUMemoryDependent.Constants.Type | string;
@@ -49493,7 +53835,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted overall GPU memory values in GiB (gibibytes) for an instance with this profile. */
+  /**
+   * The permitted overall GPU memory values in GiB (gibibytes) for an instance with this profile.
+   */
   export interface InstanceProfileGPUMemoryEnum extends InstanceProfileGPUMemory {
     /** The default value for this profile field. */
     default: number;
@@ -49511,7 +53855,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The overall GPU memory in GiB (gibibytes) for an instance with this profile. */
+  /**
+   * The overall GPU memory in GiB (gibibytes) for an instance with this profile.
+   */
   export interface InstanceProfileGPUMemoryFixed extends InstanceProfileGPUMemory {
     /** The type for this profile field. */
     type: InstanceProfileGPUMemoryFixed.Constants.Type | string;
@@ -49527,7 +53873,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted overall GPU memory range in GiB (gibibytes) for an instance with this profile. */
+  /**
+   * The permitted overall GPU memory range in GiB (gibibytes) for an instance with this profile.
+   */
   export interface InstanceProfileGPUMemoryRange extends InstanceProfileGPUMemory {
     /** The default value for this profile field. */
     default: number;
@@ -49549,7 +53897,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted GPU count range for an instance with this profile. */
+  /**
+   * The permitted GPU count range for an instance with this profile.
+   */
   export interface InstanceProfileGPURange extends InstanceProfileGPU {
     /** The default value for this profile field. */
     default: number;
@@ -49571,19 +53921,25 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceProfileIdentityByHref. */
+  /**
+   * InstanceProfileIdentityByHref.
+   */
   export interface InstanceProfileIdentityByHref extends InstanceProfileIdentity {
     /** The URL for this virtual server instance profile. */
     href: string;
   }
 
-  /** InstanceProfileIdentityByName. */
+  /**
+   * InstanceProfileIdentityByName.
+   */
   export interface InstanceProfileIdentityByName extends InstanceProfileIdentity {
     /** The globally unique name for this virtual server instance profile. */
     name: string;
   }
 
-  /** The memory value for an instance with this profile depends on its configuration. */
+  /**
+   * The memory value for an instance with this profile depends on its configuration.
+   */
   export interface InstanceProfileMemoryDependent extends InstanceProfileMemory {
     /** The type for this profile field. */
     type: InstanceProfileMemoryDependent.Constants.Type | string;
@@ -49597,7 +53953,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted memory values (in gibibytes) for an instance with this profile. */
+  /**
+   * The permitted memory values (in gibibytes) for an instance with this profile.
+   */
   export interface InstanceProfileMemoryEnum extends InstanceProfileMemory {
     /** The default value for this profile field. */
     default: number;
@@ -49615,7 +53973,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The memory (in gibibytes) for an instance with this profile. */
+  /**
+   * The memory (in gibibytes) for an instance with this profile.
+   */
   export interface InstanceProfileMemoryFixed extends InstanceProfileMemory {
     /** The type for this profile field. */
     type: InstanceProfileMemoryFixed.Constants.Type | string;
@@ -49631,7 +53991,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted memory range (in gibibytes) for an instance with this profile. */
+  /**
+   * The permitted memory range (in gibibytes) for an instance with this profile.
+   */
   export interface InstanceProfileMemoryRange extends InstanceProfileMemory {
     /** The default value for this profile field. */
     default: number;
@@ -49653,7 +54015,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The total number of NUMA nodes for an instance with this profile depends on its configuration and the capacity constraints within the zone. */
+  /**
+   * The total number of NUMA nodes for an instance with this profile depends on its configuration and the capacity
+   * constraints within the zone.
+   */
   export interface InstanceProfileNUMACountDependent extends InstanceProfileNUMACount {
     /** The type for this profile field. */
     type: InstanceProfileNUMACountDependent.Constants.Type | string;
@@ -49667,7 +54032,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The total number of NUMA nodes for an instance with this profile. */
+  /**
+   * The total number of NUMA nodes for an instance with this profile.
+   */
   export interface InstanceProfileNUMACountFixed extends InstanceProfileNUMACount {
     /** The type for this profile field. */
     type: InstanceProfileNUMACountFixed.Constants.Type | string;
@@ -49683,7 +54050,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of network attachments supported on an instance with this profile is dependent on its configuration. */
+  /**
+   * The number of network attachments supported on an instance with this profile is dependent on its configuration.
+   */
   export interface InstanceProfileNetworkAttachmentCountDependent extends InstanceProfileNetworkAttachmentCount {
     /** The type for this profile field. */
     type: InstanceProfileNetworkAttachmentCountDependent.Constants.Type | string;
@@ -49697,7 +54066,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of network attachments supported on an instance with this profile. */
+  /**
+   * The number of network attachments supported on an instance with this profile.
+   */
   export interface InstanceProfileNetworkAttachmentCountRange extends InstanceProfileNetworkAttachmentCount {
     /** The maximum value for this profile field. */
     max?: number;
@@ -49715,7 +54086,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of network interfaces supported on an instance with this profile is dependent on its configuration. */
+  /**
+   * The number of network interfaces supported on an instance with this profile is dependent on its configuration.
+   */
   export interface InstanceProfileNetworkInterfaceCountDependent extends InstanceProfileNetworkInterfaceCount {
     /** The type for this profile field. */
     type: InstanceProfileNetworkInterfaceCountDependent.Constants.Type | string;
@@ -49729,7 +54102,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The number of network interfaces supported on an instance with this profile. */
+  /**
+   * The number of network interfaces supported on an instance with this profile.
+   */
   export interface InstanceProfileNetworkInterfaceCountRange extends InstanceProfileNetworkInterfaceCount {
     /** The maximum value for this profile field. */
     max?: number;
@@ -49747,7 +54122,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The port speed of each network interface of an instance with this profile depends on its configuration. */
+  /**
+   * The port speed of each network interface of an instance with this profile depends on its configuration.
+   */
   export interface InstanceProfilePortSpeedDependent extends InstanceProfilePortSpeed {
     /** The type for this profile field. */
     type: InstanceProfilePortSpeedDependent.Constants.Type | string;
@@ -49761,7 +54138,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The maximum speed (in megabits per second) of each network interface of an instance with this profile. */
+  /**
+   * The maximum speed (in megabits per second) of each network interface of an instance with this profile.
+   */
   export interface InstanceProfilePortSpeedFixed extends InstanceProfilePortSpeed {
     /** The type for this profile field. */
     type: InstanceProfilePortSpeedFixed.Constants.Type | string;
@@ -49777,7 +54156,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The VCPU count for an instance with this profile depends on its configuration. */
+  /**
+   * The VCPU count for an instance with this profile depends on its configuration.
+   */
   export interface InstanceProfileVCPUDependent extends InstanceProfileVCPU {
     /** The type for this profile field. */
     type: InstanceProfileVCPUDependent.Constants.Type | string;
@@ -49791,7 +54172,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted values for VCPU count for an instance with this profile. */
+  /**
+   * The permitted values for VCPU count for an instance with this profile.
+   */
   export interface InstanceProfileVCPUEnum extends InstanceProfileVCPU {
     /** The default value for this profile field. */
     default: number;
@@ -49809,7 +54192,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The VCPU count for an instance with this profile. */
+  /**
+   * The VCPU count for an instance with this profile.
+   */
   export interface InstanceProfileVCPUFixed extends InstanceProfileVCPU {
     /** The type for this profile field. */
     type: InstanceProfileVCPUFixed.Constants.Type | string;
@@ -49825,7 +54210,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted range for VCPU count for an instance with this profile. */
+  /**
+   * The permitted range for VCPU count for an instance with this profile.
+   */
   export interface InstanceProfileVCPURange extends InstanceProfileVCPU {
     /** The default value for this profile field. */
     default: number;
@@ -49847,7 +54234,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The storage bandwidth shared across the storage volumes of an instance with this profile depends on its configuration. */
+  /**
+   * The storage bandwidth shared across the storage volumes of an instance with this profile depends on its
+   * configuration.
+   */
   export interface InstanceProfileVolumeBandwidthDependent extends InstanceProfileVolumeBandwidth {
     /** The type for this profile field. */
     type: InstanceProfileVolumeBandwidthDependent.Constants.Type | string;
@@ -49861,7 +54251,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted storage bandwidth values (in megabits per second) shared across the storage volumes of an instance with this profile. */
+  /**
+   * The permitted storage bandwidth values (in megabits per second) shared across the storage volumes of an instance
+   * with this profile.
+   */
   export interface InstanceProfileVolumeBandwidthEnum extends InstanceProfileVolumeBandwidth {
     /** The default value for this profile field. */
     default: number;
@@ -49879,7 +54272,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The storage bandwidth (in megabits per second) shared across the storage volumes of an instance with this profile. */
+  /**
+   * The storage bandwidth (in megabits per second) shared across the storage volumes of an instance with this profile.
+   */
   export interface InstanceProfileVolumeBandwidthFixed extends InstanceProfileVolumeBandwidth {
     /** The type for this profile field. */
     type: InstanceProfileVolumeBandwidthFixed.Constants.Type | string;
@@ -49895,7 +54290,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted storage bandwidth range (in megabits per second) shared across the storage volumes of an instance with this profile. */
+  /**
+   * The permitted storage bandwidth range (in megabits per second) shared across the storage volumes of an instance
+   * with this profile.
+   */
   export interface InstanceProfileVolumeBandwidthRange extends InstanceProfileVolumeBandwidth {
     /** The default value for this profile field. */
     default: number;
@@ -49917,7 +54315,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using a catalog offering. */
+  /**
+   * Create an instance by using a catalog offering.
+   */
   export interface InstancePrototypeInstanceByCatalogOffering extends InstancePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -49943,7 +54343,11 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using an image. The image's `user_data_format` must be `cloud_init`. */
+  /**
+   * Create an instance by using an image.
+   *
+   * The image's `user_data_format` must be `cloud_init`.
+   */
   export interface InstancePrototypeInstanceByImage extends InstancePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -49962,7 +54366,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using a snapshot. */
+  /**
+   * Create an instance by using a snapshot.
+   */
   export interface InstancePrototypeInstanceBySourceSnapshot extends InstancePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment: VolumeAttachmentPrototypeInstanceBySourceSnapshotContext;
@@ -49979,7 +54385,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using an instance template. The `primary_network_attachment` and `network_attachments` properties may only be specified if `primary_network_attachment` is specified in the source template. The `primary_network_interface` and `network_interfaces` properties may only be specified if `primary_network_interface` is specified in the source template. */
+  /**
+   * Create an instance by using an instance template.
+   *
+   * The `primary_network_attachment` and `network_attachments` properties may only be specified if
+   * `primary_network_attachment` is specified in the source template.
+   *
+   * The `primary_network_interface` and `network_interfaces` properties may only be specified if
+   * `primary_network_interface` is specified in the source template.
+   */
   export interface InstancePrototypeInstanceBySourceTemplate extends InstancePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -50019,7 +54433,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using a boot volume. */
+  /**
+   * Create an instance by using a boot volume.
+   */
   export interface InstancePrototypeInstanceByVolume extends InstancePrototype {
     /** The boot volume attachment for the virtual server instance. */
     boot_volume_attachment: VolumeAttachmentPrototypeInstanceByVolumeContext;
@@ -50036,25 +54452,33 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateIdentityByCRN. */
+  /**
+   * InstanceTemplateIdentityByCRN.
+   */
   export interface InstanceTemplateIdentityByCRN extends InstanceTemplateIdentity {
     /** The CRN for this instance template. */
     crn: string;
   }
 
-  /** InstanceTemplateIdentityByHref. */
+  /**
+   * InstanceTemplateIdentityByHref.
+   */
   export interface InstanceTemplateIdentityByHref extends InstanceTemplateIdentity {
     /** The URL for this instance template. */
     href: string;
   }
 
-  /** InstanceTemplateIdentityById. */
+  /**
+   * InstanceTemplateIdentityById.
+   */
   export interface InstanceTemplateIdentityById extends InstanceTemplateIdentity {
     /** The unique identifier for this instance template. */
     id: string;
   }
 
-  /** Create an instance template that creates instances by using a catalog offering. */
+  /**
+   * Create an instance template that creates instances by using a catalog offering.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateByCatalogOffering extends InstanceTemplatePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -50080,7 +54504,11 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance template that creates instances by using an image. The image's `user_data_format` must be `cloud_init`. */
+  /**
+   * Create an instance template that creates instances by using an image.
+   *
+   * The image's `user_data_format` must be `cloud_init`.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateByImage extends InstanceTemplatePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -50099,7 +54527,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance template that creates instances by using a snapshot. */
+  /**
+   * Create an instance template that creates instances by using a snapshot.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateBySourceSnapshot extends InstanceTemplatePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment: VolumeAttachmentPrototypeInstanceBySourceSnapshotContext;
@@ -50116,7 +54546,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance template from an existing source instance template. The `primary_network_attachment` and `network_attachments` properties may only be specified if `primary_network_attachment` is specified in the source template. The `primary_network_interface` and `network_interfaces` properties may only be specified if `primary_network_interface` is specified in the source template. */
+  /**
+   * Create an instance template from an existing source instance template.
+   *
+   * The `primary_network_attachment` and `network_attachments` properties may only be specified if
+   * `primary_network_attachment` is specified in the source template.
+   *
+   * The `primary_network_interface` and `network_interfaces` properties may only be specified if
+   * `primary_network_interface` is specified in the source template.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateBySourceTemplate extends InstanceTemplatePrototype {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -50156,7 +54594,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using a catalog offering. */
+  /**
+   * Create an instance by using a catalog offering.
+   */
   export interface InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContext extends InstanceTemplate {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -50182,7 +54622,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using an image. */
+  /**
+   * Create an instance by using an image.
+   */
   export interface InstanceTemplateInstanceByImageInstanceTemplateContext extends InstanceTemplate {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment?: VolumeAttachmentPrototypeInstanceByImageContext;
@@ -50201,7 +54643,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create an instance by using a snapshot. */
+  /**
+   * Create an instance by using a snapshot.
+   */
   export interface InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContext extends InstanceTemplate {
     /** The boot volume attachment to create for the virtual server instance. */
     boot_volume_attachment: VolumeAttachmentPrototypeInstanceBySourceSnapshotContext;
@@ -50224,13 +54668,17 @@ namespace VpcV1 {
     }
   }
 
-  /** KeyIdentityByCRN. */
+  /**
+   * KeyIdentityByCRN.
+   */
   export interface KeyIdentityByCRN extends KeyIdentity {
     /** The CRN for this key. */
     crn: string;
   }
 
-  /** KeyIdentityByFingerprint. */
+  /**
+   * KeyIdentityByFingerprint.
+   */
   export interface KeyIdentityByFingerprint extends KeyIdentity {
     /** The fingerprint for this key.  The value is returned base64-encoded and prefixed with the hash algorithm
      *  (always `SHA256`).
@@ -50238,67 +54686,89 @@ namespace VpcV1 {
     fingerprint: string;
   }
 
-  /** KeyIdentityByHref. */
+  /**
+   * KeyIdentityByHref.
+   */
   export interface KeyIdentityByHref extends KeyIdentity {
     /** The URL for this key. */
     href: string;
   }
 
-  /** KeyIdentityById. */
+  /**
+   * KeyIdentityById.
+   */
   export interface KeyIdentityById extends KeyIdentity {
     /** The unique identifier for this key. */
     id: string;
   }
 
-  /** LegacyCloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName. */
+  /**
+   * LegacyCloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName.
+   */
   export interface LegacyCloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName extends LegacyCloudObjectStorageBucketIdentity {
     /** The globally unique name of this Cloud Object Storage bucket. */
     name: string;
   }
 
-  /** LoadBalancerIdentityByCRN. */
+  /**
+   * LoadBalancerIdentityByCRN.
+   */
   export interface LoadBalancerIdentityByCRN extends LoadBalancerIdentity {
     /** The CRN for this load balancer. */
     crn: string;
   }
 
-  /** LoadBalancerIdentityByHref. */
+  /**
+   * LoadBalancerIdentityByHref.
+   */
   export interface LoadBalancerIdentityByHref extends LoadBalancerIdentity {
     /** The URL for this load balancer. */
     href: string;
   }
 
-  /** LoadBalancerIdentityById. */
+  /**
+   * LoadBalancerIdentityById.
+   */
   export interface LoadBalancerIdentityById extends LoadBalancerIdentity {
     /** The unique identifier for this load balancer. */
     id: string;
   }
 
-  /** LoadBalancerListenerDefaultPoolPatchLoadBalancerPoolIdentityByHref. */
+  /**
+   * LoadBalancerListenerDefaultPoolPatchLoadBalancerPoolIdentityByHref.
+   */
   export interface LoadBalancerListenerDefaultPoolPatchLoadBalancerPoolIdentityByHref extends LoadBalancerListenerDefaultPoolPatch {
     /** The URL for this load balancer pool. */
     href: string;
   }
 
-  /** LoadBalancerListenerDefaultPoolPatchLoadBalancerPoolIdentityById. */
+  /**
+   * LoadBalancerListenerDefaultPoolPatchLoadBalancerPoolIdentityById.
+   */
   export interface LoadBalancerListenerDefaultPoolPatchLoadBalancerPoolIdentityById extends LoadBalancerListenerDefaultPoolPatch {
     /** The unique identifier for this load balancer pool. */
     id: string;
   }
 
-  /** LoadBalancerListenerIdentityByHref. */
+  /**
+   * LoadBalancerListenerIdentityByHref.
+   */
   export interface LoadBalancerListenerIdentityByHref extends LoadBalancerListenerIdentity {
     /** The URL for this load balancer listener. */
     href: string;
   }
 
-  /** LoadBalancerListenerIdentityById. */
+  /**
+   * LoadBalancerListenerIdentityById.
+   */
   export interface LoadBalancerListenerIdentityById extends LoadBalancerListenerIdentity {
     /** The unique identifier for this load balancer listener. */
     id: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetPatchLoadBalancerListenerPolicyHTTPSRedirectPatch. */
+  /**
+   * LoadBalancerListenerPolicyTargetPatchLoadBalancerListenerPolicyHTTPSRedirectPatch.
+   */
   export interface LoadBalancerListenerPolicyTargetPatchLoadBalancerListenerPolicyHTTPSRedirectPatch extends LoadBalancerListenerPolicyTargetPatch {
     /** The HTTP status code for this redirect. */
     http_status_code?: number;
@@ -50308,7 +54778,9 @@ namespace VpcV1 {
     uri?: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetPatchLoadBalancerListenerPolicyRedirectURLPatch. */
+  /**
+   * LoadBalancerListenerPolicyTargetPatchLoadBalancerListenerPolicyRedirectURLPatch.
+   */
   export interface LoadBalancerListenerPolicyTargetPatchLoadBalancerListenerPolicyRedirectURLPatch extends LoadBalancerListenerPolicyTargetPatch {
     /** The HTTP status code for this redirect. */
     http_status_code?: number;
@@ -50333,11 +54805,15 @@ namespace VpcV1 {
     url?: string;
   }
 
-  /** Identifies a load balancer pool by a unique property. */
+  /**
+   * Identifies a load balancer pool by a unique property.
+   */
   export interface LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentity extends LoadBalancerListenerPolicyTargetPatch {
   }
 
-  /** LoadBalancerListenerPolicyTargetPrototypeLoadBalancerListenerPolicyHTTPSRedirectPrototype. */
+  /**
+   * LoadBalancerListenerPolicyTargetPrototypeLoadBalancerListenerPolicyHTTPSRedirectPrototype.
+   */
   export interface LoadBalancerListenerPolicyTargetPrototypeLoadBalancerListenerPolicyHTTPSRedirectPrototype extends LoadBalancerListenerPolicyTargetPrototype {
     /** The HTTP status code for this redirect. */
     http_status_code: number;
@@ -50347,7 +54823,9 @@ namespace VpcV1 {
     uri?: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetPrototypeLoadBalancerListenerPolicyRedirectURLPrototype. */
+  /**
+   * LoadBalancerListenerPolicyTargetPrototypeLoadBalancerListenerPolicyRedirectURLPrototype.
+   */
   export interface LoadBalancerListenerPolicyTargetPrototypeLoadBalancerListenerPolicyRedirectURLPrototype extends LoadBalancerListenerPolicyTargetPrototype {
     /** The HTTP status code for this redirect. */
     http_status_code: number;
@@ -50372,11 +54850,15 @@ namespace VpcV1 {
     url: string;
   }
 
-  /** Identifies a load balancer pool by a unique property. */
+  /**
+   * Identifies a load balancer pool by a unique property.
+   */
   export interface LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentity extends LoadBalancerListenerPolicyTargetPrototype {
   }
 
-  /** LoadBalancerListenerPolicyTargetLoadBalancerListenerPolicyHTTPSRedirect. */
+  /**
+   * LoadBalancerListenerPolicyTargetLoadBalancerListenerPolicyHTTPSRedirect.
+   */
   export interface LoadBalancerListenerPolicyTargetLoadBalancerListenerPolicyHTTPSRedirect extends LoadBalancerListenerPolicyTarget {
     /** The HTTP status code for this redirect. */
     http_status_code: number;
@@ -50385,7 +54867,9 @@ namespace VpcV1 {
     uri?: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetLoadBalancerListenerPolicyRedirectURL. */
+  /**
+   * LoadBalancerListenerPolicyTargetLoadBalancerListenerPolicyRedirectURL.
+   */
   export interface LoadBalancerListenerPolicyTargetLoadBalancerListenerPolicyRedirectURL extends LoadBalancerListenerPolicyTarget {
     /** The HTTP status code for this redirect. */
     http_status_code: number;
@@ -50410,7 +54894,9 @@ namespace VpcV1 {
     url: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetLoadBalancerPoolReference. */
+  /**
+   * LoadBalancerListenerPolicyTargetLoadBalancerPoolReference.
+   */
   export interface LoadBalancerListenerPolicyTargetLoadBalancerPoolReference extends LoadBalancerListenerPolicyTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -50424,19 +54910,25 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** LoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref. */
+  /**
+   * LoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref.
+   */
   export interface LoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref extends LoadBalancerPoolIdentity {
     /** The URL for this load balancer pool. */
     href: string;
   }
 
-  /** LoadBalancerPoolIdentityLoadBalancerPoolIdentityById. */
+  /**
+   * LoadBalancerPoolIdentityLoadBalancerPoolIdentityById.
+   */
   export interface LoadBalancerPoolIdentityLoadBalancerPoolIdentityById extends LoadBalancerPoolIdentity {
     /** The unique identifier for this load balancer pool. */
     id: string;
   }
 
-  /** LoadBalancerPoolMemberTargetPrototypeIP. */
+  /**
+   * LoadBalancerPoolMemberTargetPrototypeIP.
+   */
   export interface LoadBalancerPoolMemberTargetPrototypeIP extends LoadBalancerPoolMemberTargetPrototype {
     /** The IP address.
      *
@@ -50446,11 +54938,15 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** Identifies a virtual server instance by a unique property. */
+  /**
+   * Identifies a virtual server instance by a unique property.
+   */
   export interface LoadBalancerPoolMemberTargetPrototypeInstanceIdentity extends LoadBalancerPoolMemberTargetPrototype {
   }
 
-  /** LoadBalancerPoolMemberTargetIP. */
+  /**
+   * LoadBalancerPoolMemberTargetIP.
+   */
   export interface LoadBalancerPoolMemberTargetIP extends LoadBalancerPoolMemberTarget {
     /** The IP address.
      *
@@ -50460,7 +54956,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** LoadBalancerPoolMemberTargetInstanceReference. */
+  /**
+   * LoadBalancerPoolMemberTargetInstanceReference.
+   */
   export interface LoadBalancerPoolMemberTargetInstanceReference extends LoadBalancerPoolMemberTarget {
     /** The CRN for this virtual server instance. */
     crn: string;
@@ -50478,7 +54976,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** The availability mode for a load balancer with this profile depends on its configuration. */
+  /**
+   * The availability mode for a load balancer with this profile depends on its configuration.
+   */
   export interface LoadBalancerProfileAvailabilityDependent extends LoadBalancerProfileAvailability {
     /** The type for this profile field. */
     type: LoadBalancerProfileAvailabilityDependent.Constants.Type | string;
@@ -50492,7 +54992,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The availability mode for a load balancer with this profile. */
+  /**
+   * The availability mode for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileAvailabilityFixed extends LoadBalancerProfileAvailability {
     /** The type for this profile field. */
     type: LoadBalancerProfileAvailabilityFixed.Constants.Type | string;
@@ -50520,19 +55022,25 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerProfileIdentityByHref. */
+  /**
+   * LoadBalancerProfileIdentityByHref.
+   */
   export interface LoadBalancerProfileIdentityByHref extends LoadBalancerProfileIdentity {
     /** The URL for this load balancer profile. */
     href: string;
   }
 
-  /** LoadBalancerProfileIdentityByName. */
+  /**
+   * LoadBalancerProfileIdentityByName.
+   */
   export interface LoadBalancerProfileIdentityByName extends LoadBalancerProfileIdentity {
     /** The globally unique name for this load balancer profile. */
     name: string;
   }
 
-  /** The instance groups support for a load balancer with this profile depends on its configuration. */
+  /**
+   * The instance groups support for a load balancer with this profile depends on its configuration.
+   */
   export interface LoadBalancerProfileInstanceGroupsSupportedDependent extends LoadBalancerProfileInstanceGroupsSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileInstanceGroupsSupportedDependent.Constants.Type | string;
@@ -50546,7 +55054,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The instance groups support for a load balancer with this profile. */
+  /**
+   * The instance groups support for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileInstanceGroupsSupportedFixed extends LoadBalancerProfileInstanceGroupsSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileInstanceGroupsSupportedFixed.Constants.Type | string;
@@ -50562,7 +55072,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The route mode support for a load balancer with this profile depends on its configuration. */
+  /**
+   * The route mode support for a load balancer with this profile depends on its configuration.
+   */
   export interface LoadBalancerProfileRouteModeSupportedDependent extends LoadBalancerProfileRouteModeSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileRouteModeSupportedDependent.Constants.Type | string;
@@ -50576,7 +55088,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The route mode support for a load balancer with this profile. */
+  /**
+   * The route mode support for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileRouteModeSupportedFixed extends LoadBalancerProfileRouteModeSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileRouteModeSupportedFixed.Constants.Type | string;
@@ -50592,7 +55106,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The security group support for a load balancer with this profile depends on its configuration. */
+  /**
+   * The security group support for a load balancer with this profile depends on its configuration.
+   */
   export interface LoadBalancerProfileSecurityGroupsSupportedDependent extends LoadBalancerProfileSecurityGroupsSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileSecurityGroupsSupportedDependent.Constants.Type | string;
@@ -50606,7 +55122,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The security group support for a load balancer with this profile. */
+  /**
+   * The security group support for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileSecurityGroupsSupportedFixed extends LoadBalancerProfileSecurityGroupsSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileSecurityGroupsSupportedFixed.Constants.Type | string;
@@ -50622,7 +55140,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The source IP session persistence support for a load balancer with this profile depends on its configuration. */
+  /**
+   * The source IP session persistence support for a load balancer with this profile depends on its configuration.
+   */
   export interface LoadBalancerProfileSourceIPSessionPersistenceSupportedDependent extends LoadBalancerProfileSourceIPSessionPersistenceSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileSourceIPSessionPersistenceSupportedDependent.Constants.Type | string;
@@ -50636,7 +55156,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The source IP session persistence support for a load balancer with this profile. */
+  /**
+   * The source IP session persistence support for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileSourceIPSessionPersistenceSupportedFixed extends LoadBalancerProfileSourceIPSessionPersistenceSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileSourceIPSessionPersistenceSupportedFixed.Constants.Type | string;
@@ -50652,7 +55174,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The UDP support for a load balancer with this profile depends on its configuration. */
+  /**
+   * The UDP support for a load balancer with this profile depends on its configuration.
+   */
   export interface LoadBalancerProfileUDPSupportedDependent extends LoadBalancerProfileUDPSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileUDPSupportedDependent.Constants.Type | string;
@@ -50666,7 +55190,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The UDP support for a load balancer with this profile. */
+  /**
+   * The UDP support for a load balancer with this profile.
+   */
   export interface LoadBalancerProfileUDPSupportedFixed extends LoadBalancerProfileUDPSupported {
     /** The type for this profile field. */
     type: LoadBalancerProfileUDPSupportedFixed.Constants.Type | string;
@@ -50682,25 +55208,33 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLIdentityByCRN. */
+  /**
+   * NetworkACLIdentityByCRN.
+   */
   export interface NetworkACLIdentityByCRN extends NetworkACLIdentity {
     /** The CRN for this network ACL. */
     crn: string;
   }
 
-  /** NetworkACLIdentityByHref. */
+  /**
+   * NetworkACLIdentityByHref.
+   */
   export interface NetworkACLIdentityByHref extends NetworkACLIdentity {
     /** The URL for this network ACL. */
     href: string;
   }
 
-  /** NetworkACLIdentityById. */
+  /**
+   * NetworkACLIdentityById.
+   */
   export interface NetworkACLIdentityById extends NetworkACLIdentity {
     /** The unique identifier for this network ACL. */
     id: string;
   }
 
-  /** NetworkACLPrototypeNetworkACLByRules. */
+  /**
+   * NetworkACLPrototypeNetworkACLByRules.
+   */
   export interface NetworkACLPrototypeNetworkACLByRules extends NetworkACLPrototype {
     /** The prototype objects for rules to create along with this network ACL. If unspecified, no rules will be
      *  created, resulting in all traffic being denied.
@@ -50708,37 +55242,49 @@ namespace VpcV1 {
     rules?: NetworkACLRulePrototypeNetworkACLContext[];
   }
 
-  /** NetworkACLPrototypeNetworkACLBySourceNetworkACL. */
+  /**
+   * NetworkACLPrototypeNetworkACLBySourceNetworkACL.
+   */
   export interface NetworkACLPrototypeNetworkACLBySourceNetworkACL extends NetworkACLPrototype {
     /** Network ACL to copy rules from. */
     source_network_acl: NetworkACLIdentity;
   }
 
-  /** NetworkACLRuleBeforePatchNetworkACLRuleIdentityByHref. */
+  /**
+   * NetworkACLRuleBeforePatchNetworkACLRuleIdentityByHref.
+   */
   export interface NetworkACLRuleBeforePatchNetworkACLRuleIdentityByHref extends NetworkACLRuleBeforePatch {
     /** The URL for this network ACL rule. */
     href: string;
   }
 
-  /** NetworkACLRuleBeforePatchNetworkACLRuleIdentityById. */
+  /**
+   * NetworkACLRuleBeforePatchNetworkACLRuleIdentityById.
+   */
   export interface NetworkACLRuleBeforePatchNetworkACLRuleIdentityById extends NetworkACLRuleBeforePatch {
     /** The unique identifier for this network ACL rule. */
     id: string;
   }
 
-  /** NetworkACLRuleBeforePrototypeNetworkACLRuleIdentityByHref. */
+  /**
+   * NetworkACLRuleBeforePrototypeNetworkACLRuleIdentityByHref.
+   */
   export interface NetworkACLRuleBeforePrototypeNetworkACLRuleIdentityByHref extends NetworkACLRuleBeforePrototype {
     /** The URL for this network ACL rule. */
     href: string;
   }
 
-  /** NetworkACLRuleBeforePrototypeNetworkACLRuleIdentityById. */
+  /**
+   * NetworkACLRuleBeforePrototypeNetworkACLRuleIdentityById.
+   */
   export interface NetworkACLRuleBeforePrototypeNetworkACLRuleIdentityById extends NetworkACLRuleBeforePrototype {
     /** The unique identifier for this network ACL rule. */
     id: string;
   }
 
-  /** NetworkACLRuleItemNetworkACLRuleProtocolAll. */
+  /**
+   * NetworkACLRuleItemNetworkACLRuleProtocolAll.
+   */
   export interface NetworkACLRuleItemNetworkACLRuleProtocolAll extends NetworkACLRuleItem {
     /** The network protocol. */
     protocol: NetworkACLRuleItemNetworkACLRuleProtocolAll.Constants.Protocol | string;
@@ -50766,7 +55312,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRuleItemNetworkACLRuleProtocolICMP. */
+  /**
+   * NetworkACLRuleItemNetworkACLRuleProtocolICMP.
+   */
   export interface NetworkACLRuleItemNetworkACLRuleProtocolICMP extends NetworkACLRuleItem {
     /** The ICMP traffic code to match.
      *
@@ -50804,7 +55352,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRuleItemNetworkACLRuleProtocolTCPUDP. */
+  /**
+   * NetworkACLRuleItemNetworkACLRuleProtocolTCPUDP.
+   */
   export interface NetworkACLRuleItemNetworkACLRuleProtocolTCPUDP extends NetworkACLRuleItem {
     /** The inclusive upper bound of TCP/UDP destination port range. */
     destination_port_max: number;
@@ -50841,7 +55391,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolAllPrototype. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolAllPrototype.
+   */
   export interface NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolAllPrototype extends NetworkACLRulePrototypeNetworkACLContext {
     /** The network protocol. */
     protocol: NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolAllPrototype.Constants.Protocol | string;
@@ -50869,7 +55421,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolICMPPrototype. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolICMPPrototype.
+   */
   export interface NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolICMPPrototype extends NetworkACLRulePrototypeNetworkACLContext {
     /** The ICMP traffic code to match.
      *
@@ -50907,7 +55461,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolTCPUDPPrototype. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolTCPUDPPrototype.
+   */
   export interface NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolTCPUDPPrototype extends NetworkACLRulePrototypeNetworkACLContext {
     /** The inclusive upper bound of TCP/UDP destination port range. */
     destination_port_max?: number;
@@ -50944,7 +55500,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLRuleProtocolAllPrototype. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLRuleProtocolAllPrototype.
+   */
   export interface NetworkACLRulePrototypeNetworkACLRuleProtocolAllPrototype extends NetworkACLRulePrototype {
     /** The network protocol. */
     protocol: NetworkACLRulePrototypeNetworkACLRuleProtocolAllPrototype.Constants.Protocol | string;
@@ -50972,7 +55530,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLRuleProtocolICMPPrototype. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLRuleProtocolICMPPrototype.
+   */
   export interface NetworkACLRulePrototypeNetworkACLRuleProtocolICMPPrototype extends NetworkACLRulePrototype {
     /** The ICMP traffic code to match.
      *
@@ -51010,7 +55570,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRulePrototypeNetworkACLRuleProtocolTCPUDPPrototype. */
+  /**
+   * NetworkACLRulePrototypeNetworkACLRuleProtocolTCPUDPPrototype.
+   */
   export interface NetworkACLRulePrototypeNetworkACLRuleProtocolTCPUDPPrototype extends NetworkACLRulePrototype {
     /** The inclusive upper bound of TCP/UDP destination port range. */
     destination_port_max?: number;
@@ -51047,7 +55609,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRuleNetworkACLRuleProtocolAll. */
+  /**
+   * NetworkACLRuleNetworkACLRuleProtocolAll.
+   */
   export interface NetworkACLRuleNetworkACLRuleProtocolAll extends NetworkACLRule {
     /** The network protocol. */
     protocol: NetworkACLRuleNetworkACLRuleProtocolAll.Constants.Protocol | string;
@@ -51075,7 +55639,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRuleNetworkACLRuleProtocolICMP. */
+  /**
+   * NetworkACLRuleNetworkACLRuleProtocolICMP.
+   */
   export interface NetworkACLRuleNetworkACLRuleProtocolICMP extends NetworkACLRule {
     /** The ICMP traffic code to match.
      *
@@ -51113,7 +55679,9 @@ namespace VpcV1 {
     }
   }
 
-  /** NetworkACLRuleNetworkACLRuleProtocolTCPUDP. */
+  /**
+   * NetworkACLRuleNetworkACLRuleProtocolTCPUDP.
+   */
   export interface NetworkACLRuleNetworkACLRuleProtocolTCPUDP extends NetworkACLRule {
     /** The inclusive upper bound of TCP/UDP destination port range. */
     destination_port_max: number;
@@ -51150,11 +55718,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a reserved IP by a unique property. */
+  /**
+   * Identifies a reserved IP by a unique property.
+   */
   export interface NetworkInterfaceIPPrototypeReservedIPIdentity extends NetworkInterfaceIPPrototype {
   }
 
-  /** NetworkInterfaceIPPrototypeReservedIPPrototypeNetworkInterfaceContext. */
+  /**
+   * NetworkInterfaceIPPrototypeReservedIPPrototypeNetworkInterfaceContext.
+   */
   export interface NetworkInterfaceIPPrototypeReservedIPPrototypeNetworkInterfaceContext extends NetworkInterfaceIPPrototype {
     /** The IP address to reserve, which must not already be reserved on the subnet.
      *
@@ -51172,23 +55744,31 @@ namespace VpcV1 {
     name?: string;
   }
 
-  /** OperatingSystemIdentityByHref. */
+  /**
+   * OperatingSystemIdentityByHref.
+   */
   export interface OperatingSystemIdentityByHref extends OperatingSystemIdentity {
     /** The URL for this operating system. */
     href: string;
   }
 
-  /** OperatingSystemIdentityByName. */
+  /**
+   * OperatingSystemIdentityByName.
+   */
   export interface OperatingSystemIdentityByName extends OperatingSystemIdentity {
     /** The globally unique name for this operating system. */
     name: string;
   }
 
-  /** Identifies a floating IP by a unique property. */
+  /**
+   * Identifies a floating IP by a unique property.
+   */
   export interface PublicGatewayFloatingIPPrototypeFloatingIPIdentity extends PublicGatewayFloatingIPPrototype {
   }
 
-  /** PublicGatewayFloatingIPPrototypeFloatingIPPrototypeTargetContext. */
+  /**
+   * PublicGatewayFloatingIPPrototypeFloatingIPPrototypeTargetContext.
+   */
   export interface PublicGatewayFloatingIPPrototypeFloatingIPPrototypeTargetContext extends PublicGatewayFloatingIPPrototype {
     /** The name for this floating IP. The name must not be used by another floating IP in the region. If
      *  unspecified, the name will be a hyphenated list of randomly-selected words.
@@ -51200,63 +55780,85 @@ namespace VpcV1 {
     resource_group?: ResourceGroupIdentity;
   }
 
-  /** PublicGatewayIdentityPublicGatewayIdentityByCRN. */
+  /**
+   * PublicGatewayIdentityPublicGatewayIdentityByCRN.
+   */
   export interface PublicGatewayIdentityPublicGatewayIdentityByCRN extends PublicGatewayIdentity {
     /** The CRN for this public gateway. */
     crn: string;
   }
 
-  /** PublicGatewayIdentityPublicGatewayIdentityByHref. */
+  /**
+   * PublicGatewayIdentityPublicGatewayIdentityByHref.
+   */
   export interface PublicGatewayIdentityPublicGatewayIdentityByHref extends PublicGatewayIdentity {
     /** The URL for this public gateway. */
     href: string;
   }
 
-  /** PublicGatewayIdentityPublicGatewayIdentityById. */
+  /**
+   * PublicGatewayIdentityPublicGatewayIdentityById.
+   */
   export interface PublicGatewayIdentityPublicGatewayIdentityById extends PublicGatewayIdentity {
     /** The unique identifier for this public gateway. */
     id: string;
   }
 
-  /** RegionIdentityByHref. */
+  /**
+   * RegionIdentityByHref.
+   */
   export interface RegionIdentityByHref extends RegionIdentity {
     /** The URL for this region. */
     href: string;
   }
 
-  /** RegionIdentityByName. */
+  /**
+   * RegionIdentityByName.
+   */
   export interface RegionIdentityByName extends RegionIdentity {
     /** The globally unique name for this region. */
     name: string;
   }
 
-  /** ReservationIdentityByCRN. */
+  /**
+   * ReservationIdentityByCRN.
+   */
   export interface ReservationIdentityByCRN extends ReservationIdentity {
     /** The CRN for this reservation. */
     crn: string;
   }
 
-  /** ReservationIdentityByHref. */
+  /**
+   * ReservationIdentityByHref.
+   */
   export interface ReservationIdentityByHref extends ReservationIdentity {
     /** The URL for this reservation. */
     href: string;
   }
 
-  /** ReservationIdentityById. */
+  /**
+   * ReservationIdentityById.
+   */
   export interface ReservationIdentityById extends ReservationIdentity {
     /** The unique identifier for this reservation. */
     id: string;
   }
 
-  /** ReservedIPTargetPrototypeEndpointGatewayIdentity. */
+  /**
+   * ReservedIPTargetPrototypeEndpointGatewayIdentity.
+   */
   export interface ReservedIPTargetPrototypeEndpointGatewayIdentity extends ReservedIPTargetPrototype {
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentity extends ReservedIPTargetPrototype {
   }
 
-  /** ReservedIPTargetBareMetalServerNetworkInterfaceReferenceTargetContext. */
+  /**
+   * ReservedIPTargetBareMetalServerNetworkInterfaceReferenceTargetContext.
+   */
   export interface ReservedIPTargetBareMetalServerNetworkInterfaceReferenceTargetContext extends ReservedIPTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -51291,7 +55893,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPTargetEndpointGatewayReference. */
+  /**
+   * ReservedIPTargetEndpointGatewayReference.
+   */
   export interface ReservedIPTargetEndpointGatewayReference extends ReservedIPTarget {
     /** The CRN for this endpoint gateway. */
     crn: string;
@@ -51317,7 +55921,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifying information for a resource that is not native to the VPC API. */
+  /**
+   * Identifying information for a resource that is not native to the VPC API.
+   */
   export interface ReservedIPTargetGenericResourceReference extends ReservedIPTarget {
     /** The CRN for the resource. */
     crn: string;
@@ -51337,7 +55943,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPTargetLoadBalancerReference. */
+  /**
+   * ReservedIPTargetLoadBalancerReference.
+   */
   export interface ReservedIPTargetLoadBalancerReference extends ReservedIPTarget {
     /** The CRN for this load balancer. */
     crn: string;
@@ -51363,7 +55971,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPTargetNetworkInterfaceReferenceTargetContext. */
+  /**
+   * ReservedIPTargetNetworkInterfaceReferenceTargetContext.
+   */
   export interface ReservedIPTargetNetworkInterfaceReferenceTargetContext extends ReservedIPTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -51398,7 +56008,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPTargetVPNGatewayReference. */
+  /**
+   * ReservedIPTargetVPNGatewayReference.
+   */
   export interface ReservedIPTargetVPNGatewayReference extends ReservedIPTarget {
     /** The CRN for this VPN gateway. */
     crn: string;
@@ -51424,7 +56036,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPTargetVPNServerReference. */
+  /**
+   * ReservedIPTargetVPNServerReference.
+   */
   export interface ReservedIPTargetVPNServerReference extends ReservedIPTarget {
     /** The CRN for this VPN server. */
     crn: string;
@@ -51450,7 +56064,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ReservedIPTargetVirtualNetworkInterfaceReferenceReservedIPTargetContext. */
+  /**
+   * ReservedIPTargetVirtualNetworkInterfaceReferenceReservedIPTargetContext.
+   */
   export interface ReservedIPTargetVirtualNetworkInterfaceReferenceReservedIPTargetContext extends ReservedIPTarget {
     /** The CRN for this virtual network interface. */
     crn: string;
@@ -51474,13 +56090,17 @@ namespace VpcV1 {
     }
   }
 
-  /** ResourceGroupIdentityById. */
+  /**
+   * ResourceGroupIdentityById.
+   */
   export interface ResourceGroupIdentityById extends ResourceGroupIdentity {
     /** The unique identifier for this resource group. */
     id: string;
   }
 
-  /** RouteCreatorVPNGatewayReference. */
+  /**
+   * RouteCreatorVPNGatewayReference.
+   */
   export interface RouteCreatorVPNGatewayReference extends RouteCreator {
     /** The CRN for this VPN gateway. */
     crn: string;
@@ -51506,7 +56126,9 @@ namespace VpcV1 {
     }
   }
 
-  /** RouteCreatorVPNServerReference. */
+  /**
+   * RouteCreatorVPNServerReference.
+   */
   export interface RouteCreatorVPNServerReference extends RouteCreator {
     /** The CRN for this VPN server. */
     crn: string;
@@ -51532,7 +56154,9 @@ namespace VpcV1 {
     }
   }
 
-  /** RouteNextHopIP. */
+  /**
+   * RouteNextHopIP.
+   */
   export interface RouteNextHopIP extends RouteNextHop {
     /** The IP address.
      *
@@ -51542,23 +56166,33 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** RouteNextHopPatchRouteNextHopIP. */
+  /**
+   * RouteNextHopPatchRouteNextHopIP.
+   */
   export interface RouteNextHopPatchRouteNextHopIP extends RouteNextHopPatch {
   }
 
-  /** Identifies a VPN gateway connection by a unique property. */
+  /**
+   * Identifies a VPN gateway connection by a unique property.
+   */
   export interface RouteNextHopPatchVPNGatewayConnectionIdentity extends RouteNextHopPatch {
   }
 
-  /** RouteNextHopPrototypeRouteNextHopIP. */
+  /**
+   * RouteNextHopPrototypeRouteNextHopIP.
+   */
   export interface RouteNextHopPrototypeRouteNextHopIP extends RouteNextHopPrototype {
   }
 
-  /** Identifies a VPN gateway connection by a unique property. */
+  /**
+   * Identifies a VPN gateway connection by a unique property.
+   */
   export interface RouteNextHopPrototypeVPNGatewayConnectionIdentity extends RouteNextHopPrototype {
   }
 
-  /** RouteNextHopVPNGatewayConnectionReference. */
+  /**
+   * RouteNextHopVPNGatewayConnectionReference.
+   */
   export interface RouteNextHopVPNGatewayConnectionReference extends RouteNextHop {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -51582,43 +56216,57 @@ namespace VpcV1 {
     }
   }
 
-  /** RoutingTableIdentityByCRN. */
+  /**
+   * RoutingTableIdentityByCRN.
+   */
   export interface RoutingTableIdentityByCRN extends RoutingTableIdentity {
     /** The CRN for this VPC routing table. */
     crn: string;
   }
 
-  /** RoutingTableIdentityByHref. */
+  /**
+   * RoutingTableIdentityByHref.
+   */
   export interface RoutingTableIdentityByHref extends RoutingTableIdentity {
     /** The URL for this routing table. */
     href: string;
   }
 
-  /** RoutingTableIdentityById. */
+  /**
+   * RoutingTableIdentityById.
+   */
   export interface RoutingTableIdentityById extends RoutingTableIdentity {
     /** The unique identifier for this routing table. */
     id: string;
   }
 
-  /** SecurityGroupIdentityByCRN. */
+  /**
+   * SecurityGroupIdentityByCRN.
+   */
   export interface SecurityGroupIdentityByCRN extends SecurityGroupIdentity {
     /** The CRN for this security group. */
     crn: string;
   }
 
-  /** SecurityGroupIdentityByHref. */
+  /**
+   * SecurityGroupIdentityByHref.
+   */
   export interface SecurityGroupIdentityByHref extends SecurityGroupIdentity {
     /** The URL for this security group. */
     href: string;
   }
 
-  /** SecurityGroupIdentityById. */
+  /**
+   * SecurityGroupIdentityById.
+   */
   export interface SecurityGroupIdentityById extends SecurityGroupIdentity {
     /** The unique identifier for this security group. */
     id: string;
   }
 
-  /** SecurityGroupRuleLocalPatchCIDR. */
+  /**
+   * SecurityGroupRuleLocalPatchCIDR.
+   */
   export interface SecurityGroupRuleLocalPatchCIDR extends SecurityGroupRuleLocalPatch {
     /** The CIDR block.
      *
@@ -51628,7 +56276,9 @@ namespace VpcV1 {
     cidr_block: string;
   }
 
-  /** SecurityGroupRuleLocalPatchIP. */
+  /**
+   * SecurityGroupRuleLocalPatchIP.
+   */
   export interface SecurityGroupRuleLocalPatchIP extends SecurityGroupRuleLocalPatch {
     /** The IP address.
      *
@@ -51638,7 +56288,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** SecurityGroupRuleLocalPrototypeCIDR. */
+  /**
+   * SecurityGroupRuleLocalPrototypeCIDR.
+   */
   export interface SecurityGroupRuleLocalPrototypeCIDR extends SecurityGroupRuleLocalPrototype {
     /** The CIDR block.
      *
@@ -51648,7 +56300,9 @@ namespace VpcV1 {
     cidr_block: string;
   }
 
-  /** SecurityGroupRuleLocalPrototypeIP. */
+  /**
+   * SecurityGroupRuleLocalPrototypeIP.
+   */
   export interface SecurityGroupRuleLocalPrototypeIP extends SecurityGroupRuleLocalPrototype {
     /** The IP address.
      *
@@ -51658,7 +56312,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** SecurityGroupRuleLocalCIDR. */
+  /**
+   * SecurityGroupRuleLocalCIDR.
+   */
   export interface SecurityGroupRuleLocalCIDR extends SecurityGroupRuleLocal {
     /** The CIDR block.
      *
@@ -51668,7 +56324,9 @@ namespace VpcV1 {
     cidr_block: string;
   }
 
-  /** SecurityGroupRuleLocalIP. */
+  /**
+   * SecurityGroupRuleLocalIP.
+   */
   export interface SecurityGroupRuleLocalIP extends SecurityGroupRuleLocal {
     /** The IP address.
      *
@@ -51678,7 +56336,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** A rule allowing traffic for all supported protocols. */
+  /**
+   * A rule allowing traffic for all supported protocols.
+   */
   export interface SecurityGroupRulePrototypeSecurityGroupRuleProtocolAll extends SecurityGroupRulePrototype {
     /** The direction of traffic to allow. */
     direction: SecurityGroupRulePrototypeSecurityGroupRuleProtocolAll.Constants.Direction | string;
@@ -51725,7 +56385,9 @@ namespace VpcV1 {
     }
   }
 
-  /** A rule specifying the ICMP traffic to allow. */
+  /**
+   * A rule specifying the ICMP traffic to allow.
+   */
   export interface SecurityGroupRulePrototypeSecurityGroupRuleProtocolICMP extends SecurityGroupRulePrototype {
     /** The ICMP traffic code to allow.
      *
@@ -51782,7 +56444,12 @@ namespace VpcV1 {
     }
   }
 
-  /** A rule specifying the TCP or UDP traffic to allow. Either both `port_min` and `port_max` will be present, or neither. When neither is present, all destination ports are allowed for the protocol. When both have the same value, that single destination port is allowed. */
+  /**
+   * A rule specifying the TCP or UDP traffic to allow.
+   *
+   * Either both `port_min` and `port_max` will be present, or neither. When neither is present, all destination ports
+   * are allowed for the protocol. When both have the same value, that single destination port is allowed.
+   */
   export interface SecurityGroupRulePrototypeSecurityGroupRuleProtocolTCPUDP extends SecurityGroupRulePrototype {
     /** The direction of traffic to allow. */
     direction: SecurityGroupRulePrototypeSecurityGroupRuleProtocolTCPUDP.Constants.Direction | string;
@@ -51842,7 +56509,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupRuleRemotePatchCIDR. */
+  /**
+   * SecurityGroupRuleRemotePatchCIDR.
+   */
   export interface SecurityGroupRuleRemotePatchCIDR extends SecurityGroupRuleRemotePatch {
     /** The CIDR block.
      *
@@ -51852,7 +56521,9 @@ namespace VpcV1 {
     cidr_block: string;
   }
 
-  /** SecurityGroupRuleRemotePatchIP. */
+  /**
+   * SecurityGroupRuleRemotePatchIP.
+   */
   export interface SecurityGroupRuleRemotePatchIP extends SecurityGroupRuleRemotePatch {
     /** The IP address.
      *
@@ -51862,11 +56533,15 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** Identifies a security group by a unique property. */
+  /**
+   * Identifies a security group by a unique property.
+   */
   export interface SecurityGroupRuleRemotePatchSecurityGroupIdentity extends SecurityGroupRuleRemotePatch {
   }
 
-  /** SecurityGroupRuleRemotePrototypeCIDR. */
+  /**
+   * SecurityGroupRuleRemotePrototypeCIDR.
+   */
   export interface SecurityGroupRuleRemotePrototypeCIDR extends SecurityGroupRuleRemotePrototype {
     /** The CIDR block.
      *
@@ -51876,7 +56551,9 @@ namespace VpcV1 {
     cidr_block: string;
   }
 
-  /** SecurityGroupRuleRemotePrototypeIP. */
+  /**
+   * SecurityGroupRuleRemotePrototypeIP.
+   */
   export interface SecurityGroupRuleRemotePrototypeIP extends SecurityGroupRuleRemotePrototype {
     /** The IP address.
      *
@@ -51886,11 +56563,15 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** Identifies a security group by a unique property. */
+  /**
+   * Identifies a security group by a unique property.
+   */
   export interface SecurityGroupRuleRemotePrototypeSecurityGroupIdentity extends SecurityGroupRuleRemotePrototype {
   }
 
-  /** SecurityGroupRuleRemoteCIDR. */
+  /**
+   * SecurityGroupRuleRemoteCIDR.
+   */
   export interface SecurityGroupRuleRemoteCIDR extends SecurityGroupRuleRemote {
     /** The CIDR block.
      *
@@ -51900,7 +56581,9 @@ namespace VpcV1 {
     cidr_block: string;
   }
 
-  /** SecurityGroupRuleRemoteIP. */
+  /**
+   * SecurityGroupRuleRemoteIP.
+   */
   export interface SecurityGroupRuleRemoteIP extends SecurityGroupRuleRemote {
     /** The IP address.
      *
@@ -51910,7 +56593,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** SecurityGroupRuleRemoteSecurityGroupReference. */
+  /**
+   * SecurityGroupRuleRemoteSecurityGroupReference.
+   */
   export interface SecurityGroupRuleRemoteSecurityGroupReference extends SecurityGroupRuleRemote {
     /** The CRN for this security group. */
     crn: string;
@@ -51926,7 +56611,9 @@ namespace VpcV1 {
     name: string;
   }
 
-  /** A rule allowing traffic for all supported protocols. */
+  /**
+   * A rule allowing traffic for all supported protocols.
+   */
   export interface SecurityGroupRuleSecurityGroupRuleProtocolAll extends SecurityGroupRule {
     /** The network protocol. */
     protocol: SecurityGroupRuleSecurityGroupRuleProtocolAll.Constants.Protocol | string;
@@ -51949,7 +56636,9 @@ namespace VpcV1 {
     }
   }
 
-  /** A rule specifying the ICMP traffic to allow. */
+  /**
+   * A rule specifying the ICMP traffic to allow.
+   */
   export interface SecurityGroupRuleSecurityGroupRuleProtocolICMP extends SecurityGroupRule {
     /** The ICMP traffic code to allow. If absent, all codes are allowed. */
     code?: number;
@@ -51976,7 +56665,12 @@ namespace VpcV1 {
     }
   }
 
-  /** A rule specifying the TCP or UDP traffic to allow. Either both `port_min` and `port_max` will be present, or neither. When neither is present, all destination ports are allowed for the protocol. When both have the same value, that single destination port is allowed. */
+  /**
+   * A rule specifying the TCP or UDP traffic to allow.
+   *
+   * Either both `port_min` and `port_max` will be present, or neither. When neither is present, all destination ports
+   * are allowed for the protocol. When both have the same value, that single destination port is allowed.
+   */
   export interface SecurityGroupRuleSecurityGroupRuleProtocolTCPUDP extends SecurityGroupRule {
     /** The inclusive upper bound of TCP/UDP destination port range. */
     port_max?: number;
@@ -52004,7 +56698,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupTargetReferenceBareMetalServerNetworkInterfaceReferenceTargetContext. */
+  /**
+   * SecurityGroupTargetReferenceBareMetalServerNetworkInterfaceReferenceTargetContext.
+   */
   export interface SecurityGroupTargetReferenceBareMetalServerNetworkInterfaceReferenceTargetContext extends SecurityGroupTargetReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -52039,7 +56735,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupTargetReferenceEndpointGatewayReference. */
+  /**
+   * SecurityGroupTargetReferenceEndpointGatewayReference.
+   */
   export interface SecurityGroupTargetReferenceEndpointGatewayReference extends SecurityGroupTargetReference {
     /** The CRN for this endpoint gateway. */
     crn: string;
@@ -52065,7 +56763,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupTargetReferenceLoadBalancerReference. */
+  /**
+   * SecurityGroupTargetReferenceLoadBalancerReference.
+   */
   export interface SecurityGroupTargetReferenceLoadBalancerReference extends SecurityGroupTargetReference {
     /** The CRN for this load balancer. */
     crn: string;
@@ -52091,7 +56791,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupTargetReferenceNetworkInterfaceReferenceTargetContext. */
+  /**
+   * SecurityGroupTargetReferenceNetworkInterfaceReferenceTargetContext.
+   */
   export interface SecurityGroupTargetReferenceNetworkInterfaceReferenceTargetContext extends SecurityGroupTargetReference {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -52126,7 +56828,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupTargetReferenceVPNServerReference. */
+  /**
+   * SecurityGroupTargetReferenceVPNServerReference.
+   */
   export interface SecurityGroupTargetReferenceVPNServerReference extends SecurityGroupTargetReference {
     /** The CRN for this VPN server. */
     crn: string;
@@ -52152,7 +56856,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SecurityGroupTargetReferenceVirtualNetworkInterfaceReference. */
+  /**
+   * SecurityGroupTargetReferenceVirtualNetworkInterfaceReference.
+   */
   export interface SecurityGroupTargetReferenceVirtualNetworkInterfaceReference extends SecurityGroupTargetReference {
     /** The CRN for this virtual network interface. */
     crn: string;
@@ -52184,7 +56890,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareAccessorBindingAccessorShareReference. */
+  /**
+   * ShareAccessorBindingAccessorShareReference.
+   */
   export interface ShareAccessorBindingAccessorShareReference extends ShareAccessorBindingAccessor {
     /** The CRN for this file share. */
     crn: string;
@@ -52214,7 +56922,9 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareAccessorBindingAccessorWatsonxMachineLearningReference. */
+  /**
+   * ShareAccessorBindingAccessorWatsonxMachineLearningReference.
+   */
   export interface ShareAccessorBindingAccessorWatsonxMachineLearningReference extends ShareAccessorBindingAccessor {
     /** The CRN for the watsonx machine learning resource. */
     crn: string;
@@ -52230,25 +56940,45 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareIdentityByCRN. */
+  /**
+   * ShareIdentityByCRN.
+   */
   export interface ShareIdentityByCRN extends ShareIdentity {
     /** The CRN for this file share. */
     crn: string;
   }
 
-  /** ShareIdentityByHref. */
+  /**
+   * ShareIdentityByHref.
+   */
   export interface ShareIdentityByHref extends ShareIdentity {
     /** The URL for this file share. */
     href: string;
   }
 
-  /** ShareIdentityById. */
+  /**
+   * ShareIdentityById.
+   */
   export interface ShareIdentityById extends ShareIdentity {
     /** The unique identifier for this file share. */
     id: string;
   }
 
-  /** The virtual network interface for this share mount target. The virtual network interface must: - be in the same `zone` as the share - have `allow_ip_spoofing` set to `false` - have `enable_infrastructure_nat` set to `true` - have `protocol_state_filtering_mode` set to `auto` or `enabled` - not be in the same VPC as an existing mount target for this share - not have `ips` other than the `primary_ip` address If an existing virtual network interface is specified, it must not have a floating IP bound to it, and it must not be the target of a flow log collector. Required if the share's `access_control_mode` is `security_group`. */
+  /**
+   * The virtual network interface for this share mount target. The virtual network interface must:
+   *
+   * - be in the same `zone` as the share
+   * - have `allow_ip_spoofing` set to `false`
+   * - have `enable_infrastructure_nat` set to `true`
+   * - have `protocol_state_filtering_mode` set to `auto` or `enabled`
+   * - not be in the same VPC as an existing mount target for this share
+   * - not have `ips` other than the `primary_ip` address
+   *
+   * If an existing virtual network interface is specified, it must not have a floating IP bound to it, and it must not
+   * be the target of a flow log collector.
+   *
+   * Required if the share's `access_control_mode` is `security_group`.
+   */
   export interface ShareMountTargetPrototypeShareMountTargetByAccessControlModeSecurityGroup extends ShareMountTargetPrototype {
     virtual_network_interface: ShareMountTargetVirtualNetworkInterfacePrototype;
   }
@@ -52262,7 +56992,12 @@ namespace VpcV1 {
     }
   }
 
-  /** The VPC in which clients can mount the file share using this mount target.  The VPC must not be used by another mount target for this share. Required if the share's `access_control_mode` is `vpc`. */
+  /**
+   * The VPC in which clients can mount the file share using this mount target.  The VPC must not be used by another
+   * mount target for this share.
+   *
+   * Required if the share's `access_control_mode` is `vpc`.
+   */
   export interface ShareMountTargetPrototypeShareMountTargetByAccessControlModeVPC extends ShareMountTargetPrototype {
     /** Identifies a VPC by a unique property. */
     vpc: VPCIdentity;
@@ -52277,11 +57012,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a virtual network interface by a unique property. */
+  /**
+   * Identifies a virtual network interface by a unique property.
+   */
   export interface ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentity extends ShareMountTargetVirtualNetworkInterfacePrototype {
   }
 
-  /** The virtual network interface for this target. */
+  /**
+   * The virtual network interface for this target.
+   */
   export interface ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfacePrototypeShareMountTargetContext extends ShareMountTargetVirtualNetworkInterfacePrototype {
     /** Indicates whether source IP spoofing is allowed on this interface. If `false`, source IP spoofing is
      *  prevented on this interface. If `true`, source IP spoofing is allowed on this interface.
@@ -52357,13 +57096,14 @@ namespace VpcV1 {
       /** The protocol state filtering mode to use for this virtual network interface. If `auto`, protocol state packet filtering is enabled or disabled based on the virtual network interface's `target` resource type: - `bare_metal_server_network_attachment`: disabled - `instance_network_attachment`: enabled - `share_mount_target`: enabled Protocol state filtering monitors each network connection flowing over this virtual network interface, and drops any packets that are invalid based on the current connection state and protocol. See [Protocol state filtering mode](https://cloud.ibm.com/docs/vpc?topic=vpc-vni-about#protocol-state-filtering) for more information. */
       export enum ProtocolStateFilteringMode {
         AUTO = 'auto',
-        DISABLED = 'disabled',
         ENABLED = 'enabled',
       }
     }
   }
 
-  /** The permitted total capacity (in gigabytes) of a share with this profile depends on its configuration. */
+  /**
+   * The permitted total capacity (in gigabytes) of a share with this profile depends on its configuration.
+   */
   export interface ShareProfileCapacityDependentRange extends ShareProfileCapacity {
     /** The maximum value for this profile field. */
     max: number;
@@ -52383,10 +57123,10 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacities (in gigabytes) of a share with this profile. */
+  /**
+   * The permitted total capacities (in gigabytes) of a share with this profile.
+   */
   export interface ShareProfileCapacityEnum extends ShareProfileCapacity {
-    /** The default value for this profile field. */
-    default: any;
     /** The type for this profile field. */
     type: ShareProfileCapacityEnum.Constants.Type | string;
     /** The permitted values for this profile field. */
@@ -52401,7 +57141,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity (in gigabytes) of a share with this profile is fixed. */
+  /**
+   * The permitted total capacity (in gigabytes) of a share with this profile is fixed.
+   */
   export interface ShareProfileCapacityFixed extends ShareProfileCapacity {
     /** The type for this profile field. */
     type: ShareProfileCapacityFixed.Constants.Type | string;
@@ -52417,7 +57159,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity range (in gigabytes) of a share with this profile. */
+  /**
+   * The permitted total capacity range (in gigabytes) of a share with this profile.
+   */
   export interface ShareProfileCapacityRange extends ShareProfileCapacity {
     /** The default value for this profile field. */
     default: number;
@@ -52439,7 +57183,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS range of a share with this profile depends on its configuration. */
+  /**
+   * The permitted IOPS range of a share with this profile depends on its configuration.
+   */
   export interface ShareProfileIOPSDependentRange extends ShareProfileIOPS {
     /** The maximum value for this profile field. */
     max: number;
@@ -52459,7 +57205,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS values of a share with this profile. */
+  /**
+   * The permitted IOPS values of a share with this profile.
+   */
   export interface ShareProfileIOPSEnum extends ShareProfileIOPS {
     /** The default value for this profile field. */
     default: number;
@@ -52477,7 +57225,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS of a share with this profile is fixed. */
+  /**
+   * The permitted IOPS of a share with this profile is fixed.
+   */
   export interface ShareProfileIOPSFixed extends ShareProfileIOPS {
     /** The type for this profile field. */
     type: ShareProfileIOPSFixed.Constants.Type | string;
@@ -52493,7 +57243,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS range of a share with this profile. */
+  /**
+   * The permitted IOPS range of a share with this profile.
+   */
   export interface ShareProfileIOPSRange extends ShareProfileIOPS {
     /** The default value for this profile field. */
     default: number;
@@ -52515,19 +57267,27 @@ namespace VpcV1 {
     }
   }
 
-  /** ShareProfileIdentityByHref. */
+  /**
+   * ShareProfileIdentityByHref.
+   */
   export interface ShareProfileIdentityByHref extends ShareProfileIdentity {
     /** The URL for this share profile. */
     href: string;
   }
 
-  /** ShareProfileIdentityByName. */
+  /**
+   * ShareProfileIdentityByName.
+   */
   export interface ShareProfileIdentityByName extends ShareProfileIdentity {
     /** The globally unique name for this share profile. */
     name: string;
   }
 
-  /** Create an accessor file share for an existing file share. The values for `initial_owner`, `access_control_mode`, `encryption_key`, `zone`, `profile`, `iops` and `size` will be inherited from `origin_share`. */
+  /**
+   * Create an accessor file share for an existing file share. The values for `initial_owner`,
+   * `access_control_mode`, `encryption_key`, `zone`, `profile`, `iops` and `size` will be inherited from
+   * `origin_share`.
+   */
   export interface SharePrototypeShareByOriginShare extends SharePrototype {
     /** The origin share for the accessor share. The origin share must have an
      *  `access_control_mode` of `security_group`, and must not have an
@@ -52547,7 +57307,9 @@ namespace VpcV1 {
     }
   }
 
-  /** Create a file share by size. */
+  /**
+   * Create a file share by size.
+   */
   export interface SharePrototypeShareBySize extends SharePrototype {
     /** The access control mode for the share:
      *
@@ -52609,7 +57371,10 @@ namespace VpcV1 {
     }
   }
 
-  /** Create a replica file share for an existing file share. The values for `initial_owner`, `access_control_mode`, `encryption_key` and `size` will be inherited from `source_share`. */
+  /**
+   * Create a replica file share for an existing file share. The values for `initial_owner`,
+   * `access_control_mode`, `encryption_key` and `size` will be inherited from `source_share`.
+   */
   export interface SharePrototypeShareBySourceShare extends SharePrototype {
     /** The root key to use to wrap the data encryption key for the share.
      *
@@ -52631,7 +57396,7 @@ namespace VpcV1 {
     profile: ShareProfileIdentity;
     /** The cron specification for the file share replication schedule.
      *
-     *  Replication of a share can be scheduled to occur at most once per hour.
+     *  Replication of a share can be scheduled to occur at most once every 15 minutes.
      *
      *  The scheduling frequency for this property may
      *  [increase](https://cloud.ibm.com/apidocs/vpc#property-value-expansion) in the future.
@@ -52660,7 +57425,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SnapshotConsistencyGroupPrototypeSnapshotConsistencyGroupBySnapshots. */
+  /**
+   * SnapshotConsistencyGroupPrototypeSnapshotConsistencyGroupBySnapshots.
+   */
   export interface SnapshotConsistencyGroupPrototypeSnapshotConsistencyGroupBySnapshots extends SnapshotConsistencyGroupPrototype {
     /** The data-consistent member snapshots to create.  All snapshots must specify a
      *  `source_volume` attached to the same virtual server instance.
@@ -52668,25 +57435,33 @@ namespace VpcV1 {
     snapshots: SnapshotPrototypeSnapshotConsistencyGroupContext[];
   }
 
-  /** SnapshotIdentityByCRN. */
+  /**
+   * SnapshotIdentityByCRN.
+   */
   export interface SnapshotIdentityByCRN extends SnapshotIdentity {
     /** The CRN of this snapshot. */
     crn: string;
   }
 
-  /** SnapshotIdentityByHref. */
+  /**
+   * SnapshotIdentityByHref.
+   */
   export interface SnapshotIdentityByHref extends SnapshotIdentity {
     /** The URL for this snapshot. */
     href: string;
   }
 
-  /** SnapshotIdentityById. */
+  /**
+   * SnapshotIdentityById.
+   */
   export interface SnapshotIdentityById extends SnapshotIdentity {
     /** The unique identifier for this snapshot. */
     id: string;
   }
 
-  /** SnapshotPrototypeSnapshotBySourceSnapshot. */
+  /**
+   * SnapshotPrototypeSnapshotBySourceSnapshot.
+   */
   export interface SnapshotPrototypeSnapshotBySourceSnapshot extends SnapshotPrototype {
     /** The root key to use to wrap the data encryption key for this snapshot.
      *
@@ -52705,31 +57480,41 @@ namespace VpcV1 {
     source_snapshot: SnapshotIdentityByCRN;
   }
 
-  /** SnapshotPrototypeSnapshotBySourceVolume. */
+  /**
+   * SnapshotPrototypeSnapshotBySourceVolume.
+   */
   export interface SnapshotPrototypeSnapshotBySourceVolume extends SnapshotPrototype {
     /** The volume to create this snapshot from. */
     source_volume: VolumeIdentity;
   }
 
-  /** SubnetIdentityByCRN. */
+  /**
+   * SubnetIdentityByCRN.
+   */
   export interface SubnetIdentityByCRN extends SubnetIdentity {
     /** The CRN for this subnet. */
     crn: string;
   }
 
-  /** SubnetIdentityByHref. */
+  /**
+   * SubnetIdentityByHref.
+   */
   export interface SubnetIdentityByHref extends SubnetIdentity {
     /** The URL for this subnet. */
     href: string;
   }
 
-  /** SubnetIdentityById. */
+  /**
+   * SubnetIdentityById.
+   */
   export interface SubnetIdentityById extends SubnetIdentity {
     /** The unique identifier for this subnet. */
     id: string;
   }
 
-  /** SubnetPrototypeSubnetByCIDR. */
+  /**
+   * SubnetPrototypeSubnetByCIDR.
+   */
   export interface SubnetPrototypeSubnetByCIDR extends SubnetPrototype {
     /** The IPv4 range of the subnet, expressed in CIDR format. The prefix length of the subnet's CIDR must be
      *  between `/9` (8,388,608 addresses) and `/29` (8 addresses). The IPv4 range of the subnet's CIDR must fall within
@@ -52750,7 +57535,9 @@ namespace VpcV1 {
     }
   }
 
-  /** SubnetPrototypeSubnetByTotalCount. */
+  /**
+   * SubnetPrototypeSubnetByTotalCount.
+   */
   export interface SubnetPrototypeSubnetByTotalCount extends SubnetPrototype {
     /** The total number of IPv4 addresses required. Must be a power of 2. The VPC must have a default address
      *  prefix in the specified zone, and that prefix must have a free CIDR range with at least this number of
@@ -52769,37 +57556,49 @@ namespace VpcV1 {
     }
   }
 
-  /** SubnetPublicGatewayPatchPublicGatewayIdentityByCRN. */
+  /**
+   * SubnetPublicGatewayPatchPublicGatewayIdentityByCRN.
+   */
   export interface SubnetPublicGatewayPatchPublicGatewayIdentityByCRN extends SubnetPublicGatewayPatch {
     /** The CRN for this public gateway. */
     crn: string;
   }
 
-  /** SubnetPublicGatewayPatchPublicGatewayIdentityByHref. */
+  /**
+   * SubnetPublicGatewayPatchPublicGatewayIdentityByHref.
+   */
   export interface SubnetPublicGatewayPatchPublicGatewayIdentityByHref extends SubnetPublicGatewayPatch {
     /** The URL for this public gateway. */
     href: string;
   }
 
-  /** SubnetPublicGatewayPatchPublicGatewayIdentityById. */
+  /**
+   * SubnetPublicGatewayPatchPublicGatewayIdentityById.
+   */
   export interface SubnetPublicGatewayPatchPublicGatewayIdentityById extends SubnetPublicGatewayPatch {
     /** The unique identifier for this public gateway. */
     id: string;
   }
 
-  /** TrustedProfileIdentityTrustedProfileByCRN. */
-  export interface TrustedProfileIdentityTrustedProfileByCRN extends TrustedProfileIdentity {
+  /**
+   * TrustedProfileIdentityByCRN.
+   */
+  export interface TrustedProfileIdentityByCRN extends TrustedProfileIdentity {
     /** The CRN for this trusted profile. */
     crn: string;
   }
 
-  /** TrustedProfileIdentityTrustedProfileById. */
-  export interface TrustedProfileIdentityTrustedProfileById extends TrustedProfileIdentity {
+  /**
+   * TrustedProfileIdentityById.
+   */
+  export interface TrustedProfileIdentityById extends TrustedProfileIdentity {
     /** The unique identifier for this trusted profile. */
     id: string;
   }
 
-  /** Manually specify the DNS server addresses for this VPC. */
+  /**
+   * Manually specify the DNS server addresses for this VPC.
+   */
   export interface VPCDNSResolverPrototypeVPCDNSResolverTypeManualPrototype extends VPCDNSResolverPrototype {
     /** The DNS servers to use for this VPC. All the DNS servers must either:
      *
@@ -52827,7 +57626,11 @@ namespace VpcV1 {
     }
   }
 
-  /** The system will provide DNS server addresses for this VPC. The system-provided DNS server addresses depend on whether any endpoint gateways reside in the VPC, and whether a [DNS Services](https://cloud.ibm.com/docs/dns-svcs) instance is configured for the VPC. */
+  /**
+   * The system will provide DNS server addresses for this VPC. The system-provided DNS server addresses depend on
+   * whether any endpoint gateways reside in the VPC, and whether a
+   * [DNS Services](https://cloud.ibm.com/docs/dns-svcs) instance is configured for the VPC.
+   */
   export interface VPCDNSResolverPrototypeVPCDNSResolverTypeSystemPrototype extends VPCDNSResolverPrototype {
     /** The type of the DNS resolver to use. */
     type?: VPCDNSResolverPrototypeVPCDNSResolverTypeSystemPrototype.Constants.Type | string;
@@ -52841,7 +57644,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The DNS server addresses are delegated to the DNS resolver of another VPC. */
+  /**
+   * The DNS server addresses are delegated to the DNS resolver of another VPC.
+   */
   export interface VPCDNSResolverTypeDelegated extends VPCDNSResolver {
     /** The type of the DNS resolver used for the VPC. */
     type: VPCDNSResolverTypeDelegated.Constants.Type | string;
@@ -52860,7 +57665,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The DNS server addresses are manually specified. */
+  /**
+   * The DNS server addresses are manually specified.
+   */
   export interface VPCDNSResolverTypeManual extends VPCDNSResolver {
     /** The manually specified DNS servers for this VPC.
      *
@@ -52888,7 +57695,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The DNS server addresses are provided by the system and depend on the configuration. */
+  /**
+   * The DNS server addresses are provided by the system and depend on the configuration.
+   */
   export interface VPCDNSResolverTypeSystem extends VPCDNSResolver {
     /** The configuration of the system DNS resolver for this VPC.
      *
@@ -52927,43 +57736,57 @@ namespace VpcV1 {
     }
   }
 
-  /** VPCDNSResolverVPCPatchVPCIdentityByCRN. */
+  /**
+   * VPCDNSResolverVPCPatchVPCIdentityByCRN.
+   */
   export interface VPCDNSResolverVPCPatchVPCIdentityByCRN extends VPCDNSResolverVPCPatch {
     /** The CRN for this VPC. */
     crn: string;
   }
 
-  /** VPCDNSResolverVPCPatchVPCIdentityByHref. */
+  /**
+   * VPCDNSResolverVPCPatchVPCIdentityByHref.
+   */
   export interface VPCDNSResolverVPCPatchVPCIdentityByHref extends VPCDNSResolverVPCPatch {
     /** The URL for this VPC. */
     href: string;
   }
 
-  /** VPCDNSResolverVPCPatchVPCIdentityById. */
+  /**
+   * VPCDNSResolverVPCPatchVPCIdentityById.
+   */
   export interface VPCDNSResolverVPCPatchVPCIdentityById extends VPCDNSResolverVPCPatch {
     /** The unique identifier for this VPC. */
     id: string;
   }
 
-  /** VPCIdentityByCRN. */
+  /**
+   * VPCIdentityByCRN.
+   */
   export interface VPCIdentityByCRN extends VPCIdentity {
     /** The CRN for this VPC. */
     crn: string;
   }
 
-  /** VPCIdentityByHref. */
+  /**
+   * VPCIdentityByHref.
+   */
   export interface VPCIdentityByHref extends VPCIdentity {
     /** The URL for this VPC. */
     href: string;
   }
 
-  /** VPCIdentityById. */
+  /**
+   * VPCIdentityById.
+   */
   export interface VPCIdentityById extends VPCIdentity {
     /** The unique identifier for this VPC. */
     id: string;
   }
 
-  /** VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityFQDN. */
+  /**
+   * VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityFQDN.
+   */
   export interface VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityFQDN extends VPNGatewayConnectionIKEIdentityPrototype {
     /** The IKE identity FQDN value. */
     value: string;
@@ -52980,7 +57803,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityHostname. */
+  /**
+   * VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityHostname.
+   */
   export interface VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityHostname extends VPNGatewayConnectionIKEIdentityPrototype {
     /** The IKE identity hostname value. */
     value: string;
@@ -52997,7 +57822,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityIPv4. */
+  /**
+   * VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityIPv4.
+   */
   export interface VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityIPv4 extends VPNGatewayConnectionIKEIdentityPrototype {
     /** The IKE identity IPv4 address value. */
     value: string;
@@ -53014,7 +57841,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityKeyID. */
+  /**
+   * VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityKeyID.
+   */
   export interface VPNGatewayConnectionIKEIdentityPrototypeVPNGatewayConnectionIKEIdentityKeyID extends VPNGatewayConnectionIKEIdentityPrototype {
     /** The base64-encoded IKE identity key ID value. */
     value: string;
@@ -53031,7 +57860,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityFQDN. */
+  /**
+   * VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityFQDN.
+   */
   export interface VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityFQDN extends VPNGatewayConnectionIKEIdentity {
     /** The IKE identity FQDN value. */
     value: string;
@@ -53048,7 +57879,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityHostname. */
+  /**
+   * VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityHostname.
+   */
   export interface VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityHostname extends VPNGatewayConnectionIKEIdentity {
     /** The IKE identity hostname value. */
     value: string;
@@ -53065,7 +57898,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityIPv4. */
+  /**
+   * VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityIPv4.
+   */
   export interface VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityIPv4 extends VPNGatewayConnectionIKEIdentity {
     /** The IKE identity IPv4 address value. */
     value: string;
@@ -53082,7 +57917,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityKeyID. */
+  /**
+   * VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityKeyID.
+   */
   export interface VPNGatewayConnectionIKEIdentityVPNGatewayConnectionIKEIdentityKeyID extends VPNGatewayConnectionIKEIdentity {
     /** The base64-encoded IKE identity key ID value. */
     value: string;
@@ -53099,63 +57936,87 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityByHref. */
+  /**
+   * VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityByHref.
+   */
   export interface VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityByHref extends VPNGatewayConnectionIKEPolicyPatch {
     /** The URL for this IKE policy. */
     href: string;
   }
 
-  /** VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityById. */
+  /**
+   * VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityById.
+   */
   export interface VPNGatewayConnectionIKEPolicyPatchIKEPolicyIdentityById extends VPNGatewayConnectionIKEPolicyPatch {
     /** The unique identifier for this IKE policy. */
     id: string;
   }
 
-  /** VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityByHref. */
+  /**
+   * VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityByHref.
+   */
   export interface VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityByHref extends VPNGatewayConnectionIKEPolicyPrototype {
     /** The URL for this IKE policy. */
     href: string;
   }
 
-  /** VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityById. */
+  /**
+   * VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityById.
+   */
   export interface VPNGatewayConnectionIKEPolicyPrototypeIKEPolicyIdentityById extends VPNGatewayConnectionIKEPolicyPrototype {
     /** The unique identifier for this IKE policy. */
     id: string;
   }
 
-  /** VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityByHref. */
+  /**
+   * VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityByHref.
+   */
   export interface VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityByHref extends VPNGatewayConnectionIPsecPolicyPatch {
     /** The URL for this IPsec policy. */
     href: string;
   }
 
-  /** VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityById. */
+  /**
+   * VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityById.
+   */
   export interface VPNGatewayConnectionIPsecPolicyPatchIPsecPolicyIdentityById extends VPNGatewayConnectionIPsecPolicyPatch {
     /** The unique identifier for this IPsec policy. */
     id: string;
   }
 
-  /** VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityByHref. */
+  /**
+   * VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityByHref.
+   */
   export interface VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityByHref extends VPNGatewayConnectionIPsecPolicyPrototype {
     /** The URL for this IPsec policy. */
     href: string;
   }
 
-  /** VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityById. */
+  /**
+   * VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityById.
+   */
   export interface VPNGatewayConnectionIPsecPolicyPrototypeIPsecPolicyIdentityById extends VPNGatewayConnectionIPsecPolicyPrototype {
     /** The unique identifier for this IPsec policy. */
     id: string;
   }
 
-  /** The peer VPN gateway for this connection. If `peer.type` is `ipv4_address`, only `peer.address` may be specified. If `peer.type` is fqdn, only `peer.fqdn` may be specified. */
+  /**
+   * The peer VPN gateway for this connection. If `peer.type` is `ipv4_address`, only `peer.address` may be specified.
+   * If `peer.type` is fqdn, only `peer.fqdn` may be specified.
+   */
   export interface VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatch extends VPNGatewayConnectionPeerPatch {
   }
 
-  /** The peer VPN gateway for this connection. If `peer.type` is `ipv4_address`, only `peer.address` may be specified. If `peer.type` is fqdn, only `peer.fqdn` may be specified. */
+  /**
+   * The peer VPN gateway for this connection. If `peer.type` is `ipv4_address`, only `peer.address` may be specified.
+   * If `peer.type` is fqdn, only `peer.fqdn` may be specified.
+   */
   export interface VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatch extends VPNGatewayConnectionPeerPatch {
   }
 
-  /** VPNGatewayConnectionPolicyMode. */
+  /**
+   * VPNGatewayConnectionPolicyMode.
+   */
   export interface VPNGatewayConnectionPolicyMode extends VPNGatewayConnection {
     local: VPNGatewayConnectionPolicyModeLocal;
     peer: VPNGatewayConnectionPolicyModePeer;
@@ -53188,19 +58049,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionPolicyModePeerPrototypeVPNGatewayConnectionPeerByAddress. */
+  /**
+   * VPNGatewayConnectionPolicyModePeerPrototypeVPNGatewayConnectionPeerByAddress.
+   */
   export interface VPNGatewayConnectionPolicyModePeerPrototypeVPNGatewayConnectionPeerByAddress extends VPNGatewayConnectionPolicyModePeerPrototype {
     /** The IP address of the peer VPN gateway for this connection. */
     address: string;
   }
 
-  /** VPNGatewayConnectionPolicyModePeerPrototypeVPNGatewayConnectionPeerByFQDN. */
+  /**
+   * VPNGatewayConnectionPolicyModePeerPrototypeVPNGatewayConnectionPeerByFQDN.
+   */
   export interface VPNGatewayConnectionPolicyModePeerPrototypeVPNGatewayConnectionPeerByFQDN extends VPNGatewayConnectionPolicyModePeerPrototype {
     /** The FQDN of the peer VPN gateway for this connection. */
     fqdn: string;
   }
 
-  /** VPNGatewayConnectionPolicyModePeerVPNGatewayConnectionPeerByAddress. */
+  /**
+   * VPNGatewayConnectionPolicyModePeerVPNGatewayConnectionPeerByAddress.
+   */
   export interface VPNGatewayConnectionPolicyModePeerVPNGatewayConnectionPeerByAddress extends VPNGatewayConnectionPolicyModePeer {
     /** The IP address of the peer VPN gateway for this connection. */
     address: string;
@@ -53215,7 +58082,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionPolicyModePeerVPNGatewayConnectionPeerByFQDN. */
+  /**
+   * VPNGatewayConnectionPolicyModePeerVPNGatewayConnectionPeerByFQDN.
+   */
   export interface VPNGatewayConnectionPolicyModePeerVPNGatewayConnectionPeerByFQDN extends VPNGatewayConnectionPolicyModePeer {
     /** The FQDN of the peer VPN gateway for this connection. */
     fqdn: string;
@@ -53230,7 +58099,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionPrototypeVPNGatewayConnectionPolicyModePrototype. */
+  /**
+   * VPNGatewayConnectionPrototypeVPNGatewayConnectionPolicyModePrototype.
+   */
   export interface VPNGatewayConnectionPrototypeVPNGatewayConnectionPolicyModePrototype extends VPNGatewayConnectionPrototype {
     local: VPNGatewayConnectionPolicyModeLocalPrototype;
     peer: VPNGatewayConnectionPolicyModePeerPrototype;
@@ -53245,7 +58116,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionPrototypeVPNGatewayConnectionStaticRouteModePrototype. */
+  /**
+   * VPNGatewayConnectionPrototypeVPNGatewayConnectionStaticRouteModePrototype.
+   */
   export interface VPNGatewayConnectionPrototypeVPNGatewayConnectionStaticRouteModePrototype extends VPNGatewayConnectionPrototype {
     /** Indicates whether the traffic is distributed between the `up` tunnels of the VPN gateway connection when the
      *  VPC route's next hop is a VPN connection. If `false`, the traffic is only routed through the `up` tunnel with
@@ -53273,7 +58146,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionRouteMode. */
+  /**
+   * VPNGatewayConnectionRouteMode.
+   */
   export interface VPNGatewayConnectionRouteMode extends VPNGatewayConnection {
   }
   export namespace VPNGatewayConnectionRouteMode {
@@ -53304,19 +58179,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionStaticRouteModePeerPrototypeVPNGatewayConnectionPeerByAddress. */
+  /**
+   * VPNGatewayConnectionStaticRouteModePeerPrototypeVPNGatewayConnectionPeerByAddress.
+   */
   export interface VPNGatewayConnectionStaticRouteModePeerPrototypeVPNGatewayConnectionPeerByAddress extends VPNGatewayConnectionStaticRouteModePeerPrototype {
     /** The IP address of the peer VPN gateway for this connection. */
     address: string;
   }
 
-  /** VPNGatewayConnectionStaticRouteModePeerPrototypeVPNGatewayConnectionPeerByFQDN. */
+  /**
+   * VPNGatewayConnectionStaticRouteModePeerPrototypeVPNGatewayConnectionPeerByFQDN.
+   */
   export interface VPNGatewayConnectionStaticRouteModePeerPrototypeVPNGatewayConnectionPeerByFQDN extends VPNGatewayConnectionStaticRouteModePeerPrototype {
     /** The FQDN of the peer VPN gateway for this connection. */
     fqdn: string;
   }
 
-  /** VPNGatewayConnectionStaticRouteModePeerVPNGatewayConnectionPeerByAddress. */
+  /**
+   * VPNGatewayConnectionStaticRouteModePeerVPNGatewayConnectionPeerByAddress.
+   */
   export interface VPNGatewayConnectionStaticRouteModePeerVPNGatewayConnectionPeerByAddress extends VPNGatewayConnectionStaticRouteModePeer {
     /** The IP address of the peer VPN gateway for this connection. */
     address: string;
@@ -53331,7 +58212,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayConnectionStaticRouteModePeerVPNGatewayConnectionPeerByFQDN. */
+  /**
+   * VPNGatewayConnectionStaticRouteModePeerVPNGatewayConnectionPeerByFQDN.
+   */
   export interface VPNGatewayConnectionStaticRouteModePeerVPNGatewayConnectionPeerByFQDN extends VPNGatewayConnectionStaticRouteModePeer {
     /** The FQDN of the peer VPN gateway for this connection. */
     fqdn: string;
@@ -53346,7 +58229,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayPolicyMode. */
+  /**
+   * VPNGatewayPolicyMode.
+   */
   export interface VPNGatewayPolicyMode extends VPNGateway {
     /** Policy mode VPN gateway. */
     mode: VPNGatewayPolicyMode.Constants.Mode | string;
@@ -53381,7 +58266,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayPrototypeVPNGatewayPolicyModePrototype. */
+  /**
+   * VPNGatewayPrototypeVPNGatewayPolicyModePrototype.
+   */
   export interface VPNGatewayPrototypeVPNGatewayPolicyModePrototype extends VPNGatewayPrototype {
     /** Policy mode VPN gateway. */
     mode?: VPNGatewayPrototypeVPNGatewayPolicyModePrototype.Constants.Mode | string;
@@ -53395,7 +58282,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayPrototypeVPNGatewayRouteModePrototype. */
+  /**
+   * VPNGatewayPrototypeVPNGatewayRouteModePrototype.
+   */
   export interface VPNGatewayPrototypeVPNGatewayRouteModePrototype extends VPNGatewayPrototype {
     /** Route mode VPN gateway. */
     mode?: VPNGatewayPrototypeVPNGatewayRouteModePrototype.Constants.Mode | string;
@@ -53409,7 +58298,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNGatewayRouteMode. */
+  /**
+   * VPNGatewayRouteMode.
+   */
   export interface VPNGatewayRouteMode extends VPNGateway {
     /** Route mode VPN gateway. */
     mode: VPNGatewayRouteMode.Constants.Mode | string;
@@ -53444,7 +58335,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerAuthenticationByCertificate. */
+  /**
+   * VPNServerAuthenticationByCertificate.
+   */
   export interface VPNServerAuthenticationByCertificate extends VPNServerAuthentication {
     /** The certificate instance used for the VPN client certificate authority (CA). */
     client_ca: CertificateInstanceReference;
@@ -53461,7 +58354,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerAuthenticationByUsername. */
+  /**
+   * VPNServerAuthenticationByUsername.
+   */
   export interface VPNServerAuthenticationByUsername extends VPNServerAuthentication {
     /** The type of identity provider to be used by VPN client. */
     identity_provider: VPNServerAuthenticationByUsernameIdProvider;
@@ -53476,7 +58371,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerAuthenticationByUsernameIdProviderByIAM. */
+  /**
+   * VPNServerAuthenticationByUsernameIdProviderByIAM.
+   */
   export interface VPNServerAuthenticationByUsernameIdProviderByIAM extends VPNServerAuthenticationByUsernameIdProvider {
     /** The type of identity provider to be used by the VPN client:
      *  - `iam`: IBM identity and access management
@@ -53495,7 +58392,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerAuthenticationPrototypeVPNServerAuthenticationByCertificatePrototype. */
+  /**
+   * VPNServerAuthenticationPrototypeVPNServerAuthenticationByCertificatePrototype.
+   */
   export interface VPNServerAuthenticationPrototypeVPNServerAuthenticationByCertificatePrototype extends VPNServerAuthenticationPrototype {
     /** The certificate instance to use for the VPN client certificate authority (CA). */
     client_ca: CertificateInstanceIdentity;
@@ -53512,7 +58411,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VPNServerAuthenticationPrototypeVPNServerAuthenticationByUsernamePrototype. */
+  /**
+   * VPNServerAuthenticationPrototypeVPNServerAuthenticationByUsernamePrototype.
+   */
   export interface VPNServerAuthenticationPrototypeVPNServerAuthenticationByUsernamePrototype extends VPNServerAuthenticationPrototype {
     /** The type of identity provider to be used by VPN client. */
     identity_provider: VPNServerAuthenticationByUsernameIdProvider;
@@ -53527,11 +58428,16 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a reserved IP by a unique property. The reserved IP must be currently unbound and in the primary IP's subnet. */
+  /**
+   * Identifies a reserved IP by a unique property. The reserved IP must be currently unbound and in the primary IP's
+   * subnet.
+   */
   export interface VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContext extends VirtualNetworkInterfaceIPPrototype {
   }
 
-  /** The prototype for a new reserved IP. Must be in the primary IP's subnet. */
+  /**
+   * The prototype for a new reserved IP. Must be in the primary IP's subnet.
+   */
   export interface VirtualNetworkInterfaceIPPrototypeReservedIPPrototypeVirtualNetworkInterfaceIPsContext extends VirtualNetworkInterfaceIPPrototype {
     /** The IP address to reserve, which must not already be reserved on the subnet.
      *
@@ -53549,11 +58455,16 @@ namespace VpcV1 {
     name?: string;
   }
 
-  /** Identifies a reserved IP by a unique property. Required if `subnet` is not specified. The reserved IP must be currently unbound. */
+  /**
+   * Identifies a reserved IP by a unique property. Required if `subnet` is not specified. The reserved IP must be
+   * currently unbound.
+   */
   export interface VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContext extends VirtualNetworkInterfacePrimaryIPPrototype {
   }
 
-  /** The prototype for a new reserved IP. Requires `subnet` to be specified. */
+  /**
+   * The prototype for a new reserved IP. Requires `subnet` to be specified.
+   */
   export interface VirtualNetworkInterfacePrimaryIPPrototypeReservedIPPrototypeVirtualNetworkInterfacePrimaryIPContext extends VirtualNetworkInterfacePrimaryIPPrototype {
     /** The IP address to reserve, which must not already be reserved on the subnet.
      *
@@ -53571,7 +58482,9 @@ namespace VpcV1 {
     name?: string;
   }
 
-  /** VirtualNetworkInterfaceTargetBareMetalServerNetworkAttachmentReferenceVirtualNetworkInterfaceContext. */
+  /**
+   * VirtualNetworkInterfaceTargetBareMetalServerNetworkAttachmentReferenceVirtualNetworkInterfaceContext.
+   */
   export interface VirtualNetworkInterfaceTargetBareMetalServerNetworkAttachmentReferenceVirtualNetworkInterfaceContext extends VirtualNetworkInterfaceTarget {
     /** The URL for this bare metal server network attachment. */
     href: string;
@@ -53593,7 +58506,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VirtualNetworkInterfaceTargetInstanceNetworkAttachmentReferenceVirtualNetworkInterfaceContext. */
+  /**
+   * VirtualNetworkInterfaceTargetInstanceNetworkAttachmentReferenceVirtualNetworkInterfaceContext.
+   */
   export interface VirtualNetworkInterfaceTargetInstanceNetworkAttachmentReferenceVirtualNetworkInterfaceContext extends VirtualNetworkInterfaceTarget {
     /** The URL for this instance network attachment. */
     href: string;
@@ -53615,7 +58530,9 @@ namespace VpcV1 {
     }
   }
 
-  /** VirtualNetworkInterfaceTargetShareMountTargetReference. */
+  /**
+   * VirtualNetworkInterfaceTargetShareMountTargetReference.
+   */
   export interface VirtualNetworkInterfaceTargetShareMountTargetReference extends VirtualNetworkInterfaceTarget {
     /** If present, this property indicates the referenced resource has been deleted, and provides
      *  some supplementary information.
@@ -53639,11 +58556,15 @@ namespace VpcV1 {
     }
   }
 
-  /** Identifies a volume by a unique property. */
+  /**
+   * Identifies a volume by a unique property.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumeIdentity extends VolumeAttachmentPrototypeVolume {
   }
 
-  /** VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext. */
+  /**
+   * VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext extends VolumeAttachmentPrototypeVolume {
     /** The maximum I/O operations per second (IOPS) to use for this volume. If specified, the `family` of the
      *  volume profile must be `custom` or `defined_performance`.
@@ -53661,25 +58582,33 @@ namespace VpcV1 {
     user_tags?: string[];
   }
 
-  /** VolumeIdentityByCRN. */
+  /**
+   * VolumeIdentityByCRN.
+   */
   export interface VolumeIdentityByCRN extends VolumeIdentity {
     /** The CRN for this volume. */
     crn: string;
   }
 
-  /** VolumeIdentityByHref. */
+  /**
+   * VolumeIdentityByHref.
+   */
   export interface VolumeIdentityByHref extends VolumeIdentity {
     /** The URL for this volume. */
     href: string;
   }
 
-  /** VolumeIdentityById. */
+  /**
+   * VolumeIdentityById.
+   */
   export interface VolumeIdentityById extends VolumeIdentity {
     /** The unique identifier for this volume. */
     id: string;
   }
 
-  /** The permitted total capacity (in gigabytes) of a boot volume with this profile depends on its configuration. */
+  /**
+   * The permitted total capacity (in gigabytes) of a boot volume with this profile depends on its configuration.
+   */
   export interface VolumeProfileBootCapacityDependentRange extends VolumeProfileBootCapacity {
     /** The maximum value for this profile field. */
     max: number;
@@ -53699,7 +58628,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacities (in gigabytes) of a boot volume with this profile. */
+  /**
+   * The permitted total capacities (in gigabytes) of a boot volume with this profile.
+   */
   export interface VolumeProfileBootCapacityEnum extends VolumeProfileBootCapacity {
     /** The default value for this profile field. */
     default: number;
@@ -53717,7 +58648,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity (in gigabytes) of a boot volume with this profile is fixed. */
+  /**
+   * The permitted total capacity (in gigabytes) of a boot volume with this profile is fixed.
+   */
   export interface VolumeProfileBootCapacityFixed extends VolumeProfileBootCapacity {
     /** The type for this profile field. */
     type: VolumeProfileBootCapacityFixed.Constants.Type | string;
@@ -53733,7 +58666,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity range (in gigabytes) of a boot volume with this profile. */
+  /**
+   * The permitted total capacity range (in gigabytes) of a boot volume with this profile.
+   */
   export interface VolumeProfileBootCapacityRange extends VolumeProfileBootCapacity {
     /** The default value for this profile field. */
     default: number;
@@ -53755,7 +58690,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity (in gigabytes) of a data volume with this profile depends on its configuration. */
+  /**
+   * The permitted total capacity (in gigabytes) of a data volume with this profile depends on its configuration.
+   */
   export interface VolumeProfileCapacityDependentRange extends VolumeProfileCapacity {
     /** The maximum value for this profile field. */
     max: number;
@@ -53775,7 +58712,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacities (in gigabytes) of a data volume with this profile. */
+  /**
+   * The permitted total capacities (in gigabytes) of a data volume with this profile.
+   */
   export interface VolumeProfileCapacityEnum extends VolumeProfileCapacity {
     /** The default value for this profile field. */
     default: number;
@@ -53793,7 +58732,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity (in gigabytes) of a data volume with this profile is fixed. */
+  /**
+   * The permitted total capacity (in gigabytes) of a data volume with this profile is fixed.
+   */
   export interface VolumeProfileCapacityFixed extends VolumeProfileCapacity {
     /** The type for this profile field. */
     type: VolumeProfileCapacityFixed.Constants.Type | string;
@@ -53809,7 +58750,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted total capacity range (in gigabytes) of a data volume with this profile. */
+  /**
+   * The permitted total capacity range (in gigabytes) of a data volume with this profile.
+   */
   export interface VolumeProfileCapacityRange extends VolumeProfileCapacity {
     /** The default value for this profile field. */
     default: number;
@@ -53831,7 +58774,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS range of a volume with this profile depends on its configuration. */
+  /**
+   * The permitted IOPS range of a volume with this profile depends on its configuration.
+   */
   export interface VolumeProfileIOPSDependentRange extends VolumeProfileIOPS {
     /** The maximum value for this profile field. */
     max: number;
@@ -53851,7 +58796,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS values of a volume with this profile. */
+  /**
+   * The permitted IOPS values of a volume with this profile.
+   */
   export interface VolumeProfileIOPSEnum extends VolumeProfileIOPS {
     /** The default value for this profile field. */
     default: number;
@@ -53869,7 +58816,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS of a volume with this profile is fixed. */
+  /**
+   * The permitted IOPS of a volume with this profile is fixed.
+   */
   export interface VolumeProfileIOPSFixed extends VolumeProfileIOPS {
     /** The type for this profile field. */
     type: VolumeProfileIOPSFixed.Constants.Type | string;
@@ -53885,7 +58834,9 @@ namespace VpcV1 {
     }
   }
 
-  /** The permitted IOPS range of a volume with this profile. */
+  /**
+   * The permitted IOPS range of a volume with this profile.
+   */
   export interface VolumeProfileIOPSRange extends VolumeProfileIOPS {
     /** The default value for this profile field. */
     default: number;
@@ -53907,19 +58858,25 @@ namespace VpcV1 {
     }
   }
 
-  /** VolumeProfileIdentityByHref. */
+  /**
+   * VolumeProfileIdentityByHref.
+   */
   export interface VolumeProfileIdentityByHref extends VolumeProfileIdentity {
     /** The URL for this volume profile. */
     href: string;
   }
 
-  /** VolumeProfileIdentityByName. */
+  /**
+   * VolumeProfileIdentityByName.
+   */
   export interface VolumeProfileIdentityByName extends VolumeProfileIdentity {
     /** The globally unique name for this volume profile. */
     name: string;
   }
 
-  /** VolumePrototypeVolumeByCapacity. */
+  /**
+   * VolumePrototypeVolumeByCapacity.
+   */
   export interface VolumePrototypeVolumeByCapacity extends VolumePrototype {
     /** The capacity to use for the volume (in gigabytes). The specified value must be within the `capacity` range
      *  of the volume's profile.
@@ -53932,7 +58889,9 @@ namespace VpcV1 {
     encryption_key?: EncryptionKeyIdentity;
   }
 
-  /** VolumePrototypeVolumeBySourceSnapshot. */
+  /**
+   * VolumePrototypeVolumeBySourceSnapshot.
+   */
   export interface VolumePrototypeVolumeBySourceSnapshot extends VolumePrototype {
     /** The capacity to use for the volume (in gigabytes). The specified value must be at least the snapshot's
      *  `minimum_capacity`, and must be within the `capacity` range of the volume's profile.
@@ -53952,55 +58911,89 @@ namespace VpcV1 {
     source_snapshot: SnapshotIdentity;
   }
 
-  /** ZoneIdentityByHref. */
+  /**
+   * ZoneIdentityByHref.
+   */
   export interface ZoneIdentityByHref extends ZoneIdentity {
     /** The URL for this zone. */
     href: string;
   }
 
-  /** ZoneIdentityByName. */
+  /**
+   * ZoneIdentityByName.
+   */
   export interface ZoneIdentityByName extends ZoneIdentity {
     /** The globally unique name for this zone. */
     name: string;
   }
 
-  /** BackupPolicyScopePrototypeEnterpriseIdentityEnterpriseIdentityByCRN. */
+  /**
+   * BackupPolicyScopePrototypeEnterpriseIdentityEnterpriseIdentityByCRN.
+   */
   export interface BackupPolicyScopePrototypeEnterpriseIdentityEnterpriseIdentityByCRN extends BackupPolicyScopePrototypeEnterpriseIdentity {
     /** The CRN for this enterprise. */
     crn: string;
   }
 
-  /** BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends BareMetalServerNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** EndpointGatewayReservedIPReservedIPIdentityByHref. */
+  /**
+   * ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContextByHref.
+   */
+  export interface ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContextByHref extends ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContext {
+    /** The URL for this cluster network subnet reserved IP. */
+    href: string;
+  }
+
+  /**
+   * ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContextById.
+   */
+  export interface ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContextById extends ClusterNetworkInterfacePrimaryIPPrototypeClusterNetworkSubnetReservedIPIdentityClusterNetworkInterfacePrimaryIPContext {
+    /** The unique identifier for this cluster network subnet reserved IP. */
+    id: string;
+  }
+
+  /**
+   * EndpointGatewayReservedIPReservedIPIdentityByHref.
+   */
   export interface EndpointGatewayReservedIPReservedIPIdentityByHref extends EndpointGatewayReservedIPReservedIPIdentity {
     /** The URL for this reserved IP. */
     href: string;
   }
 
-  /** EndpointGatewayReservedIPReservedIPIdentityById. */
+  /**
+   * EndpointGatewayReservedIPReservedIPIdentityById.
+   */
   export interface EndpointGatewayReservedIPReservedIPIdentityById extends EndpointGatewayReservedIPReservedIPIdentity {
     /** The unique identifier for this reserved IP. */
     id: string;
   }
 
-  /** FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityByHref. */
+  /**
+   * FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityByHref.
+   */
   export interface FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityByHref extends FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentity {
     /** The URL for this bare metal server network interface.
      *
@@ -54011,7 +59004,9 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById. */
+  /**
+   * FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById.
+   */
   export interface FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById extends FloatingIPTargetPatchBareMetalServerNetworkInterfaceIdentity {
     /** The unique identifier for this bare metal server network interface.
      *
@@ -54023,7 +59018,9 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** FloatingIPTargetPatchNetworkInterfaceIdentityNetworkInterfaceIdentityByHref. */
+  /**
+   * FloatingIPTargetPatchNetworkInterfaceIdentityNetworkInterfaceIdentityByHref.
+   */
   export interface FloatingIPTargetPatchNetworkInterfaceIdentityNetworkInterfaceIdentityByHref extends FloatingIPTargetPatchNetworkInterfaceIdentity {
     /** The URL for this instance network interface.
      *
@@ -54034,7 +59031,9 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** FloatingIPTargetPatchNetworkInterfaceIdentityNetworkInterfaceIdentityById. */
+  /**
+   * FloatingIPTargetPatchNetworkInterfaceIdentityNetworkInterfaceIdentityById.
+   */
   export interface FloatingIPTargetPatchNetworkInterfaceIdentityNetworkInterfaceIdentityById extends FloatingIPTargetPatchNetworkInterfaceIdentity {
     /** The unique identifier for this instance network interface.
      *
@@ -54046,25 +59045,33 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends FloatingIPTargetPatchVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends FloatingIPTargetPatchVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface FloatingIPTargetPatchVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends FloatingIPTargetPatchVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityByHref. */
+  /**
+   * FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityByHref.
+   */
   export interface FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityByHref extends FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentity {
     /** The URL for this bare metal server network interface.
      *
@@ -54075,7 +59082,9 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById. */
+  /**
+   * FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById.
+   */
   export interface FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentityBareMetalServerNetworkInterfaceIdentityById extends FloatingIPTargetPrototypeBareMetalServerNetworkInterfaceIdentity {
     /** The unique identifier for this bare metal server network interface.
      *
@@ -54087,7 +59096,9 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** FloatingIPTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityByHref. */
+  /**
+   * FloatingIPTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityByHref.
+   */
   export interface FloatingIPTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityByHref extends FloatingIPTargetPrototypeNetworkInterfaceIdentity {
     /** The URL for this instance network interface.
      *
@@ -54098,7 +59109,9 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** FloatingIPTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById. */
+  /**
+   * FloatingIPTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById.
+   */
   export interface FloatingIPTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById extends FloatingIPTargetPrototypeNetworkInterfaceIdentity {
     /** The unique identifier for this instance network interface.
      *
@@ -54110,55 +59123,73 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends FloatingIPTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityByCRN. */
+  /**
+   * FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityByCRN.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityByCRN extends FlowLogCollectorTargetPrototypeInstanceIdentity {
     /** The CRN for this virtual server instance. */
     crn: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityByHref. */
+  /**
+   * FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityByHref.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityByHref extends FlowLogCollectorTargetPrototypeInstanceIdentity {
     /** The URL for this virtual server instance. */
     href: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityById. */
+  /**
+   * FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityById.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceIdentityInstanceIdentityById extends FlowLogCollectorTargetPrototypeInstanceIdentity {
     /** The unique identifier for this virtual server instance. */
     id: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentityInstanceNetworkAttachmentIdentityByHref. */
+  /**
+   * FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentityInstanceNetworkAttachmentIdentityByHref.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentityInstanceNetworkAttachmentIdentityByHref extends FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentity {
     /** The URL for this instance network attachment. */
     href: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentityInstanceNetworkAttachmentIdentityById. */
+  /**
+   * FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentityInstanceNetworkAttachmentIdentityById.
+   */
   export interface FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentityInstanceNetworkAttachmentIdentityById extends FlowLogCollectorTargetPrototypeInstanceNetworkAttachmentIdentity {
     /** The unique identifier for this instance network attachment. */
     id: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityByHref. */
+  /**
+   * FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityByHref.
+   */
   export interface FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityByHref extends FlowLogCollectorTargetPrototypeNetworkInterfaceIdentity {
     /** The URL for this instance network interface.
      *
@@ -54169,7 +59200,9 @@ namespace VpcV1 {
     href: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById. */
+  /**
+   * FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById.
+   */
   export interface FlowLogCollectorTargetPrototypeNetworkInterfaceIdentityNetworkInterfaceIdentityById extends FlowLogCollectorTargetPrototypeNetworkInterfaceIdentity {
     /** The unique identifier for this instance network interface.
      *
@@ -54181,61 +59214,97 @@ namespace VpcV1 {
     id: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityByCRN. */
+  /**
+   * FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityByCRN.
+   */
   export interface FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityByCRN extends FlowLogCollectorTargetPrototypeSubnetIdentity {
     /** The CRN for this subnet. */
     crn: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityByHref. */
+  /**
+   * FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityByHref.
+   */
   export interface FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityByHref extends FlowLogCollectorTargetPrototypeSubnetIdentity {
     /** The URL for this subnet. */
     href: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityById. */
+  /**
+   * FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityById.
+   */
   export interface FlowLogCollectorTargetPrototypeSubnetIdentitySubnetIdentityById extends FlowLogCollectorTargetPrototypeSubnetIdentity {
     /** The unique identifier for this subnet. */
     id: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByCRN. */
+  /**
+   * FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByCRN.
+   */
   export interface FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByCRN extends FlowLogCollectorTargetPrototypeVPCIdentity {
     /** The CRN for this VPC. */
     crn: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByHref. */
+  /**
+   * FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByHref.
+   */
   export interface FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByHref extends FlowLogCollectorTargetPrototypeVPCIdentity {
     /** The URL for this VPC. */
     href: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityById. */
+  /**
+   * FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityById.
+   */
   export interface FlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityById extends FlowLogCollectorTargetPrototypeVPCIdentity {
     /** The unique identifier for this VPC. */
     id: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends FlowLogCollectorTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec. */
+  /**
+   * InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentityClusterNetworkInterfaceIdentityByHref.
+   */
+  export interface InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentityClusterNetworkInterfaceIdentityByHref extends InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentity {
+    /** The URL for this cluster network interface. */
+    href: string;
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentityClusterNetworkInterfaceIdentityById.
+   */
+  export interface InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentityClusterNetworkInterfaceIdentityById extends InstanceClusterNetworkAttachmentPrototypeClusterNetworkInterfaceClusterNetworkInterfaceIdentity {
+    /** The unique identifier for this cluster network interface. */
+    id: string;
+  }
+
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec extends InstanceGroupManagerActionPrototypeScheduledActionPrototype {
     /** The cron specification for a recurring scheduled action. Actions can be applied a maximum of one time within
      *  a 5 min period.
@@ -54243,13 +59312,17 @@ namespace VpcV1 {
     cron_spec?: string;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt. */
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt extends InstanceGroupManagerActionPrototypeScheduledActionPrototype {
     /** The date and time the scheduled action will run. */
     run_at?: string;
   }
 
-  /** InstanceGroupManagerActionScheduledActionGroupTarget. */
+  /**
+   * InstanceGroupManagerActionScheduledActionGroupTarget.
+   */
   export interface InstanceGroupManagerActionScheduledActionGroupTarget extends InstanceGroupManagerActionScheduledAction {
     group: InstanceGroupManagerScheduledActionGroup;
   }
@@ -54274,7 +59347,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerActionScheduledActionManagerTarget. */
+  /**
+   * InstanceGroupManagerActionScheduledActionManagerTarget.
+   */
   export interface InstanceGroupManagerActionScheduledActionManagerTarget extends InstanceGroupManagerActionScheduledAction {
     manager: InstanceGroupManagerScheduledActionManager;
   }
@@ -54299,127 +59374,169 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeByHref. */
+  /**
+   * InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeByHref.
+   */
   export interface InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeByHref extends InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototype {
     /** The URL for this instance group manager. */
     href: string;
   }
 
-  /** InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeById. */
+  /**
+   * InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeById.
+   */
   export interface InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototypeById extends InstanceGroupManagerScheduledActionManagerPrototypeAutoScalePrototype {
     /** The unique identifier for this instance group manager. */
     id: string;
   }
 
-  /** InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends InstanceNetworkAttachmentPrototypeVirtualNetworkInterfaceVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityByCRN. */
+  /**
+   * InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityByCRN.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityByCRN extends InstancePlacementTargetPatchDedicatedHostGroupIdentity {
     /** The CRN for this dedicated host group. */
     crn: string;
   }
 
-  /** InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityByHref. */
+  /**
+   * InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityByHref.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityByHref extends InstancePlacementTargetPatchDedicatedHostGroupIdentity {
     /** The URL for this dedicated host group. */
     href: string;
   }
 
-  /** InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityById. */
+  /**
+   * InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityById.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostGroupIdentityDedicatedHostGroupIdentityById extends InstancePlacementTargetPatchDedicatedHostGroupIdentity {
     /** The unique identifier for this dedicated host group. */
     id: string;
   }
 
-  /** InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityByCRN. */
+  /**
+   * InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityByCRN.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityByCRN extends InstancePlacementTargetPatchDedicatedHostIdentity {
     /** The CRN for this dedicated host. */
     crn: string;
   }
 
-  /** InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityByHref. */
+  /**
+   * InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityByHref.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityByHref extends InstancePlacementTargetPatchDedicatedHostIdentity {
     /** The URL for this dedicated host. */
     href: string;
   }
 
-  /** InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityById. */
+  /**
+   * InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityById.
+   */
   export interface InstancePlacementTargetPatchDedicatedHostIdentityDedicatedHostIdentityById extends InstancePlacementTargetPatchDedicatedHostIdentity {
     /** The unique identifier for this dedicated host. */
     id: string;
   }
 
-  /** InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByCRN. */
+  /**
+   * InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByCRN.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByCRN extends InstancePlacementTargetPrototypeDedicatedHostGroupIdentity {
     /** The CRN for this dedicated host group. */
     crn: string;
   }
 
-  /** InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByHref. */
+  /**
+   * InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByHref.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityByHref extends InstancePlacementTargetPrototypeDedicatedHostGroupIdentity {
     /** The URL for this dedicated host group. */
     href: string;
   }
 
-  /** InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityById. */
+  /**
+   * InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityById.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostGroupIdentityDedicatedHostGroupIdentityById extends InstancePlacementTargetPrototypeDedicatedHostGroupIdentity {
     /** The unique identifier for this dedicated host group. */
     id: string;
   }
 
-  /** InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityByCRN. */
+  /**
+   * InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityByCRN.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityByCRN extends InstancePlacementTargetPrototypeDedicatedHostIdentity {
     /** The CRN for this dedicated host. */
     crn: string;
   }
 
-  /** InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityByHref. */
+  /**
+   * InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityByHref.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityByHref extends InstancePlacementTargetPrototypeDedicatedHostIdentity {
     /** The URL for this dedicated host. */
     href: string;
   }
 
-  /** InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById. */
+  /**
+   * InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById.
+   */
   export interface InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById extends InstancePlacementTargetPrototypeDedicatedHostIdentity {
     /** The unique identifier for this dedicated host. */
     id: string;
   }
 
-  /** InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityByCRN. */
+  /**
+   * InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityByCRN.
+   */
   export interface InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityByCRN extends InstancePlacementTargetPrototypePlacementGroupIdentity {
     /** The CRN for this placement group. */
     crn: string;
   }
 
-  /** InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityByHref. */
+  /**
+   * InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityByHref.
+   */
   export interface InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityByHref extends InstancePlacementTargetPrototypePlacementGroupIdentity {
     /** The URL for this placement group. */
     href: string;
   }
 
-  /** InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityById. */
+  /**
+   * InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityById.
+   */
   export interface InstancePlacementTargetPrototypePlacementGroupIdentityPlacementGroupIdentityById extends InstancePlacementTargetPrototypePlacementGroupIdentity {
     /** The unique identifier for this placement group. */
     id: string;
   }
 
-  /** InstancePrototypeInstanceByCatalogOfferingInstanceByCatalogOfferingInstanceByNetworkAttachment. */
+  /**
+   * InstancePrototypeInstanceByCatalogOfferingInstanceByCatalogOfferingInstanceByNetworkAttachment.
+   */
   export interface InstancePrototypeInstanceByCatalogOfferingInstanceByCatalogOfferingInstanceByNetworkAttachment extends InstancePrototypeInstanceByCatalogOffering {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54436,7 +59553,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceByCatalogOfferingInstanceByCatalogOfferingInstanceByNetworkInterface. */
+  /**
+   * InstancePrototypeInstanceByCatalogOfferingInstanceByCatalogOfferingInstanceByNetworkInterface.
+   */
   export interface InstancePrototypeInstanceByCatalogOfferingInstanceByCatalogOfferingInstanceByNetworkInterface extends InstancePrototypeInstanceByCatalogOffering {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54453,7 +59572,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceByImageInstanceByImageInstanceByNetworkAttachment. */
+  /**
+   * InstancePrototypeInstanceByImageInstanceByImageInstanceByNetworkAttachment.
+   */
   export interface InstancePrototypeInstanceByImageInstanceByImageInstanceByNetworkAttachment extends InstancePrototypeInstanceByImage {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54470,7 +59591,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceByImageInstanceByImageInstanceByNetworkInterface. */
+  /**
+   * InstancePrototypeInstanceByImageInstanceByImageInstanceByNetworkInterface.
+   */
   export interface InstancePrototypeInstanceByImageInstanceByImageInstanceByNetworkInterface extends InstancePrototypeInstanceByImage {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54487,7 +59610,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceBySourceSnapshotInstanceBySourceSnapshotInstanceByNetworkAttachment. */
+  /**
+   * InstancePrototypeInstanceBySourceSnapshotInstanceBySourceSnapshotInstanceByNetworkAttachment.
+   */
   export interface InstancePrototypeInstanceBySourceSnapshotInstanceBySourceSnapshotInstanceByNetworkAttachment extends InstancePrototypeInstanceBySourceSnapshot {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54504,7 +59629,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceBySourceSnapshotInstanceBySourceSnapshotInstanceByNetworkInterface. */
+  /**
+   * InstancePrototypeInstanceBySourceSnapshotInstanceBySourceSnapshotInstanceByNetworkInterface.
+   */
   export interface InstancePrototypeInstanceBySourceSnapshotInstanceBySourceSnapshotInstanceByNetworkInterface extends InstancePrototypeInstanceBySourceSnapshot {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54521,7 +59648,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceByVolumeInstanceByVolumeInstanceByNetworkAttachment. */
+  /**
+   * InstancePrototypeInstanceByVolumeInstanceByVolumeInstanceByNetworkAttachment.
+   */
   export interface InstancePrototypeInstanceByVolumeInstanceByVolumeInstanceByNetworkAttachment extends InstancePrototypeInstanceByVolume {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54538,7 +59667,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstancePrototypeInstanceByVolumeInstanceByVolumeInstanceByNetworkInterface. */
+  /**
+   * InstancePrototypeInstanceByVolumeInstanceByVolumeInstanceByNetworkInterface.
+   */
   export interface InstancePrototypeInstanceByVolumeInstanceByVolumeInstanceByNetworkInterface extends InstancePrototypeInstanceByVolume {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54555,7 +59686,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplatePrototypeInstanceTemplateByCatalogOfferingInstanceTemplateByCatalogOfferingInstanceByNetworkAttachment. */
+  /**
+   * InstanceTemplatePrototypeInstanceTemplateByCatalogOfferingInstanceTemplateByCatalogOfferingInstanceByNetworkAttachment.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateByCatalogOfferingInstanceTemplateByCatalogOfferingInstanceByNetworkAttachment extends InstanceTemplatePrototypeInstanceTemplateByCatalogOffering {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54572,7 +59705,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplatePrototypeInstanceTemplateByCatalogOfferingInstanceTemplateByCatalogOfferingInstanceByNetworkInterface. */
+  /**
+   * InstanceTemplatePrototypeInstanceTemplateByCatalogOfferingInstanceTemplateByCatalogOfferingInstanceByNetworkInterface.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateByCatalogOfferingInstanceTemplateByCatalogOfferingInstanceByNetworkInterface extends InstanceTemplatePrototypeInstanceTemplateByCatalogOffering {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54589,7 +59724,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplatePrototypeInstanceTemplateByImageInstanceTemplateByImageInstanceByNetworkAttachment. */
+  /**
+   * InstanceTemplatePrototypeInstanceTemplateByImageInstanceTemplateByImageInstanceByNetworkAttachment.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateByImageInstanceTemplateByImageInstanceByNetworkAttachment extends InstanceTemplatePrototypeInstanceTemplateByImage {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54606,7 +59743,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplatePrototypeInstanceTemplateByImageInstanceTemplateByImageInstanceByNetworkInterface. */
+  /**
+   * InstanceTemplatePrototypeInstanceTemplateByImageInstanceTemplateByImageInstanceByNetworkInterface.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateByImageInstanceTemplateByImageInstanceByNetworkInterface extends InstanceTemplatePrototypeInstanceTemplateByImage {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54623,7 +59762,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplatePrototypeInstanceTemplateBySourceSnapshotInstanceTemplateBySourceSnapshotInstanceByNetworkAttachment. */
+  /**
+   * InstanceTemplatePrototypeInstanceTemplateBySourceSnapshotInstanceTemplateBySourceSnapshotInstanceByNetworkAttachment.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateBySourceSnapshotInstanceTemplateBySourceSnapshotInstanceByNetworkAttachment extends InstanceTemplatePrototypeInstanceTemplateBySourceSnapshot {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54640,7 +59781,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplatePrototypeInstanceTemplateBySourceSnapshotInstanceTemplateBySourceSnapshotInstanceByNetworkInterface. */
+  /**
+   * InstanceTemplatePrototypeInstanceTemplateBySourceSnapshotInstanceTemplateBySourceSnapshotInstanceByNetworkInterface.
+   */
   export interface InstanceTemplatePrototypeInstanceTemplateBySourceSnapshotInstanceTemplateBySourceSnapshotInstanceByNetworkInterface extends InstanceTemplatePrototypeInstanceTemplateBySourceSnapshot {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54657,7 +59800,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContextInstanceByCatalogOfferingInstanceTemplateContextInstanceByNetworkAttachment. */
+  /**
+   * InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContextInstanceByCatalogOfferingInstanceTemplateContextInstanceByNetworkAttachment.
+   */
   export interface InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContextInstanceByCatalogOfferingInstanceTemplateContextInstanceByNetworkAttachment extends InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContext {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54674,7 +59819,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContextInstanceByCatalogOfferingInstanceTemplateContextInstanceByNetworkInterface. */
+  /**
+   * InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContextInstanceByCatalogOfferingInstanceTemplateContextInstanceByNetworkInterface.
+   */
   export interface InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContextInstanceByCatalogOfferingInstanceTemplateContextInstanceByNetworkInterface extends InstanceTemplateInstanceByCatalogOfferingInstanceTemplateContext {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54691,7 +59838,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateInstanceByImageInstanceTemplateContextInstanceByImageInstanceTemplateContextInstanceByNetworkAttachment. */
+  /**
+   * InstanceTemplateInstanceByImageInstanceTemplateContextInstanceByImageInstanceTemplateContextInstanceByNetworkAttachment.
+   */
   export interface InstanceTemplateInstanceByImageInstanceTemplateContextInstanceByImageInstanceTemplateContextInstanceByNetworkAttachment extends InstanceTemplateInstanceByImageInstanceTemplateContext {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54708,7 +59857,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateInstanceByImageInstanceTemplateContextInstanceByImageInstanceTemplateContextInstanceByNetworkInterface. */
+  /**
+   * InstanceTemplateInstanceByImageInstanceTemplateContextInstanceByImageInstanceTemplateContextInstanceByNetworkInterface.
+   */
   export interface InstanceTemplateInstanceByImageInstanceTemplateContextInstanceByImageInstanceTemplateContextInstanceByNetworkInterface extends InstanceTemplateInstanceByImageInstanceTemplateContext {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54725,7 +59876,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContextInstanceBySourceSnapshotInstanceTemplateContextInstanceByNetworkAttachment. */
+  /**
+   * InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContextInstanceBySourceSnapshotInstanceTemplateContextInstanceByNetworkAttachment.
+   */
   export interface InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContextInstanceBySourceSnapshotInstanceTemplateContextInstanceByNetworkAttachment extends InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContext {
     /** The additional network attachments to create for the virtual server instance. */
     network_attachments?: InstanceNetworkAttachmentPrototype[];
@@ -54742,7 +59895,9 @@ namespace VpcV1 {
     }
   }
 
-  /** InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContextInstanceBySourceSnapshotInstanceTemplateContextInstanceByNetworkInterface. */
+  /**
+   * InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContextInstanceBySourceSnapshotInstanceTemplateContextInstanceByNetworkInterface.
+   */
   export interface InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContextInstanceBySourceSnapshotInstanceTemplateContextInstanceByNetworkInterface extends InstanceTemplateInstanceBySourceSnapshotInstanceTemplateContext {
     /** The additional instance network interfaces to create. */
     network_interfaces?: NetworkInterfacePrototype[];
@@ -54759,121 +59914,161 @@ namespace VpcV1 {
     }
   }
 
-  /** LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref. */
+  /**
+   * LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref.
+   */
   export interface LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref extends LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentity {
     /** The URL for this load balancer pool. */
     href: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityById. */
+  /**
+   * LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityById.
+   */
   export interface LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityById extends LoadBalancerListenerPolicyTargetPatchLoadBalancerPoolIdentity {
     /** The unique identifier for this load balancer pool. */
     id: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref. */
+  /**
+   * LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref.
+   */
   export interface LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityByHref extends LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentity {
     /** The URL for this load balancer pool. */
     href: string;
   }
 
-  /** LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityById. */
+  /**
+   * LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityById.
+   */
   export interface LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentityLoadBalancerPoolIdentityLoadBalancerPoolIdentityById extends LoadBalancerListenerPolicyTargetPrototypeLoadBalancerPoolIdentity {
     /** The unique identifier for this load balancer pool. */
     id: string;
   }
 
-  /** LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityByCRN. */
+  /**
+   * LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityByCRN.
+   */
   export interface LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityByCRN extends LoadBalancerPoolMemberTargetPrototypeInstanceIdentity {
     /** The CRN for this virtual server instance. */
     crn: string;
   }
 
-  /** LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityByHref. */
+  /**
+   * LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityByHref.
+   */
   export interface LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityByHref extends LoadBalancerPoolMemberTargetPrototypeInstanceIdentity {
     /** The URL for this virtual server instance. */
     href: string;
   }
 
-  /** LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById. */
+  /**
+   * LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById.
+   */
   export interface LoadBalancerPoolMemberTargetPrototypeInstanceIdentityInstanceIdentityById extends LoadBalancerPoolMemberTargetPrototypeInstanceIdentity {
     /** The unique identifier for this virtual server instance. */
     id: string;
   }
 
-  /** NetworkInterfaceIPPrototypeReservedIPIdentityByHref. */
+  /**
+   * NetworkInterfaceIPPrototypeReservedIPIdentityByHref.
+   */
   export interface NetworkInterfaceIPPrototypeReservedIPIdentityByHref extends NetworkInterfaceIPPrototypeReservedIPIdentity {
     /** The URL for this reserved IP. */
     href: string;
   }
 
-  /** NetworkInterfaceIPPrototypeReservedIPIdentityById. */
+  /**
+   * NetworkInterfaceIPPrototypeReservedIPIdentityById.
+   */
   export interface NetworkInterfaceIPPrototypeReservedIPIdentityById extends NetworkInterfaceIPPrototypeReservedIPIdentity {
     /** The unique identifier for this reserved IP. */
     id: string;
   }
 
-  /** PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByAddress. */
+  /**
+   * PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByAddress.
+   */
   export interface PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByAddress extends PublicGatewayFloatingIPPrototypeFloatingIPIdentity {
     /** The globally unique IP address. */
     address: string;
   }
 
-  /** PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByCRN. */
+  /**
+   * PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByCRN.
+   */
   export interface PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByCRN extends PublicGatewayFloatingIPPrototypeFloatingIPIdentity {
     /** The CRN for this floating IP. */
     crn: string;
   }
 
-  /** PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByHref. */
+  /**
+   * PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByHref.
+   */
   export interface PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityByHref extends PublicGatewayFloatingIPPrototypeFloatingIPIdentity {
     /** The URL for this floating IP. */
     href: string;
   }
 
-  /** PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityById. */
+  /**
+   * PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityById.
+   */
   export interface PublicGatewayFloatingIPPrototypeFloatingIPIdentityFloatingIPIdentityById extends PublicGatewayFloatingIPPrototypeFloatingIPIdentity {
     /** The unique identifier for this floating IP. */
     id: string;
   }
 
-  /** ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityByCRN. */
+  /**
+   * ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityByCRN.
+   */
   export interface ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityByCRN extends ReservedIPTargetPrototypeEndpointGatewayIdentity {
     /** The CRN for this endpoint gateway. */
     crn: string;
   }
 
-  /** ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityByHref. */
+  /**
+   * ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityByHref.
+   */
   export interface ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityByHref extends ReservedIPTargetPrototypeEndpointGatewayIdentity {
     /** The URL for this endpoint gateway. */
     href: string;
   }
 
-  /** ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityById. */
+  /**
+   * ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityById.
+   */
   export interface ReservedIPTargetPrototypeEndpointGatewayIdentityEndpointGatewayIdentityById extends ReservedIPTargetPrototypeEndpointGatewayIdentity {
     /** The unique identifier for this endpoint gateway. */
     id: string;
   }
 
-  /** ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends ReservedIPTargetPrototypeVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** RouteNextHopPatchRouteNextHopIPRouteNextHopIPSentinelIP. */
+  /**
+   * RouteNextHopPatchRouteNextHopIPRouteNextHopIPSentinelIP.
+   */
   export interface RouteNextHopPatchRouteNextHopIPRouteNextHopIPSentinelIP extends RouteNextHopPatchRouteNextHopIP {
     /** The sentinel IP address (`0.0.0.0`).
      *
@@ -54883,7 +60078,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** RouteNextHopPatchRouteNextHopIPRouteNextHopIPUnicastIP. */
+  /**
+   * RouteNextHopPatchRouteNextHopIPRouteNextHopIPUnicastIP.
+   */
   export interface RouteNextHopPatchRouteNextHopIPRouteNextHopIPUnicastIP extends RouteNextHopPatchRouteNextHopIP {
     /** A unicast IP address, which must not be any of the following values:
      *
@@ -54897,19 +60094,25 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** RouteNextHopPatchVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityByHref. */
+  /**
+   * RouteNextHopPatchVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityByHref.
+   */
   export interface RouteNextHopPatchVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityByHref extends RouteNextHopPatchVPNGatewayConnectionIdentity {
     /** The URL for this VPN gateway connection. */
     href: string;
   }
 
-  /** RouteNextHopPatchVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityById. */
+  /**
+   * RouteNextHopPatchVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityById.
+   */
   export interface RouteNextHopPatchVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityById extends RouteNextHopPatchVPNGatewayConnectionIdentity {
     /** The unique identifier for this VPN gateway connection. */
     id: string;
   }
 
-  /** RouteNextHopPrototypeRouteNextHopIPRouteNextHopIPSentinelIP. */
+  /**
+   * RouteNextHopPrototypeRouteNextHopIPRouteNextHopIPSentinelIP.
+   */
   export interface RouteNextHopPrototypeRouteNextHopIPRouteNextHopIPSentinelIP extends RouteNextHopPrototypeRouteNextHopIP {
     /** The sentinel IP address (`0.0.0.0`).
      *
@@ -54919,7 +60122,9 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** RouteNextHopPrototypeRouteNextHopIPRouteNextHopIPUnicastIP. */
+  /**
+   * RouteNextHopPrototypeRouteNextHopIPRouteNextHopIPUnicastIP.
+   */
   export interface RouteNextHopPrototypeRouteNextHopIPRouteNextHopIPUnicastIP extends RouteNextHopPrototypeRouteNextHopIP {
     /** A unicast IP address, which must not be any of the following values:
      *
@@ -54933,97 +60138,129 @@ namespace VpcV1 {
     address: string;
   }
 
-  /** RouteNextHopPrototypeVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityByHref. */
+  /**
+   * RouteNextHopPrototypeVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityByHref.
+   */
   export interface RouteNextHopPrototypeVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityByHref extends RouteNextHopPrototypeVPNGatewayConnectionIdentity {
     /** The URL for this VPN gateway connection. */
     href: string;
   }
 
-  /** RouteNextHopPrototypeVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityById. */
+  /**
+   * RouteNextHopPrototypeVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityById.
+   */
   export interface RouteNextHopPrototypeVPNGatewayConnectionIdentityVPNGatewayConnectionIdentityById extends RouteNextHopPrototypeVPNGatewayConnectionIdentity {
     /** The unique identifier for this VPN gateway connection. */
     id: string;
   }
 
-  /** SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityByCRN. */
+  /**
+   * SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityByCRN.
+   */
   export interface SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityByCRN extends SecurityGroupRuleRemotePatchSecurityGroupIdentity {
     /** The CRN for this security group. */
     crn: string;
   }
 
-  /** SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityByHref. */
+  /**
+   * SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityByHref.
+   */
   export interface SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityByHref extends SecurityGroupRuleRemotePatchSecurityGroupIdentity {
     /** The URL for this security group. */
     href: string;
   }
 
-  /** SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityById. */
+  /**
+   * SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityById.
+   */
   export interface SecurityGroupRuleRemotePatchSecurityGroupIdentitySecurityGroupIdentityById extends SecurityGroupRuleRemotePatchSecurityGroupIdentity {
     /** The unique identifier for this security group. */
     id: string;
   }
 
-  /** SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityByCRN. */
+  /**
+   * SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityByCRN.
+   */
   export interface SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityByCRN extends SecurityGroupRuleRemotePrototypeSecurityGroupIdentity {
     /** The CRN for this security group. */
     crn: string;
   }
 
-  /** SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityByHref. */
+  /**
+   * SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityByHref.
+   */
   export interface SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityByHref extends SecurityGroupRuleRemotePrototypeSecurityGroupIdentity {
     /** The URL for this security group. */
     href: string;
   }
 
-  /** SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityById. */
+  /**
+   * SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityById.
+   */
   export interface SecurityGroupRuleRemotePrototypeSecurityGroupIdentitySecurityGroupIdentityById extends SecurityGroupRuleRemotePrototypeSecurityGroupIdentity {
     /** The unique identifier for this security group. */
     id: string;
   }
 
-  /** ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN. */
+  /**
+   * ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN.
+   */
   export interface ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByCRN extends ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentity {
     /** The CRN for this virtual network interface. */
     crn: string;
   }
 
-  /** ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref. */
+  /**
+   * ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref.
+   */
   export interface ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityByHref extends ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentity {
     /** The URL for this virtual network interface. */
     href: string;
   }
 
-  /** ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById. */
+  /**
+   * ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById.
+   */
   export interface ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentityVirtualNetworkInterfaceIdentityById extends ShareMountTargetVirtualNetworkInterfacePrototypeVirtualNetworkInterfaceIdentity {
     /** The unique identifier for this virtual network interface. */
     id: string;
   }
 
-  /** VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPeerAddressPatch. */
+  /**
+   * VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPeerAddressPatch.
+   */
   export interface VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPeerAddressPatch extends VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatch {
     /** The IP address of the peer VPN gateway for this connection. */
     address?: string;
   }
 
-  /** VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPeerFQDNPatch. */
+  /**
+   * VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPeerFQDNPatch.
+   */
   export interface VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPolicyModePeerPatchVPNGatewayConnectionPeerFQDNPatch extends VPNGatewayConnectionPeerPatchVPNGatewayConnectionPolicyModePeerPatch {
     /** The FQDN of the peer VPN gateway for this connection. */
     fqdn?: string;
   }
 
-  /** VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionPeerAddressPatch. */
+  /**
+   * VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionPeerAddressPatch.
+   */
   export interface VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionPeerAddressPatch extends VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatch {
     /** The IP address of the peer VPN gateway for this connection. */
     address?: string;
   }
 
-  /** VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionPeerFQDNPatch. */
+  /**
+   * VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionPeerFQDNPatch.
+   */
   export interface VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionStaticRouteModePeerPatchVPNGatewayConnectionPeerFQDNPatch extends VPNGatewayConnectionPeerPatchVPNGatewayConnectionStaticRouteModePeerPatch {
     /** The FQDN of the peer VPN gateway for this connection. */
     fqdn?: string;
   }
 
-  /** VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode. */
+  /**
+   * VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode.
+   */
   export interface VPNGatewayConnectionRouteModeVPNGatewayConnectionStaticRouteMode extends VPNGatewayConnectionRouteMode {
     /** Indicates whether the traffic is distributed between the `up` tunnels of the VPN gateway connection when the
      *  VPC route's next hop is a VPN connection. If `false`, the traffic is only routed through the `up` tunnel with
@@ -55069,49 +60306,65 @@ namespace VpcV1 {
     }
   }
 
-  /** VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContextByHref. */
+  /**
+   * VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContextByHref.
+   */
   export interface VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContextByHref extends VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContext {
     /** The URL for this reserved IP. */
     href: string;
   }
 
-  /** VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContextById. */
+  /**
+   * VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContextById.
+   */
   export interface VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContextById extends VirtualNetworkInterfaceIPPrototypeReservedIPIdentityVirtualNetworkInterfaceIPsContext {
     /** The unique identifier for this reserved IP. */
     id: string;
   }
 
-  /** VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContextByHref. */
+  /**
+   * VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContextByHref.
+   */
   export interface VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContextByHref extends VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContext {
     /** The URL for this reserved IP. */
     href: string;
   }
 
-  /** VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContextById. */
+  /**
+   * VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContextById.
+   */
   export interface VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContextById extends VirtualNetworkInterfacePrimaryIPPrototypeReservedIPIdentityVirtualNetworkInterfacePrimaryIPContext {
     /** The unique identifier for this reserved IP. */
     id: string;
   }
 
-  /** VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityByCRN. */
+  /**
+   * VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityByCRN.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityByCRN extends VolumeAttachmentPrototypeVolumeVolumeIdentity {
     /** The CRN for this volume. */
     crn: string;
   }
 
-  /** VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityByHref. */
+  /**
+   * VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityByHref.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityByHref extends VolumeAttachmentPrototypeVolumeVolumeIdentity {
     /** The URL for this volume. */
     href: string;
   }
 
-  /** VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityById. */
+  /**
+   * VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityById.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumeIdentityVolumeIdentityById extends VolumeAttachmentPrototypeVolumeVolumeIdentity {
     /** The unique identifier for this volume. */
     id: string;
   }
 
-  /** VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity. */
+  /**
+   * VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity extends VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext {
     /** The capacity to use for the volume (in gigabytes). The specified value must be within the `capacity` range
      *  of the volume's profile.
@@ -55124,7 +60377,9 @@ namespace VpcV1 {
     encryption_key?: EncryptionKeyIdentity;
   }
 
-  /** VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot. */
+  /**
+   * VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot.
+   */
   export interface VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot extends VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext {
     /** The capacity to use for the volume (in gigabytes). The specified value must be at least the snapshot's
      *  `minimum_capacity`, and must be within the `capacity` range of the volume's profile.
@@ -55144,22 +60399,30 @@ namespace VpcV1 {
     source_snapshot: SnapshotIdentity;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByGroup. */
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByGroup.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByGroup extends InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec {
     group: InstanceGroupManagerScheduledActionGroupPrototype;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager. */
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager extends InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec {
     manager: InstanceGroupManagerScheduledActionManagerPrototype;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByGroup. */
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByGroup.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByGroup extends InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt {
     group: InstanceGroupManagerScheduledActionGroupPrototype;
   }
 
-  /** InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager. */
+  /**
+   * InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager.
+   */
   export interface InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager extends InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt {
     manager: InstanceGroupManagerScheduledActionManagerPrototype;
   }
@@ -55452,9 +60715,9 @@ namespace VpcV1 {
 
     /**
      * Returns the next page of results by invoking listVpcRoutes().
-     * @returns {Promise<VpcV1.RouteCollectionVPCContextRoutesItem[]>}
+     * @returns {Promise<VpcV1.Route[]>}
      */
-    public async getNext(): Promise<VpcV1.RouteCollectionVPCContextRoutesItem[]> {
+    public async getNext(): Promise<VpcV1.Route[]> {
       if (!this.hasNext()) {
         throw new Error('No more results available');
       }
@@ -55480,10 +60743,10 @@ namespace VpcV1 {
 
     /**
      * Returns all results by invoking listVpcRoutes() repeatedly until all pages of results have been retrieved.
-     * @returns {Promise<VpcV1.RouteCollectionVPCContextRoutesItem[]>}
+     * @returns {Promise<VpcV1.Route[]>}
      */
-    public async getAll(): Promise<VpcV1.RouteCollectionVPCContextRoutesItem[]> {
-      const results: RouteCollectionVPCContextRoutesItem[] = [];
+    public async getAll(): Promise<VpcV1.Route[]> {
+      const results: Route[] = [];
       while (this.hasNext()) {
         const nextPage = await this.getNext();
         results.push(...nextPage);
@@ -56132,6 +61395,87 @@ namespace VpcV1 {
      */
     public async getAll(): Promise<VpcV1.Instance[]> {
       const results: Instance[] = [];
+      while (this.hasNext()) {
+        const nextPage = await this.getNext();
+        results.push(...nextPage);
+      }
+      return results;
+    }
+  }
+
+  /**
+   * InstanceClusterNetworkAttachmentsPager can be used to simplify the use of listInstanceClusterNetworkAttachments().
+   */
+  export class InstanceClusterNetworkAttachmentsPager {
+    protected _hasNext: boolean;
+
+    protected pageContext: any;
+
+    protected client: VpcV1;
+
+    protected params: VpcV1.ListInstanceClusterNetworkAttachmentsParams;
+
+    /**
+     * Construct a InstanceClusterNetworkAttachmentsPager object.
+     *
+     * @param {VpcV1}  client - The service client instance used to invoke listInstanceClusterNetworkAttachments()
+     * @param {Object} params - The parameters to be passed to listInstanceClusterNetworkAttachments()
+     * @constructor
+     * @returns {InstanceClusterNetworkAttachmentsPager}
+     */
+    constructor(client: VpcV1, params: VpcV1.ListInstanceClusterNetworkAttachmentsParams) {
+      if (params && params.start) {
+        throw new Error(`the params.start field should not be set`);
+      }
+
+      this._hasNext = true;
+      this.pageContext = { next: undefined };
+      this.client = client;
+      this.params = JSON.parse(JSON.stringify(params || {}));
+    }
+
+    /**
+     * Returns true if there are potentially more results to be retrieved by invoking getNext().
+     * @returns {boolean}
+     */
+    public hasNext(): boolean {
+      return this._hasNext;
+    }
+
+    /**
+     * Returns the next page of results by invoking listInstanceClusterNetworkAttachments().
+     * @returns {Promise<VpcV1.InstanceClusterNetworkAttachment[]>}
+     */
+    public async getNext(): Promise<VpcV1.InstanceClusterNetworkAttachment[]> {
+      if (!this.hasNext()) {
+        throw new Error('No more results available');
+      }
+
+      if (this.pageContext.next) {
+        this.params.start = this.pageContext.next;
+      }
+      const response = await this.client.listInstanceClusterNetworkAttachments(this.params);
+      const { result } = response;
+
+      let next;
+      if (result && result.next) {
+        if (result.next.href) {
+          next = getQueryParam(result.next.href, 'start');
+        }
+      }
+      this.pageContext.next = next;
+      if (!this.pageContext.next) {
+        this._hasNext = false;
+      }
+      return result.cluster_network_attachments;
+    }
+
+    /**
+     * Returns all results by invoking listInstanceClusterNetworkAttachments() repeatedly until all pages of results have been retrieved.
+     * @returns {Promise<VpcV1.InstanceClusterNetworkAttachment[]>}
+     */
+    public async getAll(): Promise<VpcV1.InstanceClusterNetworkAttachment[]> {
+      const results: InstanceClusterNetworkAttachment[] = [];
       while (this.hasNext()) {
         const nextPage = await this.getNext();
         results.push(...nextPage);
@@ -58400,6 +63744,411 @@ namespace VpcV1 {
      */
     public async getAll(): Promise<VpcV1.ReservedIPReference[]> {
       const results: ReservedIPReference[] = [];
+      while (this.hasNext()) {
+        const nextPage = await this.getNext();
+        results.push(...nextPage);
+      }
+      return results;
+    }
+  }
+
+  /**
+   * ClusterNetworkProfilesPager can be used to simplify the use of listClusterNetworkProfiles().
+   */
+  export class ClusterNetworkProfilesPager {
+    protected _hasNext: boolean;
+
+    protected pageContext: any;
+
+    protected client: VpcV1;
+
+    protected params: VpcV1.ListClusterNetworkProfilesParams;
+
+    /**
+     * Construct a ClusterNetworkProfilesPager object.
+     *
+     * @param {VpcV1}  client - The service client instance used to invoke listClusterNetworkProfiles()
+     * @param {Object} [params] - The parameters to be passed to listClusterNetworkProfiles()
+     * @constructor
+     * @returns {ClusterNetworkProfilesPager}
+     */
+    constructor(client: VpcV1, params?: VpcV1.ListClusterNetworkProfilesParams) {
+      if (params && params.start) {
+        throw new Error(`the params.start field should not be set`);
+      }
+
+      this._hasNext = true;
+      this.pageContext = { next: undefined };
+      this.client = client;
+      this.params = JSON.parse(JSON.stringify(params || {}));
+    }
+
+    /**
+     * Returns true if there are potentially more results to be retrieved by invoking getNext().
+     * @returns {boolean}
+     */
+    public hasNext(): boolean {
+      return this._hasNext;
+    }
+
+    /**
+     * Returns the next page of results by invoking listClusterNetworkProfiles().
+     * @returns {Promise<VpcV1.ClusterNetworkProfile[]>}
+     */
+    public async getNext(): Promise<VpcV1.ClusterNetworkProfile[]> {
+      if (!this.hasNext()) {
+        throw new Error('No more results available');
+      }
+
+      if (this.pageContext.next) {
+        this.params.start = this.pageContext.next;
+      }
+      const response = await this.client.listClusterNetworkProfiles(this.params);
+      const { result } = response;
+
+      let next;
+      if (result && result.next) {
+        if (result.next.href) {
+          next = getQueryParam(result.next.href, 'start');
+        }
+      }
+      this.pageContext.next = next;
+      if (!this.pageContext.next) {
+        this._hasNext = false;
+      }
+      return result.profiles;
+    }
+
+    /**
+     * Returns all results by invoking listClusterNetworkProfiles() repeatedly until all pages of results have been retrieved.
+     * @returns {Promise<VpcV1.ClusterNetworkProfile[]>}
+     */
+    public async getAll(): Promise<VpcV1.ClusterNetworkProfile[]> {
+      const results: ClusterNetworkProfile[] = [];
+      while (this.hasNext()) {
+        const nextPage = await this.getNext();
+        results.push(...nextPage);
+      }
+      return results;
+    }
+  }
+
+  /**
+   * ClusterNetworksPager can be used to simplify the use of listClusterNetworks().
+   */
+  export class ClusterNetworksPager {
+    protected _hasNext: boolean;
+
+    protected pageContext: any;
+
+    protected client: VpcV1;
+
+    protected params: VpcV1.ListClusterNetworksParams;
+
+    /**
+     * Construct a ClusterNetworksPager object.
+     *
+     * @param {VpcV1}  client - The service client instance used to invoke listClusterNetworks()
+     * @param {Object} [params] - The parameters to be passed to listClusterNetworks()
+     * @constructor
+     * @returns {ClusterNetworksPager}
+     */
+    constructor(client: VpcV1, params?: VpcV1.ListClusterNetworksParams) {
+      if (params && params.start) {
+        throw new Error(`the params.start field should not be set`);
+      }
+
+      this._hasNext = true;
+      this.pageContext = { next: undefined };
+      this.client = client;
+      this.params = JSON.parse(JSON.stringify(params || {}));
+    }
+
+    /**
+     * Returns true if there are potentially more results to be retrieved by invoking getNext().
+     * @returns {boolean}
+     */
+    public hasNext(): boolean {
+      return this._hasNext;
+    }
+
+    /**
+     * Returns the next page of results by invoking listClusterNetworks().
+     * @returns {Promise<VpcV1.ClusterNetwork[]>}
+     */
+    public async getNext(): Promise<VpcV1.ClusterNetwork[]> {
+      if (!this.hasNext()) {
+        throw new Error('No more results available');
+      }
+
+      if (this.pageContext.next) {
+        this.params.start = this.pageContext.next;
+      }
+      const response = await this.client.listClusterNetworks(this.params);
+      const { result } = response;
+
+      let next;
+      if (result && result.next) {
+        if (result.next.href) {
+          next = getQueryParam(result.next.href, 'start');
+        }
+      }
+      this.pageContext.next = next;
+      if (!this.pageContext.next) {
+        this._hasNext = false;
+      }
+      return result.cluster_networks;
+    }
+
+    /**
+     * Returns all results by invoking listClusterNetworks() repeatedly until all pages of results have been retrieved.
+     * @returns {Promise<VpcV1.ClusterNetwork[]>}
+     */
+    public async getAll(): Promise<VpcV1.ClusterNetwork[]> {
+      const results: ClusterNetwork[] = [];
+      while (this.hasNext()) {
+        const nextPage = await this.getNext();
+        results.push(...nextPage);
+      }
+      return results;
+    }
+  }
+
+  /**
+   * ClusterNetworkInterfacesPager can be used to simplify the use of listClusterNetworkInterfaces().
+   */
+  export class ClusterNetworkInterfacesPager {
+    protected _hasNext: boolean;
+
+    protected pageContext: any;
+
+    protected client: VpcV1;
+
+    protected params: VpcV1.ListClusterNetworkInterfacesParams;
+
+    /**
+     * Construct a ClusterNetworkInterfacesPager object.
+     *
+     * @param {VpcV1}  client - The service client instance used to invoke listClusterNetworkInterfaces()
+     * @param {Object} params - The parameters to be passed to listClusterNetworkInterfaces()
+     * @constructor
+     * @returns {ClusterNetworkInterfacesPager}
+     */
+    constructor(client: VpcV1, params: VpcV1.ListClusterNetworkInterfacesParams) {
+      if (params && params.start) {
+        throw new Error(`the params.start field should not be set`);
+      }
+
+      this._hasNext = true;
+      this.pageContext = { next: undefined };
+      this.client = client;
+      this.params = JSON.parse(JSON.stringify(params || {}));
+    }
+
+    /**
+     * Returns true if there are potentially more results to be retrieved by invoking getNext().
+     * @returns {boolean}
+     */
+    public hasNext(): boolean {
+      return this._hasNext;
+    }
+
+    /**
+     * Returns the next page of results by invoking listClusterNetworkInterfaces().
+     * @returns {Promise<VpcV1.ClusterNetworkInterface[]>}
+     */
+    public async getNext(): Promise<VpcV1.ClusterNetworkInterface[]> {
+      if (!this.hasNext()) {
+        throw new Error('No more results available');
+      }
+
+      if (this.pageContext.next) {
+        this.params.start = this.pageContext.next;
+      }
+      const response = await this.client.listClusterNetworkInterfaces(this.params);
+      const { result } = response;
+
+      let next;
+      if (result && result.next) {
+        if (result.next.href) {
+          next = getQueryParam(result.next.href, 'start');
+        }
+      }
+      this.pageContext.next = next;
+      if (!this.pageContext.next) {
+        this._hasNext = false;
+      }
+      return result.interfaces;
+    }
+
+    /**
+     * Returns all results by invoking listClusterNetworkInterfaces() repeatedly until all pages of results have been retrieved.
+     * @returns {Promise<VpcV1.ClusterNetworkInterface[]>}
+     */
+    public async getAll(): Promise<VpcV1.ClusterNetworkInterface[]> {
+      const results: ClusterNetworkInterface[] = [];
+      while (this.hasNext()) {
+        const nextPage = await this.getNext();
+        results.push(...nextPage);
+      }
+      return results;
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetsPager can be used to simplify the use of listClusterNetworkSubnets().
+   */
+  export class ClusterNetworkSubnetsPager {
+    protected _hasNext: boolean;
+
+    protected pageContext: any;
+
+    protected client: VpcV1;
+
+    protected params: VpcV1.ListClusterNetworkSubnetsParams;
+
+    /**
+     * Construct a ClusterNetworkSubnetsPager object.
+     *
+     * @param {VpcV1}  client - The service client instance used to invoke listClusterNetworkSubnets()
+     * @param {Object} params - The parameters to be passed to listClusterNetworkSubnets()
+     * @constructor
+     * @returns {ClusterNetworkSubnetsPager}
+     */
+    constructor(client: VpcV1, params: VpcV1.ListClusterNetworkSubnetsParams) {
+      if (params && params.start) {
+        throw new Error(`the params.start field should not be set`);
+      }
+
+      this._hasNext = true;
+      this.pageContext = { next: undefined };
+      this.client = client;
+      this.params = JSON.parse(JSON.stringify(params || {}));
+    }
+
+    /**
+     * Returns true if there are potentially more results to be retrieved by invoking getNext().
+     * @returns {boolean}
+     */
+    public hasNext(): boolean {
+      return this._hasNext;
+    }
+
+    /**
+     * Returns the next page of results by invoking listClusterNetworkSubnets().
+     * @returns {Promise<VpcV1.ClusterNetworkSubnet[]>}
+     */
+    public async getNext(): Promise<VpcV1.ClusterNetworkSubnet[]> {
+      if (!this.hasNext()) {
+        throw new Error('No more results available');
+      }
+
+      if (this.pageContext.next) {
+        this.params.start = this.pageContext.next;
+      }
+      const response = await this.client.listClusterNetworkSubnets(this.params);
+      const { result } = response;
+
+      let next;
+      if (result && result.next) {
+        if (result.next.href) {
+          next = getQueryParam(result.next.href, 'start');
+        }
+      }
+      this.pageContext.next = next;
+      if (!this.pageContext.next) {
+        this._hasNext = false;
+      }
+      return result.subnets;
+    }
+
+    /**
+     * Returns all results by invoking listClusterNetworkSubnets() repeatedly until all pages of results have been retrieved.
+     * @returns {Promise<VpcV1.ClusterNetworkSubnet[]>}
+     */
+    public async getAll(): Promise<VpcV1.ClusterNetworkSubnet[]> {
+      const results: ClusterNetworkSubnet[] = [];
+      while (this.hasNext()) {
+        const nextPage = await this.getNext();
+        results.push(...nextPage);
+      }
+      return results;
+    }
+  }
+
+  /**
+   * ClusterNetworkSubnetReservedIpsPager can be used to simplify the use of listClusterNetworkSubnetReservedIps().
+   */
+  export class ClusterNetworkSubnetReservedIpsPager {
+    protected _hasNext: boolean;
+
+    protected pageContext: any;
+
+    protected client: VpcV1;
+
+    protected params: VpcV1.ListClusterNetworkSubnetReservedIpsParams;
+
+    /**
+     * Construct a ClusterNetworkSubnetReservedIpsPager object.
+     *
+     * @param {VpcV1}  client - The service client instance used to invoke listClusterNetworkSubnetReservedIps()
+     * @param {Object} params - The parameters to be passed to listClusterNetworkSubnetReservedIps()
+     * @constructor
+     * @returns {ClusterNetworkSubnetReservedIpsPager}
+     */
+    constructor(client: VpcV1, params: VpcV1.ListClusterNetworkSubnetReservedIpsParams) {
+      if (params && params.start) {
+        throw new Error(`the params.start field should not be set`);
+      }
+
+      this._hasNext = true;
+      this.pageContext = { next: undefined };
+      this.client = client;
+      this.params = JSON.parse(JSON.stringify(params || {}));
+    }
+
+    /**
+     * Returns true if there are potentially more results to be retrieved by invoking getNext().
+     * @returns {boolean}
+     */
+    public hasNext(): boolean {
+      return this._hasNext;
+    }
+
+    /**
+     * Returns the next page of results by invoking listClusterNetworkSubnetReservedIps().
+     * @returns {Promise<VpcV1.ClusterNetworkSubnetReservedIP[]>}
+     */
+    public async getNext(): Promise<VpcV1.ClusterNetworkSubnetReservedIP[]> {
+      if (!this.hasNext()) {
+        throw new Error('No more results available');
+      }
+
+      if (this.pageContext.next) {
+        this.params.start = this.pageContext.next;
+      }
+      const response = await this.client.listClusterNetworkSubnetReservedIps(this.params);
+      const { result } = response;
+
+      let next;
+      if (result && result.next) {
+        if (result.next.href) {
+          next = getQueryParam(result.next.href, 'start');
+        }
+      }
+      this.pageContext.next = next;
+      if (!this.pageContext.next) {
+        this._hasNext = false;
+      }
+      return result.reserved_ips;
+    }
+
+    /**
+     * Returns all results by invoking listClusterNetworkSubnetReservedIps() repeatedly until all pages of results have been retrieved.
+     * @returns {Promise<VpcV1.ClusterNetworkSubnetReservedIP[]>}
+     */
+    public async getAll(): Promise<VpcV1.ClusterNetworkSubnetReservedIP[]> {
+      const results: ClusterNetworkSubnetReservedIP[] = [];
       while (this.hasNext()) {
         const nextPage = await this.getNext();
         results.push(...nextPage);


### PR DESCRIPTION
## NEW FEATURES 
- Support for cluster network
- Support for cluster network attachments in Instance and Instance Template
- Introduction of ResourceGroupId filter on ListKeys

## BREAKING CHANGES 

- All pagelinks(First, Next) on collection is changed to PageLink

## CHANGES 

- Deprecation of ClassicAccess for Vpc (Instead, use a [Transit Gateway](https://cloud.ibm.com/docs/transit-gateway) to connect VPC to Classic Infrastructure)
- api version `2024-11-12`


## BUG FIXES

- None


```

 PASS  test/unit/common.test.js
(node:597) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  test/unit/vpc.v1.test.js (7.359 s)
------------|---------|----------|---------|---------|---------------------------------------------------------------------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                               
------------|---------|----------|---------|---------|---------------------------------------------------------------------------------
All files   |   98.45 |    95.33 |     100 |   98.41 |                                                                                 
 lib        |     100 |      100 |     100 |     100 |                                                                                 
  common.ts |     100 |      100 |     100 |     100 |                                                                                 
 vpc        |   98.44 |    95.33 |     100 |   98.41 |                                                                                 
  v1.ts     |   98.44 |    95.33 |     100 |   98.41 | ...5501,65559,65582,65640,65663,65721,65744,65802,65825,65883,65906,65964,65987 
------------|---------|----------|---------|---------|---------------------------------------------------------------------------------

Test Suites: 2 passed, 2 total
Tests:       1834 passed, 1834 total
Snapshots:   0 total
Time:        8.19 s
Ran all test suites matching /test\/unit\//i.
```