### PR TITLE
fix(dependency): bump core to v5.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dependencies": {
         "@types/node": "^18.19.80",
         "extend": "^3.0.2",
-        "ibm-cloud-sdk-core": "^5.4.10",
+        "ibm-cloud-sdk-core": "^5.4.11",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@ibm-cloud/sdk-test-utilities": "^1.0.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
-        "axios": "1.14.0",
+        "axios": "1.15.0",
         "dotenv": "^16.4.5",
         "eslint": "^7.26.0",
         "eslint-config-google": "^0.14.0",
@@ -2534,9 +2534,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5048,15 +5048,15 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "5.4.10",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.10.tgz",
-      "integrity": "sha512-A9CL/XQTNoyS2fkp1uKKcYC03CJwp7hIl4DQeyG9s9QLsuMwffOM2fIkORsYHhn5wmWeFUkjAmt2iTlb7Hv1Iw==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.11.tgz",
+      "integrity": "sha512-UYm6i3OCcQ1sBOVIJh0gcwCNltiGCf7QBCPaDtqCXuHIPbn8m9sKqVBqfrgFuQpenAak/Yv/450Vw+tC59XVIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "1.14.0",
+        "axios": "1.15.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
@@ -8087,11 +8087,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
@@ -9056,11 +9051,6 @@
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   "dependencies": {
     "@types/node": "^18.19.80",
     "extend": "^3.0.2",
-    "ibm-cloud-sdk-core": "^5.4.10",
+    "ibm-cloud-sdk-core": "^5.4.11",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@ibm-cloud/sdk-test-utilities": "^1.0.0",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "dotenv": "^16.4.5",
     "eslint": "^7.26.0",
     "eslint-config-google": "^0.14.0",


### PR DESCRIPTION
```

 PASS  test/unit/common.test.js
 PASS  test/unit/vpc.v1.test.js
------------|---------|----------|---------|---------|--------------------------------------------------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                            
------------|---------|----------|---------|---------|--------------------------------------------------------------
All files   |   98.78 |    95.66 |     100 |   98.76 |                                                              
 lib        |     100 |      100 |     100 |     100 |                                                              
  common.ts |     100 |      100 |     100 |     100 |                                                              
 vpc        |   98.78 |    95.66 |     100 |   98.76 |                                                              
  v1.ts     |   98.78 |    95.66 |     100 |   98.76 | ...674,78697,78755,78778,78836,78859,78917,78940,78998,79021 
------------|---------|----------|---------|---------|--------------------------------------------------------------

Test Suites: 2 passed, 2 total
Tests:       1977 passed, 1977 total
Snapshots:   0 total
Time:        4.519 s, estimated 9 s
Ran all test suites matching /test\/unit\//i.
```