### PR TITLE
Update README with new badge from GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/IBM/vpc-node-sdk.svg?branch=master)](https://travis-ci.com/IBM/vpc-node-sdk)
+[![CI](https://github.com/IBM/vpc-node-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/IBM/vpc-node-sdk/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/IBM/vpc-node-sdk)](https://github.com/IBM/vpc-node-sdk/releases/latest)
 [![npm](https://img.shields.io/npm/v/ibm-vpc)](https://www.npmjs.com/package/ibm-vpc)
 ![npm](https://img.shields.io/npm/dm/ibm-vpc)


### PR DESCRIPTION
@ujjwal-ibm Please review

To get this in the future for other repos, you can go to `Actions -> <choose a workflow run> -> ... -> Create Status Badge`

![create status badge](https://github.com/user-attachments/assets/12d85b92-d650-4ad2-b5a3-b532c441e506)
